### PR TITLE
rbac: control noderesourcetopologies permissions from ClusterRole

### DIFF
--- a/deployment/base/nri-resource-policy/clusterrole.yaml
+++ b/deployment/base/nri-resource-policy/clusterrole.yaml
@@ -10,3 +10,13 @@ rules:
   verbs:
   - get
   - watch
+- apiGroups:
+  - topology.node.k8s.io
+  resources:
+  - noderesourcetopologies
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - delete

--- a/deployment/base/nri-resource-policy/role.yaml
+++ b/deployment/base/nri-resource-policy/role.yaml
@@ -10,13 +10,3 @@ rules:
   verbs:
   - get
   - watch
-- apiGroups:
-  - topology.node.k8s.io
-  resources:
-  - noderesourcetopologies
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - delete

--- a/test/e2e/files/nri-resource-policy-balloons-deployment.yaml.in
+++ b/test/e2e/files/nri-resource-policy-balloons-deployment.yaml.in
@@ -22,6 +22,16 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - topology.node.k8s.io
+  resources:
+  - noderesourcetopologies
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
NodeReourceTopologies CRD is cluster-scoped resource. As such, RBAC rules related to NodeReourceTopologies should be controlled from ClusterRole object instead of Role object which is more for namespaced objects.