### PR TITLE
Implement handling of update container requests.

### DIFF
--- a/cmd/topology-aware/policy/mocks_test.go
+++ b/cmd/topology-aware/policy/mocks_test.go
@@ -345,6 +345,12 @@ func (m *mockContainer) String() string {
 func (m *mockContainer) GetResourceRequirements() v1.ResourceRequirements {
 	return m.returnValueForGetResourceRequirements
 }
+func (m *mockContainer) SetResourceUpdates(*nri.LinuxResources) bool {
+	return false
+}
+func (m *mockContainer) GetResourceUpdates() (v1.ResourceRequirements, bool) {
+	return v1.ResourceRequirements{}, false
+}
 func (m *mockContainer) InsertMount(*cache.Mount) {
 	panic("unimplemented")
 }

--- a/cmd/topology-aware/policy/pod-preferences.go
+++ b/cmd/topology-aware/policy/pod-preferences.go
@@ -426,7 +426,12 @@ func cpuAllocationPreferences(pod cache.Pod, container cache.Container) (int, in
 	//
 
 	namespace := container.GetNamespace()
-	request := container.GetResourceRequirements().Requests[corev1.ResourceCPU]
+
+	reqs, ok := container.GetResourceUpdates()
+	if !ok {
+		reqs = container.GetResourceRequirements()
+	}
+	request := reqs.Requests[corev1.ResourceCPU]
 	qosClass := pod.GetQOSClass()
 	fraction := int(request.MilliValue())
 
@@ -525,7 +530,10 @@ func podMemoryTypePreference(pod cache.Pod, c cache.Container) memoryType {
 
 // memoryAllocationPreference returns the amount and kind of memory to allocate.
 func memoryAllocationPreference(pod cache.Pod, c cache.Container) (uint64, uint64, memoryType) {
-	resources := c.GetResourceRequirements()
+	resources, ok := c.GetResourceUpdates()
+	if !ok {
+		resources = c.GetResourceRequirements()
+	}
 	mtype := memoryTypePreference(pod, c)
 	req, lim := uint64(0), uint64(0)
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
-	github.com/containerd/nri v0.3.0
+	github.com/containerd/nri v0.3.1-0.20230601014931-040229d0100f
 	github.com/containers/nri-plugins/pkg/topology v0.0.0
 	github.com/intel/goresctrl v0.3.0
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
-github.com/containerd/nri v0.3.0 h1:2ZM4WImye1ypSnE7COjOvPAiLv84kaPILBDvb1tbDK8=
-github.com/containerd/nri v0.3.0/go.mod h1:Zw9q2lP16sdg0zYybemZ9yTDy8g7fPCIB3KXOGlggXI=
+github.com/containerd/nri v0.3.1-0.20230601014931-040229d0100f h1:YccqdIvYsUyuvrp+qfyJGL2Lz6XH1AGmEMc0oWi/f9E=
+github.com/containerd/nri v0.3.1-0.20230601014931-040229d0100f/go.mod h1:Zw9q2lP16sdg0zYybemZ9yTDy8g7fPCIB3KXOGlggXI=
 github.com/containerd/ttrpc v1.1.1-0.20220420014843-944ef4a40df3 h1:BhCp66ofL8oYcdelc3CBXc2/Pfvvgx+s+mrp9TvNgn8=
 github.com/containerd/ttrpc v1.1.1-0.20220420014843-944ef4a40df3/go.mod h1:YYyNVhZrTMiaf51Vj6WhAJqJw+vl/nzABhj8pWrzle4=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/pkg/resmgr/cache/cache.go
+++ b/pkg/resmgr/cache/cache.go
@@ -207,8 +207,16 @@ type Container interface {
 	// We have String() for containers.
 	fmt.Stringer
 
-	// GetResourceRequirements returns the webhook-annotated requirements for ths container.
+	// GetResourceRequirements returns the resource requirements for this container.
+	// The requirements are calculated from the containers cgroup parameters.
 	GetResourceRequirements() v1.ResourceRequirements
+
+	// SetResourceUpdates sets updated resources for a container. Returns true if the
+	// resources were really updated.
+	SetResourceUpdates(*nri.LinuxResources) bool
+	// GetResourceUpdates() returns any updated resource requirements for this container.
+	// The updates are calculated from the cgroups parameters in the resource update.
+	GetResourceUpdates() (v1.ResourceRequirements, bool)
 
 	// InsertMount inserts a mount into the container.
 	InsertMount(*Mount)
@@ -286,8 +294,9 @@ type container struct {
 	Ctr   *nri.Container // container data from NRI
 	State ContainerState // current state of the container
 
-	Requirements v1.ResourceRequirements
-	request      interface{}
+	Requirements    v1.ResourceRequirements
+	ResourceUpdates *v1.ResourceRequirements
+	request         interface{}
 
 	Resources *nri.LinuxResources
 

--- a/pkg/resmgr/nri.go
+++ b/pkg/resmgr/nri.go
@@ -103,11 +103,11 @@ func (p *nriPlugin) onClose() {
 	p.restart()
 }
 
-func (p *nriPlugin) Configure(cfg, runtime, version string) (stub.EventMask, error) {
+func (p *nriPlugin) Configure(ctx context.Context, cfg, runtime, version string) (stub.EventMask, error) {
 	event := Configure
 
 	_, span := tracing.StartSpan(
-		context.TODO(),
+		ctx,
 		event,
 		tracing.WithAttributes(
 			tracing.Attribute(SpanTagRuntimeName, runtime),
@@ -174,11 +174,11 @@ func (p *nriPlugin) syncWithNRI(pods []*api.PodSandbox, containers []*api.Contai
 	return allocated, released, nil
 }
 
-func (p *nriPlugin) Synchronize(pods []*api.PodSandbox, containers []*api.Container) (updates []*api.ContainerUpdate, retErr error) {
+func (p *nriPlugin) Synchronize(ctx context.Context, pods []*api.PodSandbox, containers []*api.Container) (updates []*api.ContainerUpdate, retErr error) {
 	event := Synchronize
 
 	_, span := tracing.StartSpan(
-		context.TODO(),
+		ctx,
 		event,
 	)
 	defer func() {
@@ -208,11 +208,11 @@ func (p *nriPlugin) Synchronize(pods []*api.PodSandbox, containers []*api.Contai
 	return p.getPendingUpdates(nil), nil
 }
 
-func (p *nriPlugin) RunPodSandbox(pod *api.PodSandbox) (retErr error) {
+func (p *nriPlugin) RunPodSandbox(ctx context.Context, pod *api.PodSandbox) (retErr error) {
 	event := RunPodSandbox
 
 	_, span := tracing.StartSpan(
-		context.TODO(),
+		ctx,
 		event,
 		tracing.WithAttributes(podSpanTags(pod)...),
 	)
@@ -233,11 +233,11 @@ func (p *nriPlugin) RunPodSandbox(pod *api.PodSandbox) (retErr error) {
 	return nil
 }
 
-func (p *nriPlugin) StopPodSandbox(pod *api.PodSandbox) (retErr error) {
+func (p *nriPlugin) StopPodSandbox(ctx context.Context, pod *api.PodSandbox) (retErr error) {
 	event := StopPodSandbox
 
 	_, span := tracing.StartSpan(
-		context.TODO(),
+		ctx,
 		event,
 		tracing.WithAttributes(podSpanTags(pod)...),
 	)
@@ -253,11 +253,11 @@ func (p *nriPlugin) StopPodSandbox(pod *api.PodSandbox) (retErr error) {
 	return nil
 }
 
-func (p *nriPlugin) RemovePodSandbox(pod *api.PodSandbox) (retErr error) {
+func (p *nriPlugin) RemovePodSandbox(ctx context.Context, pod *api.PodSandbox) (retErr error) {
 	event := RemovePodSandbox
 
 	_, span := tracing.StartSpan(
-		context.TODO(),
+		ctx,
 		event,
 		tracing.WithAttributes(podSpanTags(pod)...),
 	)
@@ -278,11 +278,11 @@ func (p *nriPlugin) RemovePodSandbox(pod *api.PodSandbox) (retErr error) {
 	return nil
 }
 
-func (p *nriPlugin) CreateContainer(pod *api.PodSandbox, container *api.Container) (adjust *api.ContainerAdjustment, updates []*api.ContainerUpdate, retErr error) {
+func (p *nriPlugin) CreateContainer(ctx context.Context, pod *api.PodSandbox, container *api.Container) (adjust *api.ContainerAdjustment, updates []*api.ContainerUpdate, retErr error) {
 	event := CreateContainer
 
 	_, span := tracing.StartSpan(
-		context.TODO(),
+		ctx,
 		event,
 		tracing.WithAttributes(containerSpanTags(pod, container)...),
 	)
@@ -326,11 +326,11 @@ func (p *nriPlugin) CreateContainer(pod *api.PodSandbox, container *api.Containe
 	return adjust, updates, nil
 }
 
-func (p *nriPlugin) StartContainer(pod *api.PodSandbox, container *api.Container) (retErr error) {
+func (p *nriPlugin) StartContainer(ctx context.Context, pod *api.PodSandbox, container *api.Container) (retErr error) {
 	event := StartContainer
 
 	_, span := tracing.StartSpan(
-		context.TODO(),
+		ctx,
 		event,
 		tracing.WithAttributes(containerSpanTags(pod, container)...),
 	)
@@ -367,11 +367,11 @@ func (p *nriPlugin) StartContainer(pod *api.PodSandbox, container *api.Container
 	return nil
 }
 
-func (p *nriPlugin) UpdateContainer(pod *api.PodSandbox, container *api.Container) (updates []*api.ContainerUpdate, retErr error) {
+func (p *nriPlugin) UpdateContainer(ctx context.Context, pod *api.PodSandbox, container *api.Container, res *api.LinuxResources) (updates []*api.ContainerUpdate, retErr error) {
 	event := UpdateContainer
 
 	_, span := tracing.StartSpan(
-		context.TODO(),
+		ctx,
 		event,
 		tracing.WithAttributes(containerSpanTags(pod, container)...),
 	)
@@ -393,11 +393,11 @@ func (p *nriPlugin) UpdateContainer(pod *api.PodSandbox, container *api.Containe
 	return nil, nil
 }
 
-func (p *nriPlugin) StopContainer(pod *api.PodSandbox, container *api.Container) (updates []*api.ContainerUpdate, retErr error) {
+func (p *nriPlugin) StopContainer(ctx context.Context, pod *api.PodSandbox, container *api.Container) (updates []*api.ContainerUpdate, retErr error) {
 	event := StopContainer
 
 	_, span := tracing.StartSpan(
-		context.TODO(),
+		ctx,
 		event,
 		tracing.WithAttributes(containerSpanTags(pod, container)...),
 	)
@@ -429,11 +429,11 @@ func (p *nriPlugin) StopContainer(pod *api.PodSandbox, container *api.Container)
 	return p.getPendingUpdates(container), nil
 }
 
-func (p *nriPlugin) RemoveContainer(pod *api.PodSandbox, container *api.Container) (retErr error) {
+func (p *nriPlugin) RemoveContainer(ctx context.Context, pod *api.PodSandbox, container *api.Container) (retErr error) {
 	event := RemoveContainer
 
 	_, span := tracing.StartSpan(
-		context.TODO(),
+		ctx,
 		event,
 		tracing.WithAttributes(containerSpanTags(pod, container)...),
 	)

--- a/pkg/resmgr/nri.go
+++ b/pkg/resmgr/nri.go
@@ -379,7 +379,7 @@ func (p *nriPlugin) UpdateContainer(ctx context.Context, pod *api.PodSandbox, co
 		span.End(tracing.WithStatus(retErr))
 	}()
 
-	p.dump(in, event, pod, container)
+	p.dump(in, event, pod, container, res)
 	defer func() {
 		p.dump(out, event, updates, retErr)
 	}()
@@ -575,7 +575,7 @@ func (p *nriPlugin) dump(dir, event string, args ...interface{}) {
 			p.Info("%s %s", dir, event)
 		}
 
-	case CreateContainer, StartContainer, UpdateContainer, StopContainer, RemoveContainer:
+	case CreateContainer, StartContainer, StopContainer, RemoveContainer:
 		if dir == in {
 			if len(args) != 2 {
 				p.Error("%s %s <dump error, %d args, expected (pod, container)>",
@@ -598,6 +598,59 @@ func (p *nriPlugin) dump(dir, event string, args ...interface{}) {
 
 			p.Info("%s %s %s/%s:%s", dir, event, pod.GetNamespace(), pod.GetName(), ctr.GetName())
 			p.dumpDetails(dir, event, ctr)
+		} else {
+			if len(args) < 1 {
+				p.Error("%s %s <dump error, missing args>", dir, event)
+				return
+			}
+
+			err := args[len(args)-1]
+			if err != nil {
+				p.Error("%s %s FAILED: %v", dir, event, err.(error))
+				return
+			}
+
+			p.Info("%s %s", dir, event)
+
+			switch event {
+			case CreateContainer:
+				p.dumpDetails(dir, event, args[0])
+				p.dumpDetails(dir, event, args[1])
+			case StopContainer, UpdateContainer:
+				p.dumpDetails(dir, event, args[0])
+			}
+		}
+
+	case UpdateContainer:
+		if dir == in {
+			if len(args) != 3 {
+				p.Error("%s %s <dump error, %d args, expected (pod, container, resources)>",
+					dir, event, len(args))
+				return
+			}
+
+			pod, ok := args[0].(*api.PodSandbox)
+			if !ok {
+				p.Error("%s %s <dump error, args %T, %T, %T, expected (pod, container, resources)>",
+					dir, event, args[0], args[1], args[2])
+				return
+			}
+			ctr, ok := args[1].(*api.Container)
+			if !ok {
+				p.Error("%s %s <dump error, args %T, %T, %T, expected (pod, container, resources)>",
+					dir, event, args[0], args[1], args[2])
+				return
+			}
+			res, ok := args[2].(*api.LinuxResources)
+			if !ok {
+				p.Error("%s %s <dump error, args %T, %T, %T, expected (pod, container, resources)>",
+					dir, event, args[0], args[1], args[2])
+				return
+			}
+
+			p.Info("%s %s %s/%s:%s", dir, event, pod.GetNamespace(), pod.GetName(), ctr.GetName())
+			p.dumpDetails(dir, event, ctr)
+			p.dumpDetails(dir, event, res)
 		} else {
 			if len(args) < 1 {
 				p.Error("%s %s <dump error, missing args>", dir, event)
@@ -712,7 +765,7 @@ func (p *nriPlugin) dumpDetails(dir, event string, arg interface{}) {
 
 	if dir == in {
 		switch event {
-		case RunPodSandbox, CreateContainer, Synchronize:
+		case RunPodSandbox, CreateContainer, UpdateContainer, Synchronize:
 		default:
 			// we only dump details for the requests listed above
 			return
@@ -734,6 +787,10 @@ func (p *nriPlugin) dumpDetails(dir, event string, arg interface{}) {
 	case *api.Container:
 		data := marshal("container", obj)
 		p.DebugBlock(dir+"   <ctr> ", "%s", data)
+
+	case *api.LinuxResources:
+		data := marshal("updated resources", obj)
+		p.DebugBlock(dir+"   <update> ", "%s", data)
 
 	case *api.ContainerAdjustment:
 		data := marshal("adjustment", obj)


### PR DESCRIPTION
This patch set implements handling requests to update container resources. This can happen if the cluster has the InPlacePodVerticalScaling feature gate set to true.

The patch series 
- updates our NRI dependencies to the latest HEAD
- updates our stub plugin interfaces with the necessary related changes (context passed from stub to plugin)
- adds functions for storing and retrieving container resource updates in the cache
- hooks the policy into NRI request processing for UpdateContainers
- implements reallocation of resources for the topology-aware policy

