### PR TITLE
e2e: Fix Ansible SELinux disabling

### DIFF
--- a/test/e2e/playbook/provision.yaml
+++ b/test/e2e/playbook/provision.yaml
@@ -94,7 +94,6 @@
 
     - name: disable SELinux
       ansible.posix.selinux:
-        update_kernel_param: true
         state: disabled
       when: ansible_facts['distribution'] == "Fedora"
 


### PR DESCRIPTION
The kernel option is no longer needed so removing it.