### PR TITLE
e2e: fix test os distro defaulting

### DIFF
--- a/test/e2e/run_tests.sh
+++ b/test/e2e/run_tests.sh
@@ -3,7 +3,7 @@
 TESTS_DIR="$1"
 RUN_SH="${0%/*}/run.sh"
 
-DEFAULT_DISTRO="generic/fedora37"
+DEFAULT_DISTRO=${DEFAULT_DISTRO:-"generic/fedora37"}
 
 k8scri=${k8scri:="containerd"}
 


### PR DESCRIPTION
Currently `DEFAULT_DISTRO` can not be tuned via environment variable from terminal because no matter what is set from terminal gets overrided by the same variable in run.sh script which gets executed before we reach variable export here.

Example: `DEFAULT_DISTRO=generic/ubuntu2204 ./run_tests.sh `won't create a ubuntu vm but instead will use fedora.