### PR TITLE
helm: add helm chart for plugins installations

### DIFF
--- a/deployment/helm/resource-management-policies/balloons/Chart.yaml
+++ b/deployment/helm/resource-management-policies/balloons/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+appVersion: main
+description: |
+  The balloons NRI resource policy plugin implements workload placement into
+  “balloons” that are disjoint CPU pools.
+name: nri-resource-policy-balloons
+sources:
+ - https://github.com/containers/nri-plugins
+home: https://github.com/containers/nri-plugins
+type: application
+version: 0.0.0

--- a/deployment/helm/resource-management-policies/balloons/crds/noderesourcetopology.yaml
+++ b/deployment/helm/resource-management-policies/balloons/crds/noderesourcetopology.yaml
@@ -1,0 +1,270 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes/enhancements/pull/1870
+    controller-gen.kubebuilder.io/version: v0.11.2
+  creationTimestamp: null
+  name: noderesourcetopologies.topology.node.k8s.io
+spec:
+  group: topology.node.k8s.io
+  names:
+    kind: NodeResourceTopology
+    listKind: NodeResourceTopologyList
+    plural: noderesourcetopologies
+    shortNames:
+    - node-res-topo
+    singular: noderesourcetopology
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NodeResourceTopology describes node resources and their topology.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          topologyPolicies:
+            items:
+              type: string
+            type: array
+          zones:
+            description: ZoneList contains an array of Zone objects.
+            items:
+              description: Zone represents a resource topology zone, e.g. socket,
+                node, die or core.
+              properties:
+                attributes:
+                  description: AttributeList contains an array of AttributeInfo objects.
+                  items:
+                    description: AttributeInfo contains one attribute of a Zone.
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                costs:
+                  description: CostList contains an array of CostInfo objects.
+                  items:
+                    description: CostInfo describes the cost (or distance) between
+                      two Zones.
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        format: int64
+                        type: integer
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                name:
+                  type: string
+                parent:
+                  type: string
+                resources:
+                  description: ResourceInfoList contains an array of ResourceInfo
+                    objects.
+                  items:
+                    description: ResourceInfo contains information about one resource
+                      type.
+                    properties:
+                      allocatable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Allocatable quantity of the resource, corresponding
+                          to allocatable in node status, i.e. total amount of this
+                          resource available to be used by pods.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      available:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Available is the amount of this resource currently
+                          available for new (to be scheduled) pods, i.e. Allocatable
+                          minus the resources reserved by currently running pods.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      capacity:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Capacity of the resource, corresponding to capacity
+                          in node status, i.e. total amount of this resource that
+                          the node has.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      name:
+                        description: Name of the resource.
+                        type: string
+                    required:
+                    - allocatable
+                    - available
+                    - capacity
+                    - name
+                    type: object
+                  type: array
+                type:
+                  type: string
+              required:
+              - name
+              - type
+              type: object
+            type: array
+        required:
+        - topologyPolicies
+        - zones
+        type: object
+    served: true
+    storage: false
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: NodeResourceTopology describes node resources and their topology.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          attributes:
+            description: AttributeList contains an array of AttributeInfo objects.
+            items:
+              description: AttributeInfo contains one attribute of a Zone.
+              properties:
+                name:
+                  type: string
+                value:
+                  type: string
+              required:
+              - name
+              - value
+              type: object
+            type: array
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          topologyPolicies:
+            description: 'DEPRECATED (to be removed in v1beta1): use top level attributes
+              if needed'
+            items:
+              type: string
+            type: array
+          zones:
+            description: ZoneList contains an array of Zone objects.
+            items:
+              description: Zone represents a resource topology zone, e.g. socket,
+                node, die or core.
+              properties:
+                attributes:
+                  description: AttributeList contains an array of AttributeInfo objects.
+                  items:
+                    description: AttributeInfo contains one attribute of a Zone.
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                costs:
+                  description: CostList contains an array of CostInfo objects.
+                  items:
+                    description: CostInfo describes the cost (or distance) between
+                      two Zones.
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        format: int64
+                        type: integer
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                name:
+                  type: string
+                parent:
+                  type: string
+                resources:
+                  description: ResourceInfoList contains an array of ResourceInfo
+                    objects.
+                  items:
+                    description: ResourceInfo contains information about one resource
+                      type.
+                    properties:
+                      allocatable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Allocatable quantity of the resource, corresponding
+                          to allocatable in node status, i.e. total amount of this
+                          resource available to be used by pods.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      available:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Available is the amount of this resource currently
+                          available for new (to be scheduled) pods, i.e. Allocatable
+                          minus the resources reserved by currently running pods.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      capacity:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Capacity of the resource, corresponding to capacity
+                          in node status, i.e. total amount of this resource that
+                          the node has.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      name:
+                        description: Name of the resource.
+                        type: string
+                    required:
+                    - allocatable
+                    - available
+                    - capacity
+                    - name
+                    type: object
+                  type: array
+                type:
+                  type: string
+              required:
+              - name
+              - type
+              type: object
+            type: array
+        required:
+        - zones
+        type: object
+    served: true
+    storage: true

--- a/deployment/helm/resource-management-policies/balloons/templates/_helpers.tpl
+++ b/deployment/helm/resource-management-policies/balloons/templates/_helpers.tpl
@@ -1,0 +1,8 @@
+{{/*
+Common labels
+*/}}
+{{- define "balloons-plugin.labels" -}}
+app: nri-resource-policy-balloons
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/deployment/helm/resource-management-policies/balloons/templates/clusterrole.yaml
+++ b/deployment/helm/resource-management-policies/balloons/templates/clusterrole.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nri-resource-policy-balloons
+  labels:
+    {{- include "balloons-plugin.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - watch
+- apiGroups:
+  - topology.node.k8s.io
+  resources:
+  - noderesourcetopologies
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - delete

--- a/deployment/helm/resource-management-policies/balloons/templates/clusterrolebinding.yaml
+++ b/deployment/helm/resource-management-policies/balloons/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nri-resource-policy-balloons
+  labels:
+    {{- include "balloons-plugin.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nri-resource-policy-balloons
+subjects:
+- kind: ServiceAccount
+  name: nri-resource-policy-balloons
+  namespace: {{ .Release.Namespace }}

--- a/deployment/helm/resource-management-policies/balloons/templates/configmap.yaml
+++ b/deployment/helm/resource-management-policies/balloons/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nri-resource-policy-balloons-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "balloons-plugin.labels" . | nindent 4 }}
+data:
+  policy: |+
+    {{- toYaml .Values.config | nindent 4 }}

--- a/deployment/helm/resource-management-policies/balloons/templates/daemonset.yaml
+++ b/deployment/helm/resource-management-policies/balloons/templates/daemonset.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    {{- include "balloons-plugin.labels" . | nindent 4 }}
+  name: nri-resource-policy-balloons
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+    {{- include "balloons-plugin.labels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+      {{- include "balloons-plugin.labels" . | nindent 8 }}
+    spec:
+      serviceAccount: nri-resource-policy-balloons
+      nodeSelector:
+        kubernetes.io/os: "linux"
+      containers:
+        - name: nri-resource-policy-balloons
+          args:
+            - --host-root
+            - /host
+            - --fallback-config
+            - /etc/nri-resource-policy/nri-resource-policy.cfg
+            - --pid-file
+            - /tmp/nri-resource-policy.pid
+            - -metrics-interval
+            - 5s
+          ports:
+            - containerPort: 8891
+              protocol: TCP
+              hostPort: {{ .Values.hostPort }}
+              name: metrics
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          image: {{ .Values.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: {{ .Values.resources.cpu }}
+              memory: {{ .Values.resources.memory }}
+          volumeMounts:
+          - name: resource-policydata
+            mountPath: /var/lib/nri-resource-policy
+          - name: hostsysfs
+            mountPath: /host/sys
+          - name: resource-policysockets
+            mountPath: /var/run/nri-resource-policy
+          - name: resource-policyconfig
+            mountPath: /etc/nri-resource-policy
+          - name: nrisockets
+            mountPath: /var/run/nri
+      volumes:
+      - name: resource-policydata
+        hostPath:
+          path: /var/lib/nri-resource-policy
+          type: DirectoryOrCreate
+      - name: hostsysfs
+        hostPath:
+          path: /sys
+          type: Directory
+      - name: resource-policysockets
+        hostPath:
+          path: /var/run/nri-resource-policy
+      - name: resource-policyconfig
+        configMap:
+          name: nri-resource-policy-balloons-config
+      - name: nrisockets
+        hostPath:
+          path: /var/run/nri
+          type: Directory

--- a/deployment/helm/resource-management-policies/balloons/templates/role.yaml
+++ b/deployment/helm/resource-management-policies/balloons/templates/role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: nri-resource-policy-balloons
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "balloons-plugin.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch

--- a/deployment/helm/resource-management-policies/balloons/templates/rolebinding.yaml
+++ b/deployment/helm/resource-management-policies/balloons/templates/rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: nri-resource-policy-balloons
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "balloons-plugin.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nri-resource-policy-balloons
+subjects:
+- kind: ServiceAccount
+  name: nri-resource-policy-balloons
+  namespace: {{ .Release.Namespace }}

--- a/deployment/helm/resource-management-policies/balloons/templates/serviceaccount.yaml
+++ b/deployment/helm/resource-management-policies/balloons/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nri-resource-policy-balloons
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "balloons-plugin.labels" . | nindent 4 }}

--- a/deployment/helm/resource-management-policies/balloons/values.yaml
+++ b/deployment/helm/resource-management-policies/balloons/values.yaml
@@ -1,0 +1,19 @@
+# Default values for nri-plugins.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+---
+image:
+  name: ghcr.io/containers/nri-plugins/nri-resource-policy-balloons
+  # tag, if defined will use the given image tag, otherwise Chart.AppVersion will be used
+  tag: unstable
+  pullPolicy: Always
+
+config:
+  ReservedResources:
+    cpu: 750m
+
+hostPort: 8891
+
+resources:
+  cpu: 500m
+  memory: 512Mi

--- a/deployment/helm/resource-management-policies/topology-aware/Chart.yaml
+++ b/deployment/helm/resource-management-policies/topology-aware/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+appVersion: main
+description: |
+  Topology-aware NRI resource policy plugin is a NRI plugin that will
+  apply hardware-aware resource allocation policies to the containers
+  running in the system.
+name: nri-resource-policy
+sources:
+ - https://github.com/containers/nri-plugins
+home: https://github.com/containers/nri-plugins
+type: application
+version: 0.0.0

--- a/deployment/helm/resource-management-policies/topology-aware/crds/noderesourcetopology.yaml
+++ b/deployment/helm/resource-management-policies/topology-aware/crds/noderesourcetopology.yaml
@@ -1,0 +1,270 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes/enhancements/pull/1870
+    controller-gen.kubebuilder.io/version: v0.11.2
+  creationTimestamp: null
+  name: noderesourcetopologies.topology.node.k8s.io
+spec:
+  group: topology.node.k8s.io
+  names:
+    kind: NodeResourceTopology
+    listKind: NodeResourceTopologyList
+    plural: noderesourcetopologies
+    shortNames:
+    - node-res-topo
+    singular: noderesourcetopology
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NodeResourceTopology describes node resources and their topology.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          topologyPolicies:
+            items:
+              type: string
+            type: array
+          zones:
+            description: ZoneList contains an array of Zone objects.
+            items:
+              description: Zone represents a resource topology zone, e.g. socket,
+                node, die or core.
+              properties:
+                attributes:
+                  description: AttributeList contains an array of AttributeInfo objects.
+                  items:
+                    description: AttributeInfo contains one attribute of a Zone.
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                costs:
+                  description: CostList contains an array of CostInfo objects.
+                  items:
+                    description: CostInfo describes the cost (or distance) between
+                      two Zones.
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        format: int64
+                        type: integer
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                name:
+                  type: string
+                parent:
+                  type: string
+                resources:
+                  description: ResourceInfoList contains an array of ResourceInfo
+                    objects.
+                  items:
+                    description: ResourceInfo contains information about one resource
+                      type.
+                    properties:
+                      allocatable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Allocatable quantity of the resource, corresponding
+                          to allocatable in node status, i.e. total amount of this
+                          resource available to be used by pods.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      available:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Available is the amount of this resource currently
+                          available for new (to be scheduled) pods, i.e. Allocatable
+                          minus the resources reserved by currently running pods.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      capacity:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Capacity of the resource, corresponding to capacity
+                          in node status, i.e. total amount of this resource that
+                          the node has.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      name:
+                        description: Name of the resource.
+                        type: string
+                    required:
+                    - allocatable
+                    - available
+                    - capacity
+                    - name
+                    type: object
+                  type: array
+                type:
+                  type: string
+              required:
+              - name
+              - type
+              type: object
+            type: array
+        required:
+        - topologyPolicies
+        - zones
+        type: object
+    served: true
+    storage: false
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: NodeResourceTopology describes node resources and their topology.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          attributes:
+            description: AttributeList contains an array of AttributeInfo objects.
+            items:
+              description: AttributeInfo contains one attribute of a Zone.
+              properties:
+                name:
+                  type: string
+                value:
+                  type: string
+              required:
+              - name
+              - value
+              type: object
+            type: array
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          topologyPolicies:
+            description: 'DEPRECATED (to be removed in v1beta1): use top level attributes
+              if needed'
+            items:
+              type: string
+            type: array
+          zones:
+            description: ZoneList contains an array of Zone objects.
+            items:
+              description: Zone represents a resource topology zone, e.g. socket,
+                node, die or core.
+              properties:
+                attributes:
+                  description: AttributeList contains an array of AttributeInfo objects.
+                  items:
+                    description: AttributeInfo contains one attribute of a Zone.
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                costs:
+                  description: CostList contains an array of CostInfo objects.
+                  items:
+                    description: CostInfo describes the cost (or distance) between
+                      two Zones.
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        format: int64
+                        type: integer
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                name:
+                  type: string
+                parent:
+                  type: string
+                resources:
+                  description: ResourceInfoList contains an array of ResourceInfo
+                    objects.
+                  items:
+                    description: ResourceInfo contains information about one resource
+                      type.
+                    properties:
+                      allocatable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Allocatable quantity of the resource, corresponding
+                          to allocatable in node status, i.e. total amount of this
+                          resource available to be used by pods.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      available:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Available is the amount of this resource currently
+                          available for new (to be scheduled) pods, i.e. Allocatable
+                          minus the resources reserved by currently running pods.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      capacity:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Capacity of the resource, corresponding to capacity
+                          in node status, i.e. total amount of this resource that
+                          the node has.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      name:
+                        description: Name of the resource.
+                        type: string
+                    required:
+                    - allocatable
+                    - available
+                    - capacity
+                    - name
+                    type: object
+                  type: array
+                type:
+                  type: string
+              required:
+              - name
+              - type
+              type: object
+            type: array
+        required:
+        - zones
+        type: object
+    served: true
+    storage: true

--- a/deployment/helm/resource-management-policies/topology-aware/templates/_helpers.tpl
+++ b/deployment/helm/resource-management-policies/topology-aware/templates/_helpers.tpl
@@ -1,0 +1,8 @@
+{{/*
+Common labels
+*/}}
+{{- define "topology-aware-plugin.labels" -}}
+app: nri-resource-policy-topology-aware
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/deployment/helm/resource-management-policies/topology-aware/templates/clusterrole.yaml
+++ b/deployment/helm/resource-management-policies/topology-aware/templates/clusterrole.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nri-resource-policy-topology-aware
+  labels:
+    {{- include "topology-aware-plugin.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - watch
+- apiGroups:
+  - topology.node.k8s.io
+  resources:
+  - noderesourcetopologies
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - delete

--- a/deployment/helm/resource-management-policies/topology-aware/templates/clusterrolebinding.yaml
+++ b/deployment/helm/resource-management-policies/topology-aware/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nri-resource-policy-topology-aware
+  labels:
+    {{- include "topology-aware-plugin.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nri-resource-policy-topology-aware
+subjects:
+- kind: ServiceAccount
+  name: nri-resource-policy-topology-aware
+  namespace: {{ .Release.Namespace }}

--- a/deployment/helm/resource-management-policies/topology-aware/templates/configmap.yaml
+++ b/deployment/helm/resource-management-policies/topology-aware/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nri-resource-policy-topology-aware-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "topology-aware-plugin.labels" . | nindent 4 }}
+data:
+  policy: |+
+    {{- toYaml .Values.config | nindent 4 }}

--- a/deployment/helm/resource-management-policies/topology-aware/templates/daemonset.yaml
+++ b/deployment/helm/resource-management-policies/topology-aware/templates/daemonset.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    {{- include "topology-aware-plugin.labels" . | nindent 4 }}
+  name: nri-resource-policy-topology-aware
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+    {{- include "topology-aware-plugin.labels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+      {{- include "topology-aware-plugin.labels" . | nindent 8 }}
+    spec:
+      serviceAccount: nri-resource-policy-topology-aware
+      nodeSelector:
+        kubernetes.io/os: "linux"
+      containers:
+        - name: nri-resource-policy-topology-aware
+          args:
+            - --host-root
+            - /host
+            - --fallback-config
+            - /etc/nri-resource-policy/nri-resource-policy.cfg
+            - --pid-file
+            - /tmp/nri-resource-policy.pid
+            - -metrics-interval
+            - 5s
+          ports:
+            - containerPort: 8891
+              protocol: TCP
+              hostPort: {{ .Values.hostPort }}
+              name: metrics
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          image: {{ .Values.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: {{ .Values.resources.cpu }}
+              memory: {{ .Values.resources.memory }}
+          volumeMounts:
+          - name: resource-policydata
+            mountPath: /var/lib/nri-resource-policy
+          - name: hostsysfs
+            mountPath: /host/sys
+          - name: resource-policysockets
+            mountPath: /var/run/nri-resource-policy
+          - name: resource-policyconfig
+            mountPath: /etc/nri-resource-policy
+          - name: nrisockets
+            mountPath: /var/run/nri
+      volumes:
+      - name: resource-policydata
+        hostPath:
+          path: /var/lib/nri-resource-policy
+          type: DirectoryOrCreate
+      - name: hostsysfs
+        hostPath:
+          path: /sys
+          type: Directory
+      - name: resource-policysockets
+        hostPath:
+          path: /var/run/nri-resource-policy
+      - name: resource-policyconfig
+        configMap:
+          name: nri-resource-policy-topology-aware-config
+      - name: nrisockets
+        hostPath:
+          path: /var/run/nri
+          type: Directory

--- a/deployment/helm/resource-management-policies/topology-aware/templates/role.yaml
+++ b/deployment/helm/resource-management-policies/topology-aware/templates/role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: nri-resource-policy-topology-aware
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "topology-aware-plugin.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch

--- a/deployment/helm/resource-management-policies/topology-aware/templates/rolebinding.yaml
+++ b/deployment/helm/resource-management-policies/topology-aware/templates/rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: nri-resource-policy-topology-aware
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "topology-aware-plugin.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nri-resource-policy-topology-aware
+subjects:
+- kind: ServiceAccount
+  name: nri-resource-policy-topology-aware
+  namespace: {{ .Release.Namespace }}

--- a/deployment/helm/resource-management-policies/topology-aware/templates/serviceaccount.yaml
+++ b/deployment/helm/resource-management-policies/topology-aware/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nri-resource-policy-topology-aware
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "topology-aware-plugin.labels" . | nindent 4 }}

--- a/deployment/helm/resource-management-policies/topology-aware/values.yaml
+++ b/deployment/helm/resource-management-policies/topology-aware/values.yaml
@@ -1,0 +1,19 @@
+# Default values for nri-plugins.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+---
+image:
+  name: ghcr.io/containers/nri-plugins/nri-resource-policy-topology-aware
+  # tag, if defined will use the given image tag, otherwise Chart.AppVersion will be used
+  tag: unstable
+  pullPolicy: Always
+
+config:
+  ReservedResources:
+    cpu: 750m
+
+hostPort: 8891
+
+resources:
+  cpu: 500m
+  memory: 512Mi


### PR DESCRIPTION
This commit adds a helm chart to install balloons and topology-aware NRI plugins.

To install the chart into local k8s cluster without current default settings, simply running below is enough:
```sh
# install topology aware plugin
helm install topology-aware deployment/helm/resource-management-policies/topology-aware/

# install balloons aware plugin
helm install balloons deployment/helm/resource-management-policies/balloons
```
For testing and just only generating the final YAML without sending it to k8s
```sh
#  generate  topology aware plugin deployment with  dry run
helm install topology-aware deployment/helm/resource-management-policies/topology-aware/ --dry-run > deployment.yaml

# generate balloons plugin deployment with dry run
helm install balloons deployment/helm/resource-management-policies/balloons --dry-run > deployment.yaml
```

The images currently the Helm chart defaulting to are:
[ghcr.io/containers/nri-plugins/nri-resource-policy-topology-aware:unstable](ghcr.io/containers/nri-plugins/nri-resource-policy-topology-aware:unstable)
[ghcr.io/containers/nri-plugins/nri-resource-policy-balloons:unstable](ghcr.io/containers/nri-plugins/nri-resource-policy-balloons:unstable)