### PR TITLE
readme: Add documentation link to readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,6 @@ Currently following plugins are available:
 | [Topology Aware][1] |  resource policy |
 | [Balloons][1]       |  resource policy |
 
+See the [NRI plugins documentation](https://containers.github.io/nri-plugins/) for more information.
+
 [1]: http://github.com/containers/nri-plugins/blob/main/docs/resource-policy/README.md


### PR DESCRIPTION
The NRI plugins documentation can be found at

https://containers.github.io/nri-plugins/devel/docs/index.html

so mention it in readme file.