### PR TITLE
kustomize: patch container name to reflect the plugin name

### DIFF
--- a/deployment/overlays/balloons/kustomization.yaml
+++ b/deployment/overlays/balloons/kustomization.yaml
@@ -12,3 +12,16 @@ resources:
 - ../../base/crds
 - ../../base/nri-resource-policy
 - sample-configmap.yaml
+
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/name
+        value: nri-resource-policy-balloons
+    target:
+      group: apps
+      version: v1
+      kind: DaemonSet
+      labelSelector: "app=nri-resource-policy"
+    options:
+      allowNameChange: true


### PR DESCRIPTION
Fix the container name used for the balloons plugin. Currently, we don't patch the container name and as such end up with the container name called nri-resource-policy-topology-aware while it is balloons plugin that is in use. Using kustomize JSON patching, lets us to alter container name.

Example of kustomize generated DaemonSet
**before this patch**
```yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  labels:
    app: nri-resource-policy
  name: nri-resource-policy
  namespace: kube-system
spec:
  selector:
    matchLabels:
      app: nri-resource-policy
  template:
    metadata:
      labels:
        app: nri-resource-policy
    spec:
      containers:
      - args:
        - --host-root
        - /host
        - --fallback-config
        - /etc/nri-resource-policy/nri-resource-policy.cfg
        - --pid-file
        - /tmp/nri-resource-policy.pid
        - -metrics-interval
        - 5s
        env:
        - name: NODE_NAME
          valueFrom:
            fieldRef:
              fieldPath: spec.nodeName
        image: nri-resource-policy-balloons:devel
        imagePullPolicy: Always
        name: nri-resource-policy-topology-aware
        ports:
        - containerPort: 8891
          hostPort: 8891
          name: metrics
          protocol: TCP
        resources:
          requests:
            cpu: 500m
            memory: 512Mi
        securityContext:
          allowPrivilegeEscalation: false
          capabilities:
            drop:
            - ALL
        volumeMounts:
        - mountPath: /var/lib/nri-resource-policy
          name: resource-policydata
        - mountPath: /host/sys
          name: hostsysfs
        - mountPath: /var/run/nri-resource-policy
          name: resource-policysockets
        - mountPath: /etc/nri-resource-policy
          name: resource-policyconfig
        - mountPath: /var/run/nri
          name: nrisockets
      nodeSelector:
        kubernetes.io/os: linux
      serviceAccount: nri-resource-policy
      volumes:
      - hostPath:
          path: /var/lib/nri-resource-policy
          type: DirectoryOrCreate
        name: resource-policydata
      - hostPath:
          path: /sys
          type: Directory
        name: hostsysfs
      - hostPath:
          path: /var/run/nri-resource-policy
        name: resource-policysockets
      - configMap:
          name: nri-resource-policy-config
        name: resource-policyconfig
      - hostPath:
          path: /var/run/nri
          type: Directory
        name: nrisockets

```
**after this patch:**
```yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  labels:
    app: nri-resource-policy
  name: nri-resource-policy
  namespace: kube-system
spec:
  selector:
    matchLabels:
      app: nri-resource-policy
  template:
    metadata:
      labels:
        app: nri-resource-policy
    spec:
      containers:
      - args:
        - --host-root
        - /host
        - --fallback-config
        - /etc/nri-resource-policy/nri-resource-policy.cfg
        - --pid-file
        - /tmp/nri-resource-policy.pid
        - -metrics-interval
        - 5s
        env:
        - name: NODE_NAME
          valueFrom:
            fieldRef:
              fieldPath: spec.nodeName
        image: nri-resource-policy-balloons:devel
        imagePullPolicy: Always
        name: nri-resource-policy-balloons
        ports:
        - containerPort: 8891
          hostPort: 8891
          name: metrics
          protocol: TCP
        resources:
          requests:
            cpu: 500m
            memory: 512Mi
        securityContext:
          allowPrivilegeEscalation: false
          capabilities:
            drop:
            - ALL
        volumeMounts:
        - mountPath: /var/lib/nri-resource-policy
          name: resource-policydata
        - mountPath: /host/sys
          name: hostsysfs
        - mountPath: /var/run/nri-resource-policy
          name: resource-policysockets
        - mountPath: /etc/nri-resource-policy
          name: resource-policyconfig
        - mountPath: /var/run/nri
          name: nrisockets
      nodeSelector:
        kubernetes.io/os: linux
      serviceAccount: nri-resource-policy
      volumes:
      - hostPath:
          path: /var/lib/nri-resource-policy
          type: DirectoryOrCreate
        name: resource-policydata
      - hostPath:
          path: /sys
          type: Directory
        name: hostsysfs
      - hostPath:
          path: /var/run/nri-resource-policy
        name: resource-policysockets
      - configMap:
          name: nri-resource-policy-config
        name: resource-policyconfig
      - hostPath:
          path: /var/run/nri
          type: Directory
        name: nrisockets

```