### PR TITLE
fixes: update container state after resource allocation in CreateContainer.

### DIFF
--- a/pkg/resmgr/nri.go
+++ b/pkg/resmgr/nri.go
@@ -365,11 +365,11 @@ func (p *nriPlugin) getPendingAdjustment(container *api.Container) *api.Containe
 	return nil
 }
 
-func (p *nriPlugin) getPendingUpdates(creating *api.Container) []*api.ContainerUpdate {
+func (p *nriPlugin) getPendingUpdates(skip *api.Container) []*api.ContainerUpdate {
 	m := p.resmgr
 	updates := []*api.ContainerUpdate{}
 	for _, c := range m.cache.GetPendingContainers() {
-		if creating != nil && creating.GetId() == c.GetID() {
+		if skip != nil && skip.GetId() == c.GetID() {
 			continue
 		}
 

--- a/pkg/resmgr/nri.go
+++ b/pkg/resmgr/nri.go
@@ -226,8 +226,10 @@ func (p *nriPlugin) CreateContainer(pod *api.PodSandbox, container *api.Containe
 	c.UpdateState(cache.ContainerStateCreating)
 
 	if err := m.policy.AllocateResources(c); err != nil {
+		c.UpdateState(cache.ContainerStateStale)
 		return nil, nil, errors.Wrap(err, "failed to allocate resources")
 	}
+	c.UpdateState(cache.ContainerStateCreated)
 
 	c.InsertMount(&cache.Mount{
 		Destination: "/.nri-resource-policy",


### PR DESCRIPTION
Update container state after resource allocation. At that point the container has been created from our point of view. Any subsequent changes to (any resources of) the container must use a ContainerUpdate instead of a ContainerAdjustment. Updating the state correctly will force subsequent changes to be collected as updates.
