### PR TITLE
benchmarks: check deployment files prior to tests/use.

### DIFF
--- a/test/statistics-analysis/scripts/plot-graphs.py
+++ b/test/statistics-analysis/scripts/plot-graphs.py
@@ -129,6 +129,12 @@ def parseLabels(labelArg):
     return labels, stripped
 
 def main():
+    importTest = argparse.ArgumentParser(description="Check python imports.")
+    importTest.add_argument("-T", "--test-imports", required=False, default=False, action="store_true", help="test python imports and exit")
+    test, unknown = importTest.parse_known_args(sys.argv[1:])
+    if test.test_imports:
+        sys.exit(0)
+
     parser = argparse.ArgumentParser(description="Get jaeger tracing data.")
     parser.add_argument("directory", help="directory containing output to scan")
     parser.add_argument("-l", "--labels", required=True, help="comma-separated list of labels used in the test setups")


### PR DESCRIPTION
Check the existence of deployment files before running any tests. If a deployment file is simply set to "1" or "yes", try picking up the corresponding generated file from its stock location, assuming we're running out of a cloned repository.