### PR TITLE
cache: implement coarse topology hint control.

### DIFF
--- a/pkg/resmgr/cache/container.go
+++ b/pkg/resmgr/cache/container.go
@@ -505,6 +505,8 @@ func getTopologyHintsForMount(hostPath, containerPath string, readOnly bool) top
 		return topology.Hints{}
 	}
 
+	log.Debug("getting topology hints for mount %s (at %s)", hostPath, containerPath)
+
 	// ignore topology information for small files in /etc, service files in /var/lib/kubelet and host libraries mounts
 	ignoredTopologyPaths := []string{"/.nri-resource-policy", "/etc/", "/dev/termination-log", "/lib/", "/lib64/", "/usr/lib/", "/usr/lib32/", "/usr/lib64/"}
 
@@ -537,6 +539,8 @@ func getTopologyHintsForMount(hostPath, containerPath string, readOnly bool) top
 }
 
 func getTopologyHintsForDevice(devType string, major, minor int64) topology.Hints {
+	log.Debug("getting topology hints for device <%s %d,%d>", devType, major, minor)
+
 	if devPath, err := topology.FindGivenSysFsDevice(devType, major, minor); err == nil {
 		// errors are ignored
 		if hints, err := topology.NewTopologyHints(devPath); err == nil && len(hints) > 0 {

--- a/pkg/resmgr/cache/container.go
+++ b/pkg/resmgr/cache/container.go
@@ -523,6 +523,15 @@ func (c *container) SetMemoryLimit(value int64) {
 	c.markPending(NRI)
 }
 
+var (
+	// More complext rules, for Kubelet secrets and config maps
+	ignoredTopologyPathRegexps = []*regexp.Regexp{
+		// Kubelet directory can be different, but we can detect it by structure inside of it.
+		// For now, we can safely ignore exposed config maps and secrets for topology hints.
+		regexp.MustCompile(`(kubelet)?/pods/[[:xdigit:]-]+/volumes/kubernetes.io~(configmap|secret)/`),
+	}
+)
+
 func getTopologyHintsForMount(hostPath, containerPath string, readOnly bool) topology.Hints {
 
 	if readOnly {
@@ -542,12 +551,6 @@ func getTopologyHintsForMount(hostPath, containerPath string, readOnly bool) top
 		}
 	}
 
-	// More complext rules, for Kubelet secrets and config maps
-	ignoredTopologyPathRegexps := []*regexp.Regexp{
-		// Kubelet directory can be different, but we can detect it by structure inside of it.
-		// For now, we can safely ignore exposed config maps and secrets for topology hints.
-		regexp.MustCompile(`(kubelet)?/pods/[[:xdigit:]-]+/volumes/kubernetes.io~(configmap|secret)/`),
-	}
 	for _, re := range ignoredTopologyPathRegexps {
 		if re.MatchString(hostPath) || re.MatchString(containerPath) {
 			return topology.Hints{}

--- a/pkg/resmgr/resource-manager.go
+++ b/pkg/resmgr/resource-manager.go
@@ -76,6 +76,10 @@ type resmgr struct {
 	agent        agent.ResourceManagerAgent
 }
 
+const (
+	topologyLogger = "topology-hints"
+)
+
 // NewResourceManager creates a new ResourceManager instance.
 func NewResourceManager() (ResourceManager, error) {
 	m := &resmgr{Logger: logger.NewLogger("resource-manager")}
@@ -86,6 +90,7 @@ func NewResourceManager() (ResourceManager, error) {
 
 	sysfs.SetSysRoot(opt.HostRoot)
 	topology.SetSysRoot(opt.HostRoot)
+	topology.SetLogger(logger.Get(topologyLogger))
 
 	m.Info("running as an NRI plugin...")
 	nrip, err := newNRIPlugin(m)


### PR DESCRIPTION
Implement coarse control over topology hints by allowing hint generation to be separately disabled for mounts and devices using annotations. In addition to this we still need to implement more fine grained control based on mount and probably also device paths.
