### PR TITLE
github: use the git checkout action to fetch all refs

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -15,10 +15,9 @@ jobs:
   update-gh-pages:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-
-    - name: Fetch gh-pages
-      run: git fetch --no-tags --prune --depth=1 origin refs/heads/gh-pages:refs/heads/gh-pages
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Install build dependencies
       run: |


### PR DESCRIPTION
Drop the separate step for fetching gh-pages branch.

Also update the checkout action to the latest version.