### PR TITLE
e2e: Add cri-o support to tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -56,6 +56,8 @@ The estimated complexity and priority of a feature/task is defined like this:
   - [ ] e2e-tests on merge by CI/self-hosted runners, C4
   - [ ] migrate shell based e2e-tests into Ansible, C4
   - [ ] make topology-aware e2e test07-mixed-allocations more reliable, C1
+  - [ ] allow e2e tests to use the upstream containerd or cri-o instead of using
+        binaries compiled from local sources, C1
 - documentation
   - [ ] minimal README with instructions about how to build/deploy/try the plugins, C2
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -60,6 +60,7 @@ Before running E2E tests ensure that you have all the required components locall
     no_proxy
     dns_nameserver
     dns_search_domain
+    k8scri
     ```
 
     For example:

--- a/test/e2e/files/Vagrantfile.in
+++ b/test/e2e/files/Vagrantfile.in
@@ -15,7 +15,15 @@ HOSTNAME = "SERVER_NAME"
 N = 1
 
 CRI_RUNTIME = "#{ENV['k8scri']}"
-CONTAINERD_SRC = "#{ENV['containerd_src']}"
+CRIO_SRC = ""
+CONTAINERD_SRC = ""
+
+if CRI_RUNTIME == "containerd"
+  CONTAINERD_SRC = "#{ENV['containerd_src']}"
+else
+  CRIO_SRC = "#{ENV['crio_src']}"
+end
+
 NRI_RESOURCE_POLICY_SRC = "#{ENV['nri_resource_policy_src']}"
 OUTPUT_DIR = "#{ENV['OUTPUT_DIR']}"
 
@@ -75,6 +83,7 @@ Vagrant.configure("2") do |config|
       no_proxy: "#{ENV['NO_PROXY']}",
       cri_runtime: CRI_RUNTIME,
       containerd_src: CONTAINERD_SRC,
+      crio_src: CRIO_SRC,
       nri_resource_policy_src: NRI_RESOURCE_POLICY_SRC,
       outdir: OUTPUT_DIR,
     }

--- a/test/e2e/files/crio-nri-enable
+++ b/test/e2e/files/crio-nri-enable
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+mkdir -p /etc/crio/crio.conf.d
+
+cat > /etc/crio/crio.conf.d/10-enable-nri.conf <<EOF
+[crio.nri]
+enable_nri = true
+EOF

--- a/test/e2e/files/crio.service
+++ b/test/e2e/files/crio.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=cri-o container runtime
+Documentation=https://cri-o.io
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/crio
+
+Delegate=yes
+KillMode=process
+Restart=always
+LimitNPROC=infinity
+LimitCORE=infinity
+LimitNOFILE=1048576
+TasksMax=infinity
+
+[Install]
+WantedBy=multi-user.target

--- a/test/e2e/lib/vm.bash
+++ b/test/e2e/lib/vm.bash
@@ -144,7 +144,7 @@ vm-play() {
 	  -i "${vm}," -u vagrant \
 	  --private-key=".vagrant/machines/${vm}/libvirt/private_key" \
 	  --ssh-common-args "-F .ssh-config" \
-	  --extra-vars "nri_resource_policy_src=${nri_resource_policy_src}"
+	  --extra-vars "cri_runtime=${k8scri} nri_resource_policy_src=${nri_resource_policy_src}"
     )
 }
 

--- a/test/e2e/playbook/nri-balloons-plugin-deploy.yaml
+++ b/test/e2e/playbook/nri-balloons-plugin-deploy.yaml
@@ -2,7 +2,19 @@
 - hosts: all
   become: no
   become_user: root
+  vars:
+    - cri_runtime: "{{ cri_runtime }}"
+    - is_containerd: false
+    - is_crio: false
+
   tasks:
+    - set_fact:
+        is_containerd: true
+      when: cri_runtime == "containerd"
+    - set_fact:
+        is_crio: true
+      when: cri_runtime == "crio"
+
     - name: create default nri configuration file
       become: yes
       copy:
@@ -32,6 +44,13 @@
       with_items:
         - sed 's/--force-config/--fallback-config/' /etc/nri-resource-policy/nri-resource-policy-deployment.yaml > /etc/nri-resource-policy/nri-resource-policy-deployment-fallback.yaml
 
+    - name: fix the image name when using cri-o
+      become: yes
+      shell: >
+        sed -i 's/image: nri-resource-policy-balloons:unknown/image: localhost\/nri-resource-policy-balloons:unknown/' /etc/nri-resource-policy/nri-resource-policy-deployment.yaml;
+        sed -i 's/image: nri-resource-policy-balloons:unknown/image: localhost\/nri-resource-policy-balloons:unknown/' /etc/nri-resource-policy/nri-resource-policy-deployment-fallback.yaml
+      when: is_crio
+
     - name: get latest nri-resource-policy deployment image name
       delegate_to: localhost
       shell: "ls -1t {{ nri_resource_policy_src }}/build/images/nri-resource-policy-balloons-image-*.tar"
@@ -40,6 +59,15 @@
     - name: copy latest nri-resource-policy deployment image
       copy: src="{{ nri_resource_policy_images.stdout_lines[0] }}" dest="."
 
-    - name: import nri plugin image
+    - name: import nri plugin image when using containerd
       become: yes
       shell: "ctr -n k8s.io images import `basename {{ nri_resource_policy_images.stdout_lines[0] }}`"
+      when: is_containerd
+
+    - name: load nri plugin image when using cri-o
+      become: yes
+      shell: "{{ item }}"
+      with_items:
+        - "podman image load -i `basename {{ nri_resource_policy_images.stdout_lines[0] }}`"
+        - "podman image scp localhost/nri-resource-policy-balloons:unknown vagrant@localhost::"
+      when: is_crio

--- a/test/e2e/playbook/nri-topology-aware-plugin-deploy.yaml
+++ b/test/e2e/playbook/nri-topology-aware-plugin-deploy.yaml
@@ -2,7 +2,19 @@
 - hosts: all
   become: no
   become_user: root
+  vars:
+    - cri_runtime: "{{ cri_runtime }}"
+    - is_containerd: false
+    - is_crio: false
+
   tasks:
+    - set_fact:
+        is_containerd: true
+      when: cri_runtime == "containerd"
+    - set_fact:
+        is_crio: true
+      when: cri_runtime == "crio"
+
     - name: create default nri configuration file
       become: yes
       copy:
@@ -34,6 +46,13 @@
       with_items:
         - sed 's/--force-config/--fallback-config/' /etc/nri-resource-policy/nri-resource-policy-deployment.yaml > /etc/nri-resource-policy/nri-resource-policy-deployment-fallback.yaml
 
+    - name: fix the image name when using cri-o
+      become: yes
+      shell: >
+        sed -i 's/image: nri-resource-policy-topology-aware:unknown/image: localhost\/nri-resource-policy-topology-aware:unknown/' /etc/nri-resource-policy/nri-resource-policy-deployment.yaml;
+        sed -i 's/image: nri-resource-policy-topology-aware:unknown/image: localhost\/nri-resource-policy-topology-aware:unknown/' /etc/nri-resource-policy/nri-resource-policy-deployment-fallback.yaml
+      when: is_crio
+
     - name: get latest nri-resource-policy deployment image name
       delegate_to: localhost
       shell: "ls -1t {{ nri_resource_policy_src }}/build/images/nri-resource-policy-topology-aware-image-*.tar"
@@ -43,6 +62,15 @@
     - name: copy latest nri-resource-policy deployment image
       copy: src="{{ nri_resource_policy_images.stdout_lines[0] }}" dest="."
 
-    - name: import nri plugin image
+    - name: import nri plugin image when using containerd
       become: yes
       shell: "ctr -n k8s.io images import `basename {{ nri_resource_policy_images.stdout_lines[0] }}`"
+      when: is_containerd
+
+    - name: load nri plugin image when using cri-o
+      become: yes
+      shell: "{{ item }}"
+      with_items:
+        - "podman image load -i `basename {{ nri_resource_policy_images.stdout_lines[0] }}`"
+        - "podman image scp localhost/nri-resource-policy-topology-aware:unknown vagrant@localhost::"
+      when: is_crio

--- a/test/e2e/playbook/provision.yaml
+++ b/test/e2e/playbook/provision.yaml
@@ -3,9 +3,18 @@
   become: yes
   become_user: root
   vars:
-    is_containerd: "{{ cri_runtime }} == containerd"
+    - cri_runtime: "{{ cri_runtime }}"
+    - is_containerd: false
+    - is_crio: false
 
   tasks:
+    - set_fact:
+        is_containerd: true
+      when: cri_runtime == "containerd"
+    - set_fact:
+        is_crio: true
+      when: cri_runtime == "crio"
+
     - name: setup DNS
       shell: "{{ item }}"
       with_items:
@@ -60,6 +69,7 @@
           - kubelet
           - kubeadm
           - kubectl
+          - systemd-container
         state: present
 
     - name: install apt packages
@@ -77,8 +87,15 @@
       dnf:
         pkg:
         - iproute-tc
+        - grubby
         state: present
         update_cache: yes
+      when: ansible_facts['distribution'] == "Fedora"
+
+    - name: disable SELinux
+      ansible.posix.selinux:
+        update_kernel_param: true
+        state: disabled
       when: ansible_facts['distribution'] == "Fedora"
 
     - name: remove the firewalld package
@@ -86,6 +103,15 @@
         name: firewalld
         state: absent
       when: ansible_facts['distribution'] == "Fedora"
+
+    - name: install additional cri-o packages
+      dnf:
+        pkg:
+        - podman
+        - cri-o
+        state: present
+        update_cache: yes
+      when: ansible_facts['distribution'] == "Fedora" and is_crio
 
     - name: install python pip based apps
       pip:
@@ -105,6 +131,16 @@
         - "{{ containerd_src }}/bin/containerd-shim-runc-v1"
         - "{{ containerd_src }}/bin/containerd-shim-runc-v2"
       when: is_containerd
+
+    # We need quite recent cri-o that has NRI support so use the one
+    # that is compiled from sources.
+    - name: copy cri-o sources
+      copy: src="{{ item }}" dest="/usr/bin" mode=0755
+      with_items:
+        - "{{ crio_src }}/bin/crio"
+        - "{{ crio_src }}/bin/crio-status"
+        - "{{ crio_src }}/bin/pinns"
+      when: is_crio
 
     - name: setup runtime systemd file
       copy:
@@ -143,6 +179,7 @@
         owner: root
         group: root
         mode: '0755'
+      when: is_containerd
 
     - name: configure containerd
       when: is_containerd
@@ -165,6 +202,7 @@
       shell: "{{ item }}"
       with_items:
         - /usr/local/bin/containerd-nri-enable
+      when: is_containerd
 
     - name: restart the containerd
       systemd:
@@ -172,6 +210,28 @@
         name: "{{ cri_runtime }}"
         daemon_reload: true
       when: is_containerd
+
+    - name: copy crio nri enable script
+      copy:
+        src: "{{ nri_resource_policy_src }}/test/e2e/files/crio-nri-enable"
+        dest: /usr/local/bin/crio-nri-enable
+        owner: root
+        group: root
+        mode: '0755'
+      when: is_crio
+
+    - name: enable nri for crio
+      shell: "{{ item }}"
+      with_items:
+        - /usr/local/bin/crio-nri-enable
+      when: is_crio
+
+    - name: restart the cri-o
+      systemd:
+        state: restarted
+        name: "{{ cri_runtime }}"
+        daemon_reload: true
+      when: is_crio
 
     - name: remove swapfile from /etc/fstab
       mount:

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -49,7 +49,9 @@ fi
 
 # Assume containerd sources are found in parent dir of this repo.
 # If that is not the case, set containerd_src when calling the e2e script.
+# Same for cri-o if using that.
 export containerd_src=${containerd_src:-"$SRC_DIR"/../containerd}
+export crio_src=${crio_src:-"$SRC_DIR"/../cri-o}
 
 # Default topology if not given. The run_tests.sh script will figure out
 # the topology from the test directory structure and contents.
@@ -82,7 +84,11 @@ echo "    Runtime         = $k8scri"
 echo "    Output dir      = $OUTPUT_DIR"
 echo "    Test output dir = $TEST_OUTPUT_DIR"
 echo "    NRI dir         = $nri_resource_policy_src"
-echo "    Containerd dir  = $containerd_src"
+if [ "$k8scri" == "containerd" ]; then
+    echo "    Containerd dir  = $containerd_src"
+else
+    echo "    CRI-O dir       = $crio_src"
+fi
 echo "    Policy          = $POLICY"
 echo "    Topology        = $topology"
 echo


### PR DESCRIPTION
This will allow user to select either containerd (default) or crio runtime when running the tests.