### PR TITLE
Automate Helm charts releasing process via GitHub action

### DIFF
--- a/.github/workflows/package-helm.yaml
+++ b/.github/workflows/package-helm.yaml
@@ -1,0 +1,37 @@
+name: Package Helm charts
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+env:
+  CHARTS_DIR: deployment/helm/resource-management-policies/
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Package Helm charts
+        run: |
+          helm package "$CHARTS_DIR"/*
+          find . -name '*.tgz' -print | while read SRC_FILE; do
+            DEST_FILE=$(echo $SRC_FILE | sed 's/v/helm-chart-v/g')
+            mv $SRC_FILE $DEST_FILE
+          done
+
+      - name: Upload Helm packages to GitHub releases
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ github.ref_name }}
+          draft: true
+          append_body: true
+          files: nri-resource-policy-*helm-chart*.tgz

--- a/.github/workflows/publish-helm-charts.yaml
+++ b/.github/workflows/publish-helm-charts.yaml
@@ -1,0 +1,35 @@
+name: Publish Helm charts
+
+on:
+  release:
+    types:
+      - published
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+        contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: main
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Run chart publisher script
+        run: ./scripts/build/helm-publisher.sh ${{ join(github.event.release.assets.*.browser_download_url, ' ') }} 
+        shell: bash
+
+      - name: Push
+        run: |
+          git push https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash

--- a/deployment/helm/resource-management-policies/balloons/Chart.yaml
+++ b/deployment/helm/resource-management-policies/balloons/Chart.yaml
@@ -8,4 +8,4 @@ sources:
  - https://github.com/containers/nri-plugins
 home: https://github.com/containers/nri-plugins
 type: application
-version: 0.0.0
+version: v0.0.0

--- a/deployment/helm/resource-management-policies/topology-aware/Chart.yaml
+++ b/deployment/helm/resource-management-policies/topology-aware/Chart.yaml
@@ -9,4 +9,4 @@ sources:
  - https://github.com/containers/nri-plugins
 home: https://github.com/containers/nri-plugins
 type: application
-version: 0.0.0
+version: v0.0.0

--- a/scripts/build/helm-publisher.sh
+++ b/scripts/build/helm-publisher.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+
+index_file="index.yaml"
+browser_download_url="$@"
+
+git checkout gh-pages
+
+# Verify if the release assets include Helm chart packages. If they do,
+# we can proceed with updating the index.yaml file, otherwise throw an error.
+charts_urls=$(echo "$browser_download_url" | grep '.*helm-chart-.*.tgz')
+
+# Check if Helm release assets were found
+if [ -n "$charts_urls" ]; then
+    # Loop through the URLs
+    for chart in $charts_urls; do
+        # Check if the URL path exists in index.yaml
+        # and if not, update the index.yaml accordingly
+        if ! grep -q "$chart" "$index_file"; then
+            wget "$chart"
+            base_url=$(dirname "$chart")
+            if ! helm repo index . --url "$base_url" --merge "$index_file"; then
+                echo "Failed to update "$index_file" for: $base_url"
+            fi
+            rm nri-resource-policy-*.tgz
+        fi
+    done
+else
+    echo "No Helm packages were found on this release"
+    exit 1
+fi
+
+# Create a new commit
+release=$(basename "$base_url")
+commit_msg="Update Helm index for release $release"
+
+echo "Committing changes..."
+
+git config user.name "Github Actions"
+git config user.email "no-reply@github.com"
+git add index.yaml
+git commit -m "$commit_msg"
+
+echo "gh-pages branch successfully updated"


### PR DESCRIPTION
Add two GitHub actions to automate Helm charts releasing process. First action would be responsible for packaging the charts and pushing them to the releases and the second action is responsible for updating the index.yaml whenever there is a new release available.

In other words, one GitHub action to package helm charts and upload those charts including the source code to GitHub releases and create a draft release. This job gets triggered when a new tag is pushed.

Second GitHub action - to officially release the charts once official release is published. When repo maintainers, publish the draft release this action gets triggered in updates the index.yaml in `gh-pages` branch with the corresponding URLs of the chart packages.

The benefit of storing index.yaml in `gh-pages` is that it will be a single source of the trust for the chart package URLs even though there will be multiple branches on the project in the future. Second, if we happen to use artifacthub.io, then it is easy to configure it, because artifacthub.io reads the charts info from index.yaml located on the GitHub pages of the project.
Here is a short POC how two actions would look like in action.

https://github.com/containers/nri-plugins/assets/35802557/70d85fa0-9710-49fc-84f2-3d405fb9b4a3

