### PR TITLE
e2e: Fix the return value of run_ci.sh

### DIFF
--- a/test/e2e/run_ci.sh
+++ b/test/e2e/run_ci.sh
@@ -27,6 +27,8 @@ export LC_ALL=C
 
 echo "Test started" | ts '[%Y-%m-%d %H:%M:%S %z]'
 
+set -o pipefail
+
 # Run the actual tests inside another VM.
 ./run_tests.sh $1 "$GITHUB_WORKSPACE/e2e-test-results" | ts -s '(%H:%M:%.S)'
 RET=$?


### PR DESCRIPTION
Catch the status value of run_ci.sh instead of ts command. This way we will be able to catch if e2e tests failed or not.