### PR TITLE
helm: don't set image.tag in values.yaml

### DIFF
--- a/deployment/helm/memory-qos/Chart.yaml
+++ b/deployment/helm/memory-qos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "main"
+appVersion: unstable
 description: |
   The memory-qos NRI plugin adds two methods for controlling cgroups v2
   memory.* parameters: QoS class and direct memory annotations.

--- a/deployment/helm/memory-qos/values.yaml
+++ b/deployment/helm/memory-qos/values.yaml
@@ -5,7 +5,7 @@
 image:
   name: ghcr.io/containers/nri-plugins/nri-memory-qos
   # tag, if defined will use the given image tag, otherwise Chart.AppVersion will be used
-  tag: unstable
+  #tag: unstable
   pullPolicy: Always
 
 resources:

--- a/deployment/helm/memtierd/Chart.yaml
+++ b/deployment/helm/memtierd/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "main"
+appVersion: unstable
 description: |
   The memtierd NRI plugin enables managing workloads with Memtierd in Kubernetes.
 name: nri-memtierd

--- a/deployment/helm/memtierd/values.yaml
+++ b/deployment/helm/memtierd/values.yaml
@@ -5,7 +5,7 @@
 image:
   name: ghcr.io/containers/nri-plugins/nri-memtierd
   # tag, if defined will use the given image tag, otherwise Chart.AppVersion will be used
-  tag: unstable
+  #tag: unstable
   pullPolicy: Always
 
 resources:

--- a/deployment/helm/resource-management-policies/balloons/Chart.yaml
+++ b/deployment/helm/resource-management-policies/balloons/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: main
+appVersion: unstable
 description: |
   The balloons NRI resource policy plugin implements workload placement into
   “balloons” that are disjoint CPU pools.

--- a/deployment/helm/resource-management-policies/balloons/values.yaml
+++ b/deployment/helm/resource-management-policies/balloons/values.yaml
@@ -5,7 +5,7 @@
 image:
   name: ghcr.io/containers/nri-plugins/nri-resource-policy-balloons
   # tag, if defined will use the given image tag, otherwise Chart.AppVersion will be used
-  tag: unstable
+  #tag: unstable
   pullPolicy: Always
 
 config:

--- a/deployment/helm/resource-management-policies/topology-aware/Chart.yaml
+++ b/deployment/helm/resource-management-policies/topology-aware/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: main
+appVersion: unstable
 description: |
   Topology-aware NRI resource policy plugin is a NRI plugin that will
   apply hardware-aware resource allocation policies to the containers

--- a/deployment/helm/resource-management-policies/topology-aware/values.yaml
+++ b/deployment/helm/resource-management-policies/topology-aware/values.yaml
@@ -5,7 +5,7 @@
 image:
   name: ghcr.io/containers/nri-plugins/nri-resource-policy-topology-aware
   # tag, if defined will use the given image tag, otherwise Chart.AppVersion will be used
-  tag: unstable
+  #tag: unstable
   pullPolicy: Always
 
 config:


### PR DESCRIPTION
This way the default is to fallback to appVersion from the Chart.yaml.