### PR TITLE
deployment: fix the nri volume type to DirectoryOrCreate

### DIFF
--- a/deployment/helm/resource-management-policies/balloons/templates/daemonset.yaml
+++ b/deployment/helm/resource-management-policies/balloons/templates/daemonset.yaml
@@ -90,7 +90,7 @@ spec:
       - name: nrisockets
         hostPath:
           path: /var/run/nri
-          type: Directory
+          type: DirectoryOrCreate
       {{- if .Values.nri.patchContainerdConfig }}
       - name: containerd-config
         hostPath:

--- a/deployment/helm/resource-management-policies/topology-aware/templates/daemonset.yaml
+++ b/deployment/helm/resource-management-policies/topology-aware/templates/daemonset.yaml
@@ -90,7 +90,7 @@ spec:
       - name: nrisockets
         hostPath:
           path: /var/run/nri
-          type: Directory
+          type: DirectoryOrCreate
       {{- if .Values.nri.patchContainerdConfig }}
       - name: containerd-config
         hostPath:


### PR DESCRIPTION
If the NRI feature is not enable yet in the runtime, runnig Helm charts with `nri.patchContainerdConfig `parameter set to true will fail because the directory is not created yet. Setting the hostPath volume type to DirectoryOrCreate ensures that we get the directory created in case it's missing.