### PR TITLE
build: Fix baseurl when building documentation version selector

### DIFF
--- a/scripts/build/update-gh-pages.sh
+++ b/scripts/build/update-gh-pages.sh
@@ -15,7 +15,7 @@ EOF
 
 # Helper function for detecting available versions from the current directory
 create_versions_js() {
-    _baseurl="/nri-resource-policy"
+    _baseurl="/nri-plugins"
 
     echo -e "function getVersionsMenuItems() {\n  return ["
     # 'stable' is a symlink pointing to the latest version


### PR DESCRIPTION
The update-gh-pages.sh builds the version selector at the bottom left corner of the documentation. The baseurl was wrong so all the versioned, stable and devel documentation gave 404 error.