### PR TITLE
nri-memtierd: mount only needed dirs from host

### DIFF
--- a/cmd/plugins/memtierd/nri-memtierd-deployment.yaml.in
+++ b/cmd/plugins/memtierd/nri-memtierd-deployment.yaml.in
@@ -25,8 +25,10 @@ spec:
             - "45"
             - --config
             - /etc/nri/memtierd/config.yaml
-            - --host-root
-            - /host
+            - --run-dir
+            - /run-dir
+            - --cgroups-dir
+            - /sys/fs/cgroup
             - -v
           image: IMAGE_PLACEHOLDER
           imagePullPolicy: IfNotPresent
@@ -41,9 +43,11 @@ spec:
             mountPath: /etc/nri/memtierd
           - name: nri-sockets-vol
             mountPath: /var/run/nri
-          - name: host-vol
-            mountPath: /host
-          - name: host-bitmap
+          - name: run-dir-vol
+            mountPath: /run-dir
+          - name: cgroups-vol
+            mountPath: /sys/fs/cgroup
+          - name: idlepage-vol
             mountPath: /sys/kernel/mm/page_idle/bitmap
       volumes:
       - name: memtierd-config-vol
@@ -53,13 +57,18 @@ spec:
         hostPath:
           path: /var/run/nri
           type: Directory
-      - name: host-vol
+      - name: run-dir-vol
         hostPath:
-          path: /
+          path: /var/run/nri-memtierd
+          type: DirectoryOrCreate
+      - name: cgroups-vol
+        hostPath:
+          path: /sys/fs/cgroup
           type: Directory
-      - name: host-bitmap
+      - name: idlepage-vol
         hostPath:
           path: /sys/kernel/mm/page_idle/bitmap
+          type: File
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/deployment/overlays/memtierd/daemonset.yaml
+++ b/deployment/overlays/memtierd/daemonset.yaml
@@ -25,8 +25,10 @@ spec:
             - "45"
             - --config
             - /etc/nri/memtierd/config.yaml
-            - --host-root
-            - /host
+            - --run-dir
+            - /run-dir
+            - --cgroups-dir
+            - /sys/fs/cgroup
             - -v
           image: IMAGE_PLACEHOLDER
           imagePullPolicy: IfNotPresent
@@ -41,9 +43,12 @@ spec:
             mountPath: /etc/nri/memtierd
           - name: nri-sockets-vol
             mountPath: /var/run/nri
-          - name: host-vol
-            mountPath: /host
-          - name: host-bitmap
+          # # Uncomment to access memtierd.output files from host
+          # - name: run-dir-vol
+          #   mountPath: /run-dir
+          - name: cgroups-vol
+            mountPath: /sys/fs/cgroup
+          - name: idlepage-vol
             mountPath: /sys/kernel/mm/page_idle/bitmap
       volumes:
       - name: memtierd-config-vol
@@ -53,10 +58,15 @@ spec:
         hostPath:
           path: /var/run/nri
           type: Directory
-      - name: host-vol
+      # # Uncomment to access memtierd.output files from host
+      # - name: run-dir-vol
+      #   hostPath:
+      #     path: /var/run/nri-memtierd
+      #     type: DirectoryOrCreate
+      - name: cgroups-vol
         hostPath:
-          path: /
+          path: /sys/fs/cgroup
           type: Directory
-      - name: host-bitmap
+      - name: idlepage-vol
         hostPath:
           path: /sys/kernel/mm/page_idle/bitmap

--- a/deployment/overlays/memtierd/sample-configmap.yaml
+++ b/deployment/overlays/memtierd/sample-configmap.yaml
@@ -28,3 +28,27 @@ data:
             mover:
               intervalms: 20
               bandwidth: 50
+    - name: track-working-set-size
+      allowswap: false
+      memtierdconfig: |
+        policy:
+          name: age
+          config: |
+            intervalms: 20000
+            pidwatcher:
+              name: cgroups
+              config: |
+                cgroups:
+                  - $CGROUP2_ABS_PATH
+            tracker:
+              name: idlepage
+              config: |
+                pagesinregion: 512
+                maxcountperregion: 1
+                scanintervalms: 20000
+        routines:
+          - name: statactions
+            config: |
+              intervalms: 60000
+              intervalcommand: ["policy", "-dump", "accessed", "0,1m,30m,2h,24h,0"]
+              intervalcommandrunner: memtier

--- a/test/e2e/files/nri-memtierd-deployment.yaml.in
+++ b/test/e2e/files/nri-memtierd-deployment.yaml.in
@@ -25,8 +25,10 @@ spec:
             - "45"
             - --config
             - /etc/nri/memtierd/config.yaml
-            - --host-root
-            - /host
+            - --run-dir
+            - /run-dir
+            - --cgroups-dir
+            - /sys/fs/cgroup
             - -vv
           image: IMAGE_PLACEHOLDER
           imagePullPolicy: IfNotPresent
@@ -41,9 +43,11 @@ spec:
             mountPath: /etc/nri/memtierd
           - name: nri-sockets-vol
             mountPath: /var/run/nri
-          - name: host-vol
-            mountPath: /host
-          - name: host-bitmap
+          - name: run-dir-vol
+            mountPath: /run-dir
+          - name: cgroups-vol
+            mountPath: /sys/fs/cgroup
+          - name: idlepage-vol
             mountPath: /sys/kernel/mm/page_idle/bitmap
       volumes:
       - name: memtierd-config-vol
@@ -53,11 +57,15 @@ spec:
         hostPath:
           path: /var/run/nri
           type: Directory
-      - name: host-vol
+      - name: run-dir-vol
         hostPath:
-          path: /
+          path: /var/run/nri-memtierd
+          type: DirectoryOrCreate
+      - name: cgroups-vol
+        hostPath:
+          path: /sys/fs/cgroup
           type: Directory
-      - name: host-bitmap
+      - name: idlepage-vol
         hostPath:
           path: /sys/kernel/mm/page_idle/bitmap
 ---


### PR DESCRIPTION
Hardening nri-memtierd deployment.