### PR TITLE
Fix balloons helm installation and add doc

### DIFF
--- a/deployment/helm/resource-management-policies/balloons/templates/configmap.yaml
+++ b/deployment/helm/resource-management-policies/balloons/templates/configmap.yaml
@@ -1,10 +1,15 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nri-resource-policy-config.default
+  name: nri-resource-policy-config
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "balloons-plugin.labels" . | nindent 4 }}
 data:
-  policy: |+
-    {{- toYaml .Values.config | nindent 4 }}
+  nri-resource-policy.cfg: |+
+    policy:
+      {{- toYaml .Values.config | nindent 6 }}
+    instrumentation:
+      {{- toYaml .Values.instrumentation | nindent 6 }}
+    cpu:
+      {{- toYaml .Values.cpu | nindent 6 }}

--- a/deployment/helm/resource-management-policies/balloons/templates/daemonset.yaml
+++ b/deployment/helm/resource-management-policies/balloons/templates/daemonset.yaml
@@ -73,7 +73,7 @@ spec:
           path: /var/run/nri-resource-policy
       - name: resource-policyconfig
         configMap:
-          name: nri-resource-policy-config.default
+          name: nri-resource-policy-config
       - name: nrisockets
         hostPath:
           path: /var/run/nri

--- a/deployment/helm/resource-management-policies/balloons/values.yaml
+++ b/deployment/helm/resource-management-policies/balloons/values.yaml
@@ -6,11 +6,54 @@ image:
   name: ghcr.io/containers/nri-plugins/nri-resource-policy-balloons
   # tag, if defined will use the given image tag, otherwise Chart.AppVersion will be used
   tag: unstable
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 
 config:
+  Active: balloons
   ReservedResources:
     cpu: 750m
+  balloons:
+    PinCPU: true
+    PinMemory: true
+    BalloonTypes:
+      - Name: btype0
+        MinCPUs: 2
+        MaxCPUs: 2
+        AllocationPriority: 0
+        CPUClass: classA
+        PreferNewBalloons: true
+        PreferSpreadingPods: false
+        MinBalloons: 1
+      - Name: btype2
+        Namespaces:
+          - "*"
+          - btype2ns1
+        MinCPUs: 4
+        MaxCPUs: 8
+        MinBalloons: 1
+        AllocatorPriority: 2
+        CPUClass: classB
+        PreferNewBalloons: false
+        PreferSpreadingPods: false
+cpu:
+  classes:
+    default:
+      minFreq: 1800000
+      maxFreq: 2800000
+    classA:
+      minFreq: 1100000
+      maxFreq: 1100000
+    classB:
+      minFreq: 1000000
+      maxFreq: 3000000
+    classC:
+      minFreq: 1100000
+      maxFreq: 3100000
+      energyPerformancePreference: 1
+
+instrumentation:
+  HTTPEndpoint: :8891
+  PrometheusExport: true
 
 hostPort: 8891
 

--- a/docs/resource-policy/installation.md
+++ b/docs/resource-policy/installation.md
@@ -139,6 +139,14 @@ For the manual installation we will be using templating tool to generate Kuberne
 
 That's it! You have now installed the topology-aware NRI resource policy plugin using kutomize.
 
+Also, you can use the following **helm** command to install the NRI resource policy plugin in the **nri-plugins/deployment/helm/resource-management-policies/balloons** directory.
+
+```
+helm install balloons . --namespace kube-system
+```
+
+*Note: please specify the kube-system namespace.*
+
 ## Manual uninstallation
 
 To uninstall plugin manifests you can run the following command:
@@ -149,3 +157,5 @@ kustomize build deployment/overlays/topology-aware/ | kubectl delete -f -
 
 Note: this removes DaemonSet, ConfigMap, CustomResourceDefinition, and RBAC-related objects associated
 with the chart.
+
+Also, you can use the **helm uninstall balloons --namespace kube-system** to uninstall the NRI resource policy plugin.


### PR DESCRIPTION
1. Add more document about balloons helm installation guide.
2. Remove the ".default" suffix from the daemonset and configmap yaml files.