### PR TITLE
gihub-action: fix helm linter action trigger path

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -2,7 +2,7 @@ name: helm linter
 
 on: 
   pull_request:
-    paths-ignore:
+    paths:
       - 'deployment/helm/**'
 
 jobs:


### PR DESCRIPTION
We would like to trigger helm linter github action only when helm directory has been changed on a pull request. Currently, we are doing opposite of that, which means don't run it when helm directory has changed. This commit fixes that bug.