### PR TITLE
Makefile: fix pkg path thinko for plugin binary deps.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ $(BIN_PATH)/%: .static.%.$(STATIC)
 $(BIN_PATH)/nri-resource-policy-topology-aware: \
     $(shell for f in cmd/topology-aware/*.go; do echo $$f; done; \
             for dir in $(shell $(GO_DEPS) ./cmd/topology-aware/... | \
-                          grep '/nri-resource-policy/' | \
+                          grep '/nri-plugins/' | \
                           sed 's#github.com/containers/nri-plugins/##g'); do \
                 find $$dir -name \*.go; \
             done | sort | uniq)
@@ -170,7 +170,7 @@ $(BIN_PATH)/nri-resource-policy-topology-aware: \
 $(BIN_PATH)/nri-resource-policy-balloons: \
     $(shell for f in cmd/balloons/*.go; do echo $$f; done; \
                 for dir in $(shell $(GO_DEPS) ./cmd/balloons/... | \
-                          grep '/nri-resource-policy/' | \
+                          grep '/nri-plugins/' | \
                           sed 's#github.com/containers/nri-plugins/##g'); do \
                 find $$dir -name \*.go; \
             done | sort | uniq)
@@ -178,7 +178,7 @@ $(BIN_PATH)/nri-resource-policy-balloons: \
 $(BIN_PATH)/nri-resource-policy-template: \
     $(shell for f in cmd/template/*.go; do echo $$f; done; \
                 for dir in $(shell $(GO_DEPS) ./cmd/template/... | \
-                          grep '/nri-resource-policy/' | \
+                          grep '/nri-plugins/' | \
                           sed 's#github.com/containers/nri-plugins/##g'); do \
                 find $$dir -name \*.go; \
             done | sort | uniq)


### PR DESCRIPTION
Filter for '/nri-plugins/' not '/nri-resource-policy/' for plugin binary dependencies.