### PR TITLE
config: Fix configuration files for kustomize

### DIFF
--- a/deployment/base/nri-resource-policy/daemonset.yaml
+++ b/deployment/base/nri-resource-policy/daemonset.yaml
@@ -73,7 +73,7 @@ spec:
           path: /var/run/nri-resource-policy
       - name: resource-policyconfig
         configMap:
-          name: nri-resource-policy-config
+          name: nri-resource-policy-config.default
       - name: nrisockets
         hostPath:
           path: /var/run/nri

--- a/deployment/overlays/balloons/kustomization.yaml
+++ b/deployment/overlays/balloons/kustomization.yaml
@@ -5,8 +5,8 @@ namespace: kube-system
 
 images:
 - name: '*'
-  newName: nri-resource-policy-balloons
-  newTag: devel
+  newName: ghcr.io/containers/nri-plugins/nri-resource-policy-balloons
+  newTag: unstable
 
 resources:
 - ../../base/crds

--- a/deployment/overlays/balloons/sample-configmap.yaml
+++ b/deployment/overlays/balloons/sample-configmap.yaml
@@ -6,6 +6,35 @@ data:
   policy: |+
     ReservedResources:
       cpu: 750m
-    #balloons:
+  #  balloons:
+  #    PinCPU: true
+  #    PinMemory: true
+  #    IdleCPUClass: lowpower
+  #    BalloonTypes:
+  #      - Name: "quad"
+  #        MinCpus: 1
+  #        MaxCPUs: 4
+  #        CPUClass: dynamic
+  #        Namespaces:
+  #          - "*"
+  #cpu: |+
+  #  classes:
+  #    lowpower:
+  #      minFreq: 800
+  #      maxFreq: 800
+  #    dynamic:
+  #      minFreq: 800
+  #      maxFreq: 3600
+  #    turbo:
+  #      minFreq: 3000
+  #      maxFreq: 3600
+  #      uncoreMinFreq: 2000
+  #      uncoreMaxFreq: 2400
+  #instrumentation: |+
+  #  # The balloons policy exports containers running in each balloon,
+  #  # and cpusets of balloons. Accessible in command line:
+  #  # curl --silent http://localhost:8891/metrics
+  #  HTTPEndpoint: :8891
+  #  PrometheusExport: true
   #logger: |+
-    #Debug: resource-manager,cache,policy,resource-control
+  #  Debug: resource-manager,cache,policy,resource-control

--- a/deployment/overlays/topology-aware/kustomization.yaml
+++ b/deployment/overlays/topology-aware/kustomization.yaml
@@ -5,8 +5,8 @@ namespace: kube-system
 
 images:
 - name: '*'
-  newName: nri-resource-policy-topology-aware
-  newTag: devel
+  newName: ghcr.io/containers/nri-plugins/nri-resource-policy-topology-aware
+  newTag: unstable
 
 resources:
 - ../../base/crds


### PR DESCRIPTION
1. Add the "default" suffix of the daemonset.yam to keep with sample-configmap.yaml .

2. Fix the wrong image name, both the topology-aware and balloons policy.

3. Add more sample configurations to the balloon policy.

Signed-off-by: zhi.chang <zhi.chang@intel.com>