### PR TITLE
helm: add charts for memtierd and memory-qos

### DIFF
--- a/deployment/helm/memory-qos/Chart.yaml
+++ b/deployment/helm/memory-qos/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+appVersion: "main"
+description: |
+  The memory-qos NRI plugin adds two methods for controlling cgroups v2
+  memory.* parameters: QoS class and direct memory annotations.
+name: nri-memory-qos
+sources:
+ - https://github.com/containers/nri-plugins
+home: https://github.com/containers/nri-plugins
+type: application
+version: v0.0.0

--- a/deployment/helm/memory-qos/templates/_helpers.tpl
+++ b/deployment/helm/memory-qos/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/*
+Common labels
+*/}}
+{{- define "memory-qos.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ include "memory-qos.selectorLabels" . }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "memory-qos.selectorLabels" -}}
+app.kubernetes.io/name: nri-memory-qos
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/deployment/helm/memory-qos/templates/configmap.yaml
+++ b/deployment/helm/memory-qos/templates/configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nri-memory-qos-config.default
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "memory-qos.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    classes:
+    - name: bronze
+      swaplimitratio: 0.5
+    - name: silver
+      swaplimitratio: 0.2
+    unifiedannotations:
+    - memory.swap.max
+    - memory.high

--- a/deployment/helm/memory-qos/templates/daemonset.yaml
+++ b/deployment/helm/memory-qos/templates/daemonset.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    {{- include "memory-qos.labels" . | nindent 4 }}
+  name: nri-memory-qos
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+    {{- include "memory-qos.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+      {{- include "memory-qos.labels" . | nindent 8 }}
+    spec:
+      nodeSelector:
+        kubernetes.io/os: "linux"
+      containers:
+        - name: nri-memory-qos
+          command:
+            - nri-memory-qos
+            - --idx
+            - "40"
+            - --config
+            - /etc/nri/memory-qos/config.yaml
+            - -v
+          image: {{ .Values.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+            requests:
+              cpu: {{ .Values.resources.cpu }}
+              memory: {{ .Values.resources.memory }}
+          volumeMounts:
+          - name: memory-qos-config-vol
+            mountPath: /etc/nri/memory-qos
+          - name: nrisockets
+            mountPath: /var/run/nri
+      volumes:
+      - name: memory-qos-config-vol
+        configMap:
+          name: nri-memory-qos-config.default
+      - name: nrisockets
+        hostPath:
+          path: /var/run/nri
+          type: Directory

--- a/deployment/helm/memory-qos/values.scheme.json
+++ b/deployment/helm/memory-qos/values.scheme.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "required": [
+        "image",
+        "resources"
+    ],
+    "properties": {
+        "image": {
+            "type": "object",
+            "required": [
+                "name",
+                "tag",
+                "pullPolicy"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "enum": ["Never", "Always", "IfNotPresent"]
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "required": [
+                "cpu",
+                "memory"
+            ],
+            "properties": {
+                "cpu": {
+                    "type": "integer"
+                },
+                "memory": {
+                    "type": "integer"
+                }
+            }
+        }
+    }
+ }

--- a/deployment/helm/memory-qos/values.yaml
+++ b/deployment/helm/memory-qos/values.yaml
@@ -1,0 +1,13 @@
+# Default values for memory-qos.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+---
+image:
+  name: ghcr.io/containers/nri-plugins/nri-memory-qos
+  # tag, if defined will use the given image tag, otherwise Chart.AppVersion will be used
+  tag: unstable
+  pullPolicy: Always
+
+resources:
+  cpu: 10m
+  memory: 100Mi

--- a/deployment/helm/memtierd/Chart.yaml
+++ b/deployment/helm/memtierd/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+appVersion: "main"
+description: |
+  The memtierd NRI plugin enables managing workloads with Memtierd in Kubernetes.
+name: nri-memtierd
+sources:
+ - https://github.com/containers/nri-plugins
+home: https://github.com/containers/nri-plugins
+type: application
+version: v0.0.0

--- a/deployment/helm/memtierd/templates/_helpers.tpl
+++ b/deployment/helm/memtierd/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/*
+Common labels
+*/}}
+{{- define "memtierd.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ include "memtierd.selectorLabels" . }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "memtierd.selectorLabels" -}}
+app.kubernetes.io/name: nri-memtierd
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/deployment/helm/memtierd/templates/configmap.yaml
+++ b/deployment/helm/memtierd/templates/configmap.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nri-memtierd-config.default
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "memtierd.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    classes:
+    - name: swap-idle-data
+      allowswap: true
+      memtierdconfig: |
+        policy:
+          name: age
+          config: |
+            intervalms: 10000
+            pidwatcher:
+              name: cgroups
+              config: |
+                cgroups:
+                  - $CGROUP2_ABS_PATH
+            swapoutms: 10000
+            tracker:
+              name: idlepage
+              config: |
+                pagesinregion: 512
+                maxcountperregion: 1
+                scanintervalms: 10000
+            mover:
+              intervalms: 20
+              bandwidth: 50
+    - name: track-working-set-size
+      allowswap: false
+      memtierdconfig: |
+        policy:
+          name: age
+          config: |
+            intervalms: 20000
+            pidwatcher:
+              name: cgroups
+              config: |
+                cgroups:
+                  - $CGROUP2_ABS_PATH
+            tracker:
+              name: idlepage
+              config: |
+                pagesinregion: 512
+                maxcountperregion: 1
+                scanintervalms: 20000
+        routines:
+          - name: statactions
+            config: |
+              intervalms: 60000
+              intervalcommand: ["policy", "-dump", "accessed", "0,1m,30m,2h,24h,0"]
+              intervalcommandrunner: memtier

--- a/deployment/helm/memtierd/templates/daemonset.yaml
+++ b/deployment/helm/memtierd/templates/daemonset.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    {{- include "memtierd.labels" . | nindent 4 }}
+  name: nri-memtierd
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+    {{- include "memtierd.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+      {{- include "memtierd.labels" . | nindent 8 }}
+    spec:
+      nodeSelector:
+        kubernetes.io/os: "linux"
+      hostPID: true
+      containers:
+        - name: nri-memtierd
+          command:
+            - nri-memtierd
+            - --idx
+            - "45"
+            - --config
+            - /etc/nri/memtierd/config.yaml
+            {{- if .Values.outputDir }}
+            - --run-dir
+            - /run-dir
+            {{- end }}
+            - --cgroups-dir
+            - /sys/fs/cgroup
+            - -v
+          image: {{ .Values.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+            requests:
+              cpu: {{ .Values.resources.cpu }}
+              memory: {{ .Values.resources.memory }}
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - name: memtierd-config-vol
+            mountPath: /etc/nri/memtierd
+          - name: nrisockets
+            mountPath: /var/run/nri
+          - name: host-bitmap
+            mountPath: /sys/kernel/mm/page_idle/bitmap
+          - name: cgroups-vol
+            mountPath: /sys/fs/cgroup
+          {{- if .Values.outputDir }}
+          # Set outputDir parameter to access memtierd.output files from host
+          - name: run-dir-vol
+            mountPath: /run-dir
+          {{- end }}
+      volumes:
+      - name: memtierd-config-vol
+        configMap:
+          name: nri-memtierd-config.default
+      - name: nrisockets
+        hostPath:
+          path: /var/run/nri
+          type: Directory
+      - name: host-bitmap
+        hostPath:
+          path: /sys/kernel/mm/page_idle/bitmap
+      - name: cgroups-vol
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      {{- if .Values.outputDir }}
+      - name: run-dir-vol
+        hostPath:
+          path: {{ .Values.outputDir }}
+          type: DirectoryOrCreate
+      {{- end }}

--- a/deployment/helm/memtierd/values.scheme.json
+++ b/deployment/helm/memtierd/values.scheme.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "required": [
+        "image",
+        "resources"
+    ],
+    "properties": {
+        "image": {
+            "type": "object",
+            "required": [
+                "name",
+                "tag",
+                "pullPolicy"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "enum": ["Never", "Always", "IfNotPresent"]
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "required": [
+                "cpu",
+                "memory"
+            ],
+            "properties": {
+                "cpu": {
+                    "type": "integer"
+                },
+                "memory": {
+                    "type": "integer"
+                }
+            }
+        }
+    }
+ }

--- a/deployment/helm/memtierd/values.yaml
+++ b/deployment/helm/memtierd/values.yaml
@@ -1,0 +1,15 @@
+# Default values for memory-qos.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+---
+image:
+  name: ghcr.io/containers/nri-plugins/nri-memtierd
+  # tag, if defined will use the given image tag, otherwise Chart.AppVersion will be used
+  tag: unstable
+  pullPolicy: Always
+
+resources:
+  cpu: 250m
+  memory: 100Mi
+
+outputDir: ""

--- a/docs/resource-policy/installation.md
+++ b/docs/resource-policy/installation.md
@@ -103,6 +103,27 @@ along with the default values, for the Topology-aware and Balloons plugins Helm 
 | `hostPort`         | 8891                                                                                                                          | metrics port to expose on the host                   |
 | `config`           | <pre><code>ReservedResources:</code><br><code>  cpu: 750m</code></pre>                                                        | plugin configuration data                            |
 
+#### Memtierd
+
+| Name               | Default                                                                                                                       | Description                                          |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `image.name`       | [ghcr.io/containers/nri-plugins/nri-memtierd](ghcr.io/containers/nri-plugins/nri-memtierd)                                    | container image name                                 |
+| `image.tag`        | unstable                                                                                                                      | container image tag                                  |
+| `image.pullPolicy` | Always                                                                                                                        | image pull policy                                    |
+| `resources.cpu`    | 250m                                                                                                                          | cpu resources for the Pod                            |
+| `resources.memory` | 100Mi                                                                                                                         | memory qouta for the                                 |
+| `outputDir`        | empty string                                                                                                                  | host directory for memtierd.output files             |
+
+#### Memory-qos
+
+| Name               | Default                                                                                                                       | Description                                          |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `image.name`       | [ghcr.io/containers/nri-plugins/nri-memory-qos](ghcr.io/containers/nri-plugins/nri-memory-qos)                                | container image name                                 |
+| `image.tag`        | unstable                                                                                                                      | container image tag                                  |
+| `image.pullPolicy` | Always                                                                                                                        | image pull policy                                    |
+| `resources.cpu`    | 10m                                                                                                                           | cpu resources for the Pod                            |
+| `resources.memory` | 100Mi                                                                                                                         | memory qouta for the                                 |
+
 ## Manual installation
 
 For the manual installation we will be using templating tool to generate Kubernetes YAML manifests.


### PR DESCRIPTION
This commit adds two new Helm charts for installing memory-qos(https://github.com/containers/nri-plugins/pull/115) and memtierd(https://github.com/containers/nri-plugins/pull/117) NRI plugins via Helm.