### PR TITLE
helm: fix topology-aware helm chart naming

### DIFF
--- a/deployment/helm/resource-management-policies/topology-aware/Chart.yaml
+++ b/deployment/helm/resource-management-policies/topology-aware/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   Topology-aware NRI resource policy plugin is a NRI plugin that will
   apply hardware-aware resource allocation policies to the containers
   running in the system.
-name: nri-resource-policy
+name: nri-resource-policy-topology-aware
 sources:
  - https://github.com/containers/nri-plugins
 home: https://github.com/containers/nri-plugins


### PR DESCRIPTION
Having plugin specific/unique naming is important for the chart and we have currently incorrect naming for the TA plugin. This commit fixes the name of the TA Helm chart.