### PR TITLE
docs: flatten the hierarchy

### DIFF
--- a/docs/resource-policy/configuration.rst
+++ b/docs/resource-policy/configuration.rst
@@ -1,7 +1,0 @@
-Configuration
-#############
-.. toctree::
-   :maxdepth: 1
-
-   policy/index.rst
-   node-agent.md

--- a/docs/resource-policy/index.rst
+++ b/docs/resource-policy/index.rst
@@ -8,6 +8,7 @@ Resource Policy Plugins
    introduction.md
    installation.md
    setup.md
-   configuration.rst
+   node-agent.md
+   policy/index.rst
 
    developers-guide/index.rst


### PR DESCRIPTION
Drop one level of sub-hierarchy, making "Policies" a top-level item in the "Resource Policy Plugins" section. Makes the documentation easier to follow (and easier to find the detailed docs of the actual policies/plugins).