### PR TITLE
resmgr, instrumentation: tag instrumentation traces with policy name.

### DIFF
--- a/pkg/instrumentation/instrumentation.go
+++ b/pkg/instrumentation/instrumentation.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	// ServiceName is our service name in external tracing and metrics services.
-	ServiceName = "NRI-Resource-Plugin"
+	ServiceName = "nri-resource-policy"
 )
 
 var (

--- a/pkg/instrumentation/tracing/tracing.go
+++ b/pkg/instrumentation/tracing/tracing.go
@@ -134,9 +134,10 @@ func (t *tracing) start(options ...Option) error {
 			append(
 				[]attribute.KeyValue{
 					semconv.ServiceName(t.service),
+					semconv.HostNameKey.String(hostname),
+					semconv.ProcessPIDKey.Int64(int64(os.Getpid())),
 					attribute.String("Version", version.Version),
 					attribute.String("Build", version.Build),
-					attribute.String("hostname", hostname),
 				},
 				t.identity...,
 			)...,

--- a/pkg/resmgr/main/main.go
+++ b/pkg/resmgr/main/main.go
@@ -109,6 +109,10 @@ func (m *Main) parseCmdline() {
 }
 
 func (m *Main) startTracing() error {
+	instrumentation.SetIdentity(
+		instrumentation.Attribute("resource-manager.policy", m.policy),
+	)
+
 	err := instrumentation.Start()
 	if err != nil {
 		return fmt.Errorf("failed to set up instrumentation: %v", err)


### PR DESCRIPTION
Set up an extra `resource-manager.policy = $policy` attribute in our instrumentation telemetry process/Resource.

