### PR TITLE
pkg: eliminate usage of obsolete github.com/pkg/errors.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.0
 	github.com/onsi/ginkgo/v2 v2.9.1
 	github.com/onsi/gomega v1.27.4
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0
 	github.com/prometheus/client_model v0.3.0
 	github.com/prometheus/common v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -287,7 +287,6 @@ github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb/go.m
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pkg/pidfile/pidfile_test.go
+++ b/pkg/pidfile/pidfile_test.go
@@ -15,12 +15,12 @@
 package pidfile
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -244,7 +244,7 @@ func TestOwnerPid(t *testing.T) {
 func mkTestDir(t *testing.T) (string, error) {
 	tmp, err := ioutil.TempDir("", ".pidfile-test*")
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to create test directory")
+		return "", fmt.Errorf("failed to create test directory: %w", err)
 	}
 
 	t.Cleanup(func() {

--- a/pkg/resmgr/cache/container_test.go
+++ b/pkg/resmgr/cache/container_test.go
@@ -29,7 +29,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	nri "github.com/containerd/nri/pkg/api"
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 	"sigs.k8s.io/yaml"
 )
@@ -871,9 +870,9 @@ func setupSysFsDevice(dev string) error {
 	fi, err := os.Stat(dev)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return errors.Wrapf(err, "no such file %s", dev)
+			return fmt.Errorf("no such file %s: %w", dev, err)
 		}
-		return errors.Wrapf(err, "unable to get stat for %s", dev)
+		return fmt.Errorf("unable to get stat for %s: %w", dev, err)
 	}
 
 	devType := "block"
@@ -888,12 +887,12 @@ func setupSysFsDevice(dev string) error {
 	major := int64(unix.Major(rdev))
 	minor := int64(unix.Minor(rdev))
 	if major == 0 {
-		return errors.Errorf("%s is a virtual device node", dev)
+		return fmt.Errorf("%s is a virtual device node", dev)
 	}
 
 	err = createSysFsDevice(devType, major, minor)
 	if err != nil {
-		return errors.Wrapf(err, "failed to find sysfs device for %s", dev)
+		return fmt.Errorf("failed to find sysfs device for %s: %w", dev, err)
 	}
 
 	return nil

--- a/pkg/topology/go.mod
+++ b/pkg/topology/go.mod
@@ -2,7 +2,4 @@ module github.com/containers/nri-plugins/pkg/topology
 
 go 1.19
 
-require (
-	github.com/pkg/errors v0.9.1
-	golang.org/x/sys v0.1.0
-)
+require golang.org/x/sys v0.1.0

--- a/pkg/topology/go.sum
+++ b/pkg/topology/go.sum
@@ -1,4 +1,2 @@
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Switch from `errors.Wrap` and `errors.Errorf` to `fmt.Errorf`.