### PR TITLE
balloons: pull in balloons policy to balloons NRI plugin binary.

### DIFF
--- a/cmd/balloons/main.go
+++ b/cmd/balloons/main.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	policy "github.com/containers/nri-plugins/cmd/topology-aware/policy"
+	policy "github.com/containers/nri-plugins/cmd/balloons/policy"
 	logger "github.com/containers/nri-plugins/pkg/log"
 	resmgr "github.com/containers/nri-plugins/pkg/resmgr/main"
 )


### PR DESCRIPTION
Fix overly zealous unification of policy bootstrap code accidentally converting balloons to topology-aware.