### PR TITLE
deployment: refactor config manager to support NRI enabling in CRI-O 

### DIFF
--- a/deployment/helm/balloons/templates/daemonset.yaml
+++ b/deployment/helm/balloons/templates/daemonset.yaml
@@ -17,14 +17,17 @@ spec:
       serviceAccount: nri-resource-policy-balloons
       nodeSelector:
         kubernetes.io/os: "linux"
-      {{- if .Values.nri.patchContainerdConfig }}
+      {{- if .Values.nri.patchRuntimeConfig }}
       initContainers:
-      - name: patch-containerd
+      - name: patch-runtime
         image: {{ .Values.initContainerImage.name }}:{{ .Values.initContainerImage.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
+        restartPolicy: Never
         volumeMounts:
         - name: containerd-config
-          mountPath: /etc/containerd/config.toml
+          mountPath: /etc/containerd
+        - name: crio-config
+          mountPath: /etc/crio/crio.conf.d
         - name: dbus-socket
           mountPath: /var/run/dbus/system_bus_socket
         securityContext:
@@ -91,11 +94,15 @@ spec:
         hostPath:
           path: /var/run/nri
           type: DirectoryOrCreate
-      {{- if .Values.nri.patchContainerdConfig }}
+      {{- if .Values.nri.patchRuntimeConfig }}
       - name: containerd-config
         hostPath:
-          path: /etc/containerd/config.toml
-          type: File
+          path: /etc/containerd/
+          type: DirectoryOrCreate
+      - name: crio-config
+        hostPath:
+          path: /etc/crio/crio.conf.d/
+          type: DirectoryOrCreate
       - name: dbus-socket
         hostPath:
           path: /var/run/dbus/system_bus_socket

--- a/deployment/helm/balloons/values.yaml
+++ b/deployment/helm/balloons/values.yaml
@@ -20,7 +20,8 @@ resources:
   memory: 512Mi
 
 nri:
-  patchContainerdConfig: false
+  patchRuntimeConfig: false
+
 
 initContainerImage:
   name: ghcr.io/containers/nri-plugins/nri-config-manager

--- a/deployment/helm/topology-aware/templates/daemonset.yaml
+++ b/deployment/helm/topology-aware/templates/daemonset.yaml
@@ -17,14 +17,17 @@ spec:
       serviceAccount: nri-resource-policy-topology-aware
       nodeSelector:
         kubernetes.io/os: "linux"
-      {{- if .Values.nri.patchContainerdConfig }}
+      {{- if .Values.nri.patchRuntimeConfig }}
       initContainers:
-      - name: patch-containerd
+      - name: patch-runtime
         image: {{ .Values.initContainerImage.name }}:{{ .Values.initContainerImage.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
+        restartPolicy: Never
         volumeMounts:
         - name: containerd-config
-          mountPath: /etc/containerd/config.toml
+          mountPath: /etc/containerd
+        - name: crio-config
+          mountPath: /etc/crio/crio.conf.d
         - name: dbus-socket
           mountPath: /var/run/dbus/system_bus_socket
         securityContext:
@@ -91,11 +94,15 @@ spec:
         hostPath:
           path: /var/run/nri
           type: DirectoryOrCreate
-      {{- if .Values.nri.patchContainerdConfig }}
+      {{- if .Values.nri.patchRuntimeConfig }}
       - name: containerd-config
         hostPath:
-          path: /etc/containerd/config.toml
-          type: File
+          path: /etc/containerd/
+          type: DirectoryOrCreate
+      - name: crio-config
+        hostPath:
+          path: /etc/crio/crio.conf.d/
+          type: DirectoryOrCreate
       - name: dbus-socket
         hostPath:
           path: /var/run/dbus/system_bus_socket

--- a/deployment/helm/topology-aware/values.yaml
+++ b/deployment/helm/topology-aware/values.yaml
@@ -20,7 +20,7 @@ resources:
   memory: 512Mi
 
 nri:
-  patchContainerdConfig: false
+  patchRuntimeConfig: false
 
 initContainerImage:
   name: ghcr.io/containers/nri-plugins/nri-config-manager

--- a/docs/resource-policy/installation.md
+++ b/docs/resource-policy/installation.md
@@ -18,23 +18,32 @@ following components: DaemonSet, ConfigMap, CustomResourceDefinition, and RBAC-r
 - Container runtime:
     - containerD:
         - At least [containerd 1.7.0](https://github.com/containerd/containerd/releases/tag/v1.7.0)
-            release version to use the NRI feature
+            release version to use the NRI feature.
+
         - Enable NRI feature by following [these](https://github.com/containerd/containerd/blob/main/docs/NRI.md#enabling-nri-support-in-containerd)
           detailed instructions. You can optionally enable the NRI in containerd using the Helm chart
-          during the chart installation simply by setting the `nri.patchContainerdConfig` parameter.
+          during the chart installation simply by setting the `nri.patchRuntimeConfig` parameter.
           For instance,
 
           ```sh
-          helm install topology-aware --namespace kube-system --set nri.patchContainerdConfig=true deployment/helm/topology-aware/
+          helm install topology-aware --namespace kube-system --set nri.patchRuntimeConfig=true deployment/helm/topology-aware/
           ```
 
-          Enabling `nri.patchContainerdConfig` creates an init container to turn on
+          Enabling `nri.patchRuntimeConfig` creates an init container to turn on
           NRI feature in containerd and only after that proceed the plugin installation.
 
     - CRI-O
         - At least [v1.26.0](https://github.com/cri-o/cri-o/releases/tag/v1.26.0) release version to
             use the NRI feature
         - Enable NRI feature by following [these](https://github.com/cri-o/cri-o/blob/main/docs/crio.conf.5.md#crionri-table) detailed instructions.
+          You can optionally enable the NRI in CRI-O using the Helm chart
+          during the chart installation simply by setting the `nri.patchRuntimeConfig` parameter.
+          For instance,
+
+          ```sh
+          helm install topology-aware --namespace kube-system --set nri.patchRuntimeConfig=true deployment/helm/topology-aware/
+          ```
+
 - Kubernetes 1.24+
 - Helm 3.0.0+
 
@@ -94,14 +103,14 @@ along with the default values, for the Topology-aware and Balloons plugins Helm 
 
 | Name               | Default                                                                                                                       | Description                                          |
 | ------------------ | ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| `image.name`       | [ghcr.io/containers/nri-plugins/nri-resource-policy-topology-aware](ghcr.io/containers/nri-plugins/nri-resource-policy-topology-aware)    | container image name                                 |
+| `image.name`       | [ghcr.io/containers/nri-plugins/nri-resource-policy-topology-aware](ghcr.io/containers/nri-plugins/nri-resource-policy-topology-aware)    | container image name                     |
 | `image.tag`        | unstable                                                                                                                      | container image tag                                  |
 | `image.pullPolicy` | Always                                                                                                                        | image pull policy                                    |
 | `resources.cpu`    | 500m                                                                                                                          | cpu resources for the Pod                            |
 | `resources.memory` | 512Mi                                                                                                                         | memory qouta for the Pod                             | 
 | `hostPort`         | 8891                                                                                                                          | metrics port to expose on the host                   |
 | `config`           | <pre><code>ReservedResources:</code><br><code>  cpu: 750m</code></pre>                                                        | plugin configuration data                            |
-| `nri.patchContainerdConfig`       | false                                                                                                          | enable/disable NRI in containerd.                    |
+| `nri.patchRuntimeConfig` | false                                                                                                                   | enable NRI in containerd or CRI-O                    |
 | `initImage.name`   | [ghcr.io/containers/nri-plugins/config-manager](ghcr.io/containers/nri-plugins/config-manager)                                | init container image name                            |
 | `initImage.tag`    | unstable                                                                                                                      | init container image tag                             |
 | `initImage.pullPolicy` | Always                                                                                                                    | init container image pull policy                     |
@@ -117,7 +126,7 @@ along with the default values, for the Topology-aware and Balloons plugins Helm 
 | `resources.memory` | 512Mi                                                                                                                         | memory qouta for the Pod                             | 
 | `hostPort`         | 8891                                                                                                                          | metrics port to expose on the host                   |
 | `config`           | <pre><code>ReservedResources:</code><br><code>  cpu: 750m</code></pre>                                                        | plugin configuration data                            |
-| `nri.patchContainerdConfig`       | false                                                                                                          | enable/disable NRI in containerd.                    |
+| `nri.patchRuntimeConfig` | false                                                                                                                   | enable NRI in containerd or CRI-O                    |
 | `initImage.name`   | [ghcr.io/containers/nri-plugins/config-manager](ghcr.io/containers/nri-plugins/config-manager)                                | init container image name                            |
 | `initImage.tag`    | unstable                                                                                                                      | init container image tag                             |
 | `initImage.pullPolicy` | Always                                                                                                                    | init container image pull policy                     |


### PR DESCRIPTION
This PR extends config manager code and the plugins helm charts
so that CRI-O users are also able to enable NRI via our charts if they
wish to. Same parameter is used to opt in for the feature in Helm
charts and we don't require users to indicate what container runtime
is being used. Instead the config manager auto-detects the runtime
and does the necessary changes to its configuration file. In scenarios
with multiple active runtimes (e.g., CRI-O and containerd), the
manager gracefully exits and throws an error.