### PR TITLE
.github: trigger e2e-test on a self-hosted runner for PRs.

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -4,8 +4,8 @@ name: NRI Resource Policy CI
 
 # Controls when the workflow will run
 on:
-#  pull_request:
-#    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
   schedule:
     - cron: '0 4 * * *'
 
@@ -17,7 +17,7 @@ jobs:
     name: "e2e tests"
     runs-on: >-
       ${{ (
-        github.event_name == 'push' ||
+        github.event_name == 'push' || github.event_name == 'pull_request' ||
         github.event_name == 'schedule' ||
         github.event.pull_request.author_association == 'OWNER' ||
         github.event.pull_request.author_association == 'MEMBER'


### PR DESCRIPTION
For PRs against main run our end-to-end tests on a self- hosted runner.