### PR TITLE
nri: don't dump Synchronize reponse twice.

### DIFF
--- a/pkg/resmgr/nri.go
+++ b/pkg/resmgr/nri.go
@@ -683,7 +683,6 @@ func (p *nriPlugin) dump(dir, event string, args ...interface{}) {
 
 			p.Info("%s %s", dir, event)
 			p.dumpDetails(dir, event, args[0])
-			p.dumpDetails(dir, event, args[0])
 		}
 
 	default:


### PR DESCRIPTION
The response to a Synchronize request is now dumped twice. This PR stops doing it.