### PR TITLE
config: Fix configuration files for sample-configmap

### DIFF
--- a/deployment/overlays/balloons/sample-configmap.yaml
+++ b/deployment/overlays/balloons/sample-configmap.yaml
@@ -3,38 +3,53 @@ kind: ConfigMap
 metadata:
   name: nri-resource-policy-config.default
 data:
-  policy: |+
-    ReservedResources:
-      cpu: 750m
-  #  balloons:
-  #    PinCPU: true
-  #    PinMemory: true
-  #    IdleCPUClass: lowpower
-  #    BalloonTypes:
-  #      - Name: "quad"
-  #        MinCpus: 1
-  #        MaxCPUs: 4
-  #        CPUClass: dynamic
-  #        Namespaces:
-  #          - "*"
-  #cpu: |+
-  #  classes:
-  #    lowpower:
-  #      minFreq: 800
-  #      maxFreq: 800
-  #    dynamic:
-  #      minFreq: 800
-  #      maxFreq: 3600
-  #    turbo:
-  #      minFreq: 3000
-  #      maxFreq: 3600
-  #      uncoreMinFreq: 2000
-  #      uncoreMaxFreq: 2400
-  #instrumentation: |+
-  #  # The balloons policy exports containers running in each balloon,
-  #  # and cpusets of balloons. Accessible in command line:
-  #  # curl --silent http://localhost:8891/metrics
-  #  HTTPEndpoint: :8891
-  #  PrometheusExport: true
-  #logger: |+
-  #  Debug: resource-manager,cache,policy,resource-control
+  nri-resource-policy.cfg: |+
+    policy:
+      Active: balloons
+      AvailableResources:
+        CPU: cpuset:0-15
+      ReservedResources:
+        CPU: 1
+      balloons:
+        PinCPU: true
+        PinMemory: true
+        BalloonTypes:
+          - Name: btype0
+            MinCPUs: 2
+            MaxCPUs: 2
+            AllocationPriority: 0
+            CPUClass: classA
+            PreferNewBalloons: true
+            PreferSpreadingPods: false
+            MinBalloons: 1
+          - Name: btype2
+            Namespaces:
+              - "*"
+              - btype2ns1
+            MinCPUs: 4
+            MaxCPUs: 8
+            MinBalloons: 1
+            AllocatorPriority: 2
+            CPUClass: classB
+            PreferNewBalloons: false
+            PreferSpreadingPods: false
+    instrumentation:
+      HTTPEndpoint: :8891
+      PrometheusExport: true
+    logger:
+      Debug: policy,cpu
+    cpu:
+      classes:
+        default:
+          minFreq: 800
+          maxFreq: 2800
+        classA:
+          minFreq: 900
+          maxFreq: 2900
+        classB:
+          minFreq: 1000
+          maxFreq: 3000
+        classC:
+          minFreq: 1100
+          maxFreq: 3100
+          energyPerformancePreference: 1


### PR DESCRIPTION
It tries to read the "nri-resource-policy.cfg" file from the configmap. But the configmap misses the "nri-resource-policy.cfg" key.

Otherwise, the pod can't start with the "no such file or directory" error.

The detailed error message is:
```
F0629 07:03:01.197013       1 log.go:486] failed to create resource manager: resource-manager: failed to load fallback configuration /etc/nri-resource-policy/nri-resource-policy.cfg: config error: failed to apply configuration from file: config error: failed to read file "/etc/nri-resource-policy/nri-resource-policy.cfg": open /etc/nri-resource-policy/nri-resource-policy.cfg: no such file or directory
```