### PR TITLE
helm: fix config-manager image name reference in charts defaults

### DIFF
--- a/deployment/helm/resource-management-policies/balloons/values.yaml
+++ b/deployment/helm/resource-management-policies/balloons/values.yaml
@@ -23,6 +23,6 @@ nri:
   patchContainerdConfig: false
 
 initContainerImage:
-  name: ghcr.io/containers/nri-plugins/nri-resource-policy-config-manager
+  name: ghcr.io/containers/nri-plugins/nri-config-manager
   tag: unstable
   pullPolicy: Always

--- a/deployment/helm/resource-management-policies/topology-aware/values.yaml
+++ b/deployment/helm/resource-management-policies/topology-aware/values.yaml
@@ -23,6 +23,6 @@ nri:
   patchContainerdConfig: false
 
 initContainerImage:
-  name: ghcr.io/containers/nri-plugins/nri-resource-policy-config-manager
+  name: ghcr.io/containers/nri-plugins/nri-config-manager
   tag: unstable
   pullPolicy: Always


### PR DESCRIPTION
Fix incorrect naming of the config-manager container image in the Helm charts values.yaml.
