### PR TITLE
config-manager: bump go version to 1.20

### DIFF
--- a/cmd/config-manager/Dockerfile
+++ b/cmd/config-manager/Dockerfile
@@ -1,5 +1,5 @@
 # Build Stage
-ARG GO_VERSION=1.19
+ARG GO_VERSION=1.20
 
 FROM golang:${GO_VERSION}-bullseye as build
 WORKDIR /go/builder


### PR DESCRIPTION
Bump go version to 1.20 to follow the same versioning as in other components of the project.