### PR TITLE
e2e: Add developer friendly output to self hosted runner

### DIFF
--- a/test/e2e/run_ci.sh
+++ b/test/e2e/run_ci.sh
@@ -22,5 +22,15 @@ if [ -f /mnt/env ]; then
     . /mnt/env
 fi
 
+# Make sure ts does not print error
+export LC_ALL=C
+
+echo "Test started" | ts '[%Y-%m-%d %H:%M:%S %z]'
+
 # Run the actual tests inside another VM.
-./run_tests.sh $1 "$GITHUB_WORKSPACE/e2e-test-results"
+./run_tests.sh $1 "$GITHUB_WORKSPACE/e2e-test-results" | ts -s '(%H:%M:%.S)'
+RET=$?
+
+echo "Test stopped" | ts '[%Y-%m-%d %H:%M:%S %z]'
+
+exit $RET

--- a/test/self-hosted-runner/docker/Dockerfile
+++ b/test/self-hosted-runner/docker/Dockerfile
@@ -39,7 +39,8 @@ RUN apt-get update -y && apt-get install -y \
   gnupg \
   sudo \
   bc \
-  lsb-release
+  lsb-release \
+  moreutils
 
 RUN if [ ! -f /usr/share/keyrings/docker-archive-keyring.gpg ]; then \
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg; \


### PR DESCRIPTION
Prepend each line printed by e2e tests by current time so that it is easier to see how long the various operations take.