### PR TITLE
topology-aware: pick reserved pool by CPU type alone.

### DIFF
--- a/cmd/topology-aware/policy/pools.go
+++ b/cmd/topology-aware/policy/pools.go
@@ -348,7 +348,7 @@ func (p *policy) allocatePool(container cache.Container, poolHint string) (Grant
 	// the same pool. This assumption can be relaxed later, requires separate
 	// (but connected) scoring of memory and CPU.
 
-	if request.CPUType() == cpuReserved || container.GetNamespace() == kubernetes.NamespaceSystem {
+	if request.CPUType() == cpuReserved {
 		pool = p.root
 	} else {
 		affinity, err := p.calculatePoolAffinities(request.GetContainer())


### PR DESCRIPTION
Do not second guess the already determined CPU type for containers in the kube-system namespace by checking the namespace again. Short circuit assigning reserved-pool containers to the root based on the CPU type alone.

Note that this also allows containers to be opted out from the reserved pool using an explicit
  prefer-reserved-cpus.resource-policy.nri.io/pod: "false"
annotation.