### PR TITLE
fixes: build only the right binary for each image.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,9 @@ verify: verify-godeps verify-fmt
 
 build-plugins: $(foreach bin,$(PLUGINS),$(BIN_PATH)/$(bin))
 
+build-plugins-static:
+	$(MAKE) STATIC=1 build-plugins
+
 build-check:
 	$(Q)$(GO_BUILD) -v $(GO_MODULES)
 

--- a/cmd/balloons/Dockerfile
+++ b/cmd/balloons/Dockerfile
@@ -13,12 +13,9 @@ RUN go mod download
 COPY . .
 
 RUN make clean
-RUN make build-static
+RUN make PLUGINS=nri-resource-policy-balloons build-plugins-static
 
 FROM gcr.io/distroless/static
-#debian:bullseye-slim
-#gcr.io/distroless/base
-#gcr.io/distroless/static
 
 COPY --from=builder /go/builder/build/bin/nri-resource-policy-balloons /bin/nri-resource-policy-balloons
 

--- a/cmd/template/Dockerfile
+++ b/cmd/template/Dockerfile
@@ -13,7 +13,7 @@ RUN go mod download
 COPY . .
 
 RUN make clean
-RUN make build-static
+RUN make PLUGINS=nri-resource-policy-template build-plugins-static
 
 FROM gcr.io/distroless/static
 

--- a/cmd/topology-aware/Dockerfile
+++ b/cmd/topology-aware/Dockerfile
@@ -13,12 +13,9 @@ RUN go mod download
 COPY . .
 
 RUN make clean
-RUN make build-static
+RUN make PLUGINS=nri-resource-policy-topology-aware build-plugins-static
 
 FROM gcr.io/distroless/static
-#debian:bullseye-slim
-#gcr.io/distroless/base
-#gcr.io/distroless/static
 
 COPY --from=builder /go/builder/build/bin/nri-resource-policy-topology-aware /bin/nri-resource-policy-topology-aware
 


### PR DESCRIPTION
Only build the binary which will end up in the image we are building. Skip other binaries and the build check.