### PR TITLE
github/workflows: ditch softprops/turnstyle action

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -8,19 +8,14 @@ on:
     tags:
         - v*
 
+concurrency:
+  group: gh-pages
+
 jobs:
   update-gh-pages:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-
-    - name: Turnstyle
-      uses: softprops/turnstyle@v1
-      with:
-        abort-after-seconds: 600
-        same-branch-only: false
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Fetch gh-pages
       run: git fetch --no-tags --prune --depth=1 origin refs/heads/gh-pages:refs/heads/gh-pages

--- a/.github/workflows/publish-helm-charts.yaml
+++ b/.github/workflows/publish-helm-charts.yaml
@@ -6,7 +6,7 @@ on:
       - published
 
 concurrency:
-  group: ${{ github.workflow }}
+  group: gh-pages
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Use github's built-in concurrency, instead.