### PR TITLE
Patch containerd to enable NRI before running NRI plugin

### DIFF
--- a/deployment/helm/resource-management-policies/balloons/templates/configmap_enable_nri.yaml
+++ b/deployment/helm/resource-management-policies/balloons/templates/configmap_enable_nri.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.nri.enable }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: patch-containerd-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "balloons-plugin.labels" . | nindent 4 }}
+data:
+  patch_nri.sh: |
+   #!/bin/bash
+
+   config_file="/home/config.toml" 
+   cp /etc/containerd/config.toml "$config_file"
+
+   # Check if the disable field is set to false under [plugins."io.containerd.nri.v1.nri"]
+   status=$(awk -F ' = ' '/^\[plugins\."io\.containerd\.nri\.v1\.nri"\]/{flag=1} flag && /disable/{print $2; exit}' "$config_file")
+   if [ "$status" = "false" ]; then
+      echo "NRI is already enabled..."
+   elif [ "$status" = "true" ]; then
+      # Enable the NRI plugin in containerd
+      sed '/\[plugins.\"io.containerd.nri.v1.nri/,/^$/s/disable = true/disable = false/' -i "$config_file"
+      cp -f "$config_file" /etc/containerd/config.toml
+      echo "Restarting containerd...."
+      nsenter -t 1 -m systemctl restart containerd
+      echo "NRI has now been enabled..."
+   else
+      echo "NRI plugin entry doesn't exist in the continerd config file."
+      echo "Doing nothing..."
+   fi
+{{- end }}

--- a/deployment/helm/resource-management-policies/balloons/templates/daemonset.yaml
+++ b/deployment/helm/resource-management-policies/balloons/templates/daemonset.yaml
@@ -17,6 +17,20 @@ spec:
       serviceAccount: nri-resource-policy-balloons
       nodeSelector:
         kubernetes.io/os: "linux"
+      {{- if .Values.nri.enable }}
+      hostPID: true
+      initContainers:
+      - name: patch-containerd
+        image: ubuntu:22.04
+        command: ["/tmp/patch_nri.sh"]
+        volumeMounts:
+        - name: patch-containerd-config
+          mountPath: /tmp
+        - name: containerd-config
+          mountPath: /etc/containerd/config.toml
+        securityContext:
+          privileged: true
+      {{- end }}
       containers:
         - name: nri-resource-policy-balloons
           args:
@@ -78,3 +92,13 @@ spec:
         hostPath:
           path: /var/run/nri
           type: Directory
+      {{- if .Values.nri.enable }}
+      - name: patch-containerd-config
+        configMap:
+          name: patch-containerd-config
+          defaultMode: 0777
+      - name: containerd-config
+        hostPath:
+          path: /etc/containerd/config.toml
+          type: File
+      {{- end }}

--- a/deployment/helm/resource-management-policies/balloons/values.yaml
+++ b/deployment/helm/resource-management-policies/balloons/values.yaml
@@ -17,3 +17,6 @@ hostPort: 8891
 resources:
   cpu: 500m
   memory: 512Mi
+
+nri:
+  enable: false

--- a/deployment/helm/resource-management-policies/topology-aware/templates/configmap_emable_nri.yaml
+++ b/deployment/helm/resource-management-policies/topology-aware/templates/configmap_emable_nri.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.nri.enable }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: patch-containerd-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "topology-aware-plugin.labels" . | nindent 4 }}
+data:
+  patch_nri.sh: |
+   #!/bin/bash
+
+   config_file="/home/config.toml" 
+   cp /etc/containerd/config.toml "$config_file"
+
+   # Check if the disable field is set to false under [plugins."io.containerd.nri.v1.nri"]
+   status=$(awk -F ' = ' '/^\[plugins\."io\.containerd\.nri\.v1\.nri"\]/{flag=1} flag && /disable/{print $2; exit}' "$config_file")
+   if [ "$status" = "false" ]; then
+      echo "NRI is already enabled..."
+   elif [ "$status" = "true" ]; then
+      # Enable the NRI plugin in containerd
+      sed '/\[plugins.\"io.containerd.nri.v1.nri/,/^$/s/disable = true/disable = false/' -i "$config_file"
+      cp -f "$config_file" /etc/containerd/config.toml
+      echo "Restarting containerd...."
+      nsenter -t 1 -m systemctl restart containerd
+      echo "NRI has now been enabled..."
+   else
+      echo "NRI plugin entry doesn't exist in the continerd config file."
+      echo "Doing nothing..."
+   fi
+{{- end }}

--- a/deployment/helm/resource-management-policies/topology-aware/templates/daemonset.yaml
+++ b/deployment/helm/resource-management-policies/topology-aware/templates/daemonset.yaml
@@ -17,6 +17,20 @@ spec:
       serviceAccount: nri-resource-policy-topology-aware
       nodeSelector:
         kubernetes.io/os: "linux"
+      {{- if .Values.nri.enable }}
+      hostPID: true
+      initContainers:
+      - name: patch-containerd
+        image: ubuntu:22.04
+        command: ["/tmp/patch_nri.sh"]
+        volumeMounts:
+        - name: patch-containerd-config
+          mountPath: /tmp
+        - name: containerd-config
+          mountPath: /etc/containerd/config.toml
+        securityContext:
+          privileged: true
+      {{- end }}
       containers:
         - name: nri-resource-policy-topology-aware
           args:
@@ -78,3 +92,13 @@ spec:
         hostPath:
           path: /var/run/nri
           type: Directory
+      {{- if .Values.nri.enable }}
+      - name: patch-containerd-config
+        configMap:
+          name: patch-containerd-config
+          defaultMode: 0777
+      - name: containerd-config
+        hostPath:
+          path: /etc/containerd/config.toml
+          type: File
+      {{- end }}

--- a/deployment/helm/resource-management-policies/topology-aware/values.yaml
+++ b/deployment/helm/resource-management-policies/topology-aware/values.yaml
@@ -17,3 +17,6 @@ hostPort: 8891
 resources:
   cpu: 500m
   memory: 512Mi
+
+nri:
+  enable: false

--- a/docs/resource-policy/installation.md
+++ b/docs/resource-policy/installation.md
@@ -102,6 +102,7 @@ along with the default values, for the Topology-aware and Balloons plugins Helm 
 | `resources.memory` | 512Mi                                                                                                                         | memory qouta for the Pod                             | 
 | `hostPort`         | 8891                                                                                                                          | metrics port to expose on the host                   |
 | `config`           | <pre><code>ReservedResources:</code><br><code>  cpu: 750m</code></pre>                                                        | plugin configuration data                            |
+| `nri.enable`       | false                                                                                                                         | enable/disbale NRI in containerd                     |
 
 ## Manual installation
 


### PR DESCRIPTION
This commit adds an init container to enable NRI in containerd configuration file. Users installing plugin via Helm have an option to opt in for using that init container to enable the NRI before running plugin. By default, this option is disabled.
