### PR TITLE
Helm chart configmap fixes and some YAML clean up

### DIFF
--- a/cmd/balloons/nri-resource-policy-balloons-deployment.yaml.in
+++ b/cmd/balloons/nri-resource-policy-balloons-deployment.yaml.in
@@ -121,7 +121,7 @@ spec:
           path: /var/run/nri-resource-policy
       - name: resource-policyconfig
         configMap:
-          name: nri-resource-policy-config
+          name: fallback-config
       - name: nrisockets
         hostPath:
           path: /var/run/nri
@@ -138,5 +138,5 @@ data:
       Debug: resource-manager,cache,policy,resource-control
 kind: ConfigMap
 metadata:
-  name: nri-resource-policy-config
+  name: fallback-config
   namespace: kube-system

--- a/cmd/template/nri-resource-policy-template-deployment.yaml.in
+++ b/cmd/template/nri-resource-policy-template-deployment.yaml.in
@@ -121,7 +121,7 @@ spec:
           path: /var/run/nri-resource-policy
       - name: resmgrconfig
         configMap:
-          name: nri-resource-policy-config
+          name: fallback-config
       - name: nrisockets
         hostPath:
           path: /var/run/nri
@@ -138,5 +138,5 @@ data:
       Debug: nri-resource-policy,resource-manager,cache,policy
 kind: ConfigMap
 metadata:
-  name: nri-resource-policy-config
+  name: fallback-config
   namespace: kube-system

--- a/cmd/topology-aware/nri-resource-policy-topology-aware-deployment.yaml.in
+++ b/cmd/topology-aware/nri-resource-policy-topology-aware-deployment.yaml.in
@@ -121,7 +121,7 @@ spec:
           path: /var/run/nri-resource-policy
       - name: resource-policyconfig
         configMap:
-          name: nri-resource-policy-config
+          name: fallback-config
       - name: nrisockets
         hostPath:
           path: /var/run/nri
@@ -138,5 +138,5 @@ data:
       Debug: nri-resource-policy,resource-manager,cache,policy
 kind: ConfigMap
 metadata:
-  name: nri-resource-policy-config
+  name: fallback-config
   namespace: kube-system

--- a/deployment/helm/resource-management-policies/balloons/templates/configmap.yaml
+++ b/deployment/helm/resource-management-policies/balloons/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nri-resource-policy-balloons-config
+  name: nri-resource-policy-config.default
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "balloons-plugin.labels" . | nindent 4 }}

--- a/deployment/helm/resource-management-policies/balloons/templates/daemonset.yaml
+++ b/deployment/helm/resource-management-policies/balloons/templates/daemonset.yaml
@@ -73,7 +73,7 @@ spec:
           path: /var/run/nri-resource-policy
       - name: resource-policyconfig
         configMap:
-          name: nri-resource-policy-balloons-config
+          name: nri-resource-policy-config.default
       - name: nrisockets
         hostPath:
           path: /var/run/nri

--- a/deployment/helm/resource-management-policies/topology-aware/templates/configmap.yaml
+++ b/deployment/helm/resource-management-policies/topology-aware/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nri-resource-policy-topology-aware-config
+  name: nri-resource-policy-config.default
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "topology-aware-plugin.labels" . | nindent 4 }}

--- a/deployment/helm/resource-management-policies/topology-aware/templates/daemonset.yaml
+++ b/deployment/helm/resource-management-policies/topology-aware/templates/daemonset.yaml
@@ -73,7 +73,7 @@ spec:
           path: /var/run/nri-resource-policy
       - name: resource-policyconfig
         configMap:
-          name: nri-resource-policy-topology-aware-config
+          name: nri-resource-policy-config.default
       - name: nrisockets
         hostPath:
           path: /var/run/nri


### PR DESCRIPTION
This PR corrects the name of the configMap that agents is expecting and also corrects the name of the configMap that used as a base for fallback config.