### PR TITLE
docker: Template image entrypoint was wrong

### DIFF
--- a/cmd/template/Dockerfile
+++ b/cmd/template/Dockerfile
@@ -19,4 +19,4 @@ FROM gcr.io/distroless/static
 
 COPY --from=builder /go/builder/build/bin/nri-resource-policy-template /bin/nri-resource-policy-template
 
-ENTRYPOINT ["/bin/nri-resource-policy"]
+ENTRYPOINT ["/bin/nri-resource-policy-template"]


### PR DESCRIPTION
The entrypoint binary name was wrong for the template image, the binary name must contain also the policy name.