### PR TITLE
[WIP] Self hosted runner optimizations

### DIFF
--- a/test/e2e/files/Vagrantfile.in
+++ b/test/e2e/files/Vagrantfile.in
@@ -24,6 +24,12 @@ else
   CRIO_SRC = "#{ENV['crio_src']}"
 end
 
+if "#{ENV['RUN_INSIDE_CONTAINER']}" == "1"
+  RUN_INSIDE_CONTAINER=1
+else
+  RUN_INSIDE_CONTAINER=0
+end
+
 NRI_RESOURCE_POLICY_SRC = "#{ENV['nri_resource_policy_src']}"
 OUTPUT_DIR = "#{ENV['OUTPUT_DIR']}"
 
@@ -86,6 +92,7 @@ Vagrant.configure("2") do |config|
       crio_src: CRIO_SRC,
       nri_resource_policy_src: NRI_RESOURCE_POLICY_SRC,
       outdir: OUTPUT_DIR,
+      run_inside_container: RUN_INSIDE_CONTAINER,
     }
   end
 end

--- a/test/e2e/playbook/provision.yaml
+++ b/test/e2e/playbook/provision.yaml
@@ -6,6 +6,8 @@
     - cri_runtime: "{{ cri_runtime }}"
     - is_containerd: false
     - is_crio: false
+    - is_inside_container: false
+    - run_inside_container: "{{ run_inside_container }}"
 
   tasks:
     - set_fact:
@@ -14,6 +16,21 @@
     - set_fact:
         is_crio: true
       when: cri_runtime == "crio"
+    - set_fact:
+        is_inside_container: true
+      when: run_inside_container == 1
+
+    - name: check self signed cert for self hosted runner
+      local_action: stat path=/etc/squid/certs/squid-ca-cert.pem
+      register: file
+
+    - name: copy self signed cert if it exists in Fedora
+      copy: src=/etc/squid/certs/squid-ca-cert.pem dest=/etc/pki/ca-trust/source/anchors/
+      when: file.stat.exists and ansible_facts['distribution'] == "Fedora"
+
+    - name: update self signed certs certs
+      command: update-ca-trust
+      when: file.stat.exists and ansible_facts['distribution'] == "Fedora"
 
     - name: setup DNS
       shell: "{{ item }}"
@@ -96,7 +113,7 @@
       ansible.posix.selinux:
         update_kernel_param: true
         state: disabled
-      when: ansible_facts['distribution'] == "Fedora"
+      when: ansible_facts['distribution'] == "Fedora" and is_inside_container == false
 
     - name: remove the firewalld package
       ansible.builtin.package:

--- a/test/self-hosted-runner/Makefile
+++ b/test/self-hosted-runner/Makefile
@@ -1,9 +1,11 @@
 PREFIX ?= `pwd`/shr
 
+# Outer container image settings
 BASE_IMAGE_BUILD_CMD ?= docker build
 BASE_IMAGE_BUILD_EXTRA_OPTS ?=
 BASE_IMAGE ?= ubuntu:22.04
 
+# Inner e2e VM image settings (this is run inside the outer container)
 VM_BASE_IMAGE ?= https://vagrantcloud.com/generic/boxes/fedora37/versions/4.2.14/providers/libvirt.box
 VM_BASE_IMAGE_FILENAME ?= generic-fedora37-4.2.14.box
 VM_DIR ?= $(PREFIX)/mnt/vagrant

--- a/test/self-hosted-runner/dnsmasq.conf.in
+++ b/test/self-hosted-runner/dnsmasq.conf.in
@@ -1,0 +1,5 @@
+port=53
+resolv-file=/mnt/conf/resolv.conf.orig
+
+address=/proxy.runner/LOCALIP
+address=/mirror.runner/LOCALIP

--- a/test/self-hosted-runner/docker/Dockerfile
+++ b/test/self-hosted-runner/docker/Dockerfile
@@ -39,7 +39,8 @@ RUN apt-get update -y && apt-get install -y \
   gnupg \
   sudo \
   bc \
-  lsb-release
+  lsb-release \
+  dnsmasq
 
 RUN if [ ! -f /usr/share/keyrings/docker-archive-keyring.gpg ]; then \
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg; \

--- a/test/self-hosted-runner/docker/Dockerfile
+++ b/test/self-hosted-runner/docker/Dockerfile
@@ -40,7 +40,9 @@ RUN apt-get update -y && apt-get install -y \
   sudo \
   bc \
   lsb-release \
-  dnsmasq
+  dnsmasq \
+  squid-openssl \
+  iputils-ping
 
 RUN if [ ! -f /usr/share/keyrings/docker-archive-keyring.gpg ]; then \
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg; \
@@ -56,4 +58,5 @@ RUN apt-get install -y vagrant vagrant-libvirt bridge-utils make \
     libvirt-daemon guestfs-tools qemu-kvm libvirt-daemon-system \
     qemu ebtables libxslt-dev libxml2-dev libvirt-dev zlib1g-dev ruby-dev
 
+COPY squid.conf /etc/squid/
 COPY runner-in-container.sh /shr/

--- a/test/self-hosted-runner/runner.sh
+++ b/test/self-hosted-runner/runner.sh
@@ -8,6 +8,11 @@
 # and other downloaded files are located.
 PREFIX=${PREFIX:-`pwd`/shr}
 
+# For testing things without actually running the GH runner script,
+# you can set TESTING env variable which will start the container
+# and wait for actions in it. In this case the GH run.sh script is
+# not run.
+
 if [ $(readlink -f "$PREFIX") = `pwd` ]; then
     echo "PREFIX $PREFIX cannot point to current directory."
     exit 1
@@ -159,31 +164,45 @@ get_latest_runner() {
 start_docker_container() {
     echo "Starting container"
 
+    EXTRA_PARAMS="$1"
+    SOURCES="$2"
+
     # Execute the GH self hosted runner inside the container.
     docker container run --pull never \
+	   "$SOURCES" \
 	   -v "${PREFIX}/mnt/actions-runner:/mnt/actions-runner" \
 	   -v "${PREFIX}/mnt/vagrant:/mnt/vagrant:ro" \
 	   -v "${PREFIX}/mnt/env:/mnt/env:ro" \
+	   -v "${PREFIX}/mnt/conf:/mnt/conf" \
 	   -v "${CONTAINERD_SRC}:/mnt/containerd:ro" \
 	   -v "/var/run/docker.sock:/var/run/docker.sock" \
-	   --device=/dev/kvm \
-	   --env-file "${PREFIX}/mnt/env" \
+	   --rm --device=/dev/kvm \
+	   --env-file "${PREFIX}/mnt/env" $EXTRA_PARAMS \
 	   shr-base-image \
 	   /shr/runner-in-container.sh "`id --group`" "`id --user`" \
 	   "`getent group docker | cut -d: -f3`" \
 	   "`getent group kvm | cut -d: -f3`"
 }
 
+setup_dnsmasq() {
+    mkdir -p ${PREFIX}/mnt/conf
+    cp -p dnsmasq.conf.in ${PREFIX}/mnt/conf/dnsmasq.conf
+}
+
 while [ $STOPPED -eq 0 ]; do
-    GH_RUNNER_TOKEN=$(get_runner_token)
-    if [ "$GH_RUNNER_TOKEN" == "null" ]; then
-	echo "Cannot get self-hosted runner registration token!"
-	break
+    setup_dnsmasq
+
+    if [ -z "$TESTING" ]; then
+	GH_RUNNER_TOKEN=$(get_runner_token)
+	if [ "$GH_RUNNER_TOKEN" == "null" ]; then
+	    echo "Cannot get self-hosted runner registration token!"
+	    break
+	fi
+
+	get_latest_runner
+
+	create_actions_runner
     fi
-
-    get_latest_runner
-
-    create_actions_runner
 
     # Generate env file that describes local configuration data and which
     # is exported to the container.
@@ -197,18 +216,26 @@ while [ $STOPPED -eq 0 ]; do
     echo https_proxy="$https_proxy" >> ${PREFIX}/mnt/env
     echo no_proxy="$no_proxy" >> ${PREFIX}/mnt/env
 
-    (
-	start_docker_container
-	if [ $? -ne 0 ]; then
-	    # User stopped the script, we should quit
-	    STOPPED=1
-	    exit 1
-	fi
-    ) &
+    if [ -z "$TESTING" ]; then
+	(
+	    start_docker_container
+	    if [ $? -ne 0 ]; then
+		# User stopped the script, we should quit
+		STOPPED=1
+		exit 1
+	    fi
+	) &
 
-    wait -f
+	wait -f
 
-    remove_actions_runner
+	remove_actions_runner
+    else
+	echo "TESTING=\"$TESTING\"" >> ${PREFIX}/mnt/env
+
+	# Mount the plugin sources so that we can run the e2e tests manually.
+	SRC_DIR=$(realpath `pwd`/../../)
+	start_docker_container "-it" "-v ${SRC_DIR}:/mnt/sources"
+    fi
 
     unset GH_RUNNER_NAME GH_RUNNER_URL GH_RUNNER_TOKEN
 

--- a/test/self-hosted-runner/squid.conf.in
+++ b/test/self-hosted-runner/squid.conf.in
@@ -1,0 +1,51 @@
+# Listen on port 3128
+http_port 3128 ssl-bump generate-host-certificates=on cert=/etc/squid/certs/squid-ca-cert-key.pem dynamic_cert_mem_cache_size=16MB options=NO_SSLv3,NO_TLSv1,NO_TLSv1_1,SINGLE_DH_USE,SINGLE_ECDH_USE cipher=HIGH:MEDIUM:!RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS
+
+# Custom config SSL-MITM mode
+tls_outgoing_options options=NO_SSLv3,NO_TLSv1,NO_TLSv1_1,SINGLE_DH_USE,SINGLE_ECDH_USE cipher=HIGH:MEDIUM:!RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS
+
+sslcrtd_program /usr/lib/squid/security_file_certgen -s /var/lib/ssl_db -M 16MB
+
+acl step1 at_step SslBump1
+ssl_bump peek step1
+ssl_bump bump all
+
+# Define ACLs for forwarding requests to another proxy
+never_direct allow all
+always_direct deny all
+cache_peer $PROXY_HTTP parent $PROXY_HTTP_PORT 0 no-query default
+http_access allow all
+
+# Create a disk-based cache of up to 10GB in size:
+# (10000 is the size in MB. 16 and 256 seem to set how many subdirectories
+#  are created, and are default values.)
+cache_dir ufs /mnt/squid 10000 16 256
+
+# Use the LFUDA cache eviction policy -- Least Frequently Used, with
+#  Dynamic Aging. http://www.squid-cache.org/Doc/config/cache_replacement_policy/
+# It's more important to me to keep bigger files in cache than to keep
+# more, smaller files -- We are optimizing for bandwidth savings, not latency.
+cache_replacement_policy heap LFUDA
+
+# The top two are new lines, and probably aren't everything you would ever
+# want to cache. They're cached for 129600 minutes, which is 90 days.
+# refresh-ims and override-expire are described in the configuration here:
+#  http://www.squid-cache.org/Doc/config/refresh_pattern/
+# but basically, refresh-ims makes squid check with the backend server
+# when someone does a conditional get, to be cautious.
+# override-expire lets us override the specified expiry time. (This is
+#  illegal per the RFC, but works for our specific purposes.)
+refresh_pattern -i .rpm$ 129600 100% 129600 refresh-ims override-expire
+refresh_pattern -i .deb$ 129600 100% 129600 refresh-ims override-expire
+refresh_pattern -i .iso$ 129600 100% 129600 refresh-ims override-expire
+refresh_pattern -i .box$ 129600 100% 129600 refresh-ims override-expire
+refresh_pattern -i .tar.gz$ 129600 100% 129600 refresh-ims override-expire
+refresh_pattern ^ftp:           1440    20%     10080
+refresh_pattern ^gopher:        1440    0%      1440
+refresh_pattern -i (/cgi-bin/|\?) 0     0%      0
+refresh_pattern .               0       20%     4320
+
+# Squid defaults to not caching objects over 4MB, which may be
+# a reasonable default, but is awful behavior on our
+# pseudo-mirror. Let's make it 4GB:
+maximum_object_size 4096 MB


### PR DESCRIPTION
Run squid inside the self hosted runner container, this will allow us to cache data that is downloaded by the e2e VM and speed up the individual test run. This is still WIP and needs more testing.
