### PR TITLE
helm: support NRI enabling prior to running memtierd & memory-qos plugins

### DIFF
--- a/deployment/helm/memory-qos/templates/daemonset.yaml
+++ b/deployment/helm/memory-qos/templates/daemonset.yaml
@@ -16,6 +16,22 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: "linux"
+      {{- if .Values.nri.patchRuntimeConfig }}
+      initContainers:
+      - name: patch-runtime
+        image: {{ .Values.initContainerImage.name }}:{{ .Values.initContainerImage.tag | default .Chart.AppVersion }}
+        imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
+        restartPolicy: Never
+        volumeMounts:
+        - name: containerd-config
+          mountPath: /etc/containerd
+        - name: crio-config
+          mountPath: /etc/crio/crio.conf.d
+        - name: dbus-socket
+          mountPath: /var/run/dbus/system_bus_socket
+        securityContext:
+          privileged: true
+      {{- end }}
       containers:
         - name: nri-memory-qos
           command:
@@ -44,3 +60,17 @@ spec:
         hostPath:
           path: /var/run/nri
           type: Directory
+      {{- if .Values.nri.patchRuntimeConfig }}
+      - name: containerd-config
+        hostPath:
+          path: /etc/containerd/
+          type: DirectoryOrCreate
+      - name: crio-config
+        hostPath:
+          path: /etc/crio/crio.conf.d/
+          type: DirectoryOrCreate
+      - name: dbus-socket
+        hostPath:
+          path: /var/run/dbus/system_bus_socket
+          type: Socket
+      {{- end }}

--- a/deployment/helm/memory-qos/values.yaml
+++ b/deployment/helm/memory-qos/values.yaml
@@ -11,3 +11,11 @@ image:
 resources:
   cpu: 10m
   memory: 100Mi
+
+nri:
+  patchRuntimeConfig: false
+
+initContainerImage:
+  name: ghcr.io/containers/nri-plugins/nri-config-manager
+  tag: unstable
+  pullPolicy: Always

--- a/deployment/helm/memtierd/templates/daemonset.yaml
+++ b/deployment/helm/memtierd/templates/daemonset.yaml
@@ -17,6 +17,22 @@ spec:
       nodeSelector:
         kubernetes.io/os: "linux"
       hostPID: true
+      {{- if .Values.nri.patchRuntimeConfig }}
+      initContainers:
+      - name: patch-runtime
+        image: {{ .Values.initContainerImage.name }}:{{ .Values.initContainerImage.tag | default .Chart.AppVersion }}
+        imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
+        restartPolicy: Never
+        volumeMounts:
+        - name: containerd-config
+          mountPath: /etc/containerd
+        - name: crio-config
+          mountPath: /etc/crio/crio.conf.d
+        - name: dbus-socket
+          mountPath: /var/run/dbus/system_bus_socket
+        securityContext:
+          privileged: true
+      {{- end }}
       containers:
         - name: nri-memtierd
           command:
@@ -74,4 +90,18 @@ spec:
         hostPath:
           path: {{ .Values.outputDir }}
           type: DirectoryOrCreate
+      {{- end }}
+      {{- if .Values.nri.patchRuntimeConfig }}
+      - name: containerd-config
+        hostPath:
+          path: /etc/containerd/
+          type: DirectoryOrCreate
+      - name: crio-config
+        hostPath:
+          path: /etc/crio/crio.conf.d/
+          type: DirectoryOrCreate
+      - name: dbus-socket
+        hostPath:
+          path: /var/run/dbus/system_bus_socket
+          type: Socket
       {{- end }}

--- a/deployment/helm/memtierd/values.yaml
+++ b/deployment/helm/memtierd/values.yaml
@@ -13,3 +13,11 @@ resources:
   memory: 100Mi
 
 outputDir: ""
+
+nri:
+  patchRuntimeConfig: false
+
+initContainerImage:
+  name: ghcr.io/containers/nri-plugins/nri-config-manager
+  tag: unstable
+  pullPolicy: Always

--- a/docs/resource-policy/installation.md
+++ b/docs/resource-policy/installation.md
@@ -141,6 +141,11 @@ along with the default values, for the Topology-aware and Balloons plugins Helm 
 | `resources.cpu`    | 250m                                                                                                                          | cpu resources for the Pod                            |
 | `resources.memory` | 100Mi                                                                                                                         | memory qouta for the                                 |
 | `outputDir`        | empty string                                                                                                                  | host directory for memtierd.output files             |
+| `nri.patchRuntimeConfig` | false                                                                                                                   | enable NRI in containerd or CRI-O                    |
+| `initImage.name`   | [ghcr.io/containers/nri-plugins/config-manager](ghcr.io/containers/nri-plugins/config-manager)                                | init container image name                            |
+| `initImage.tag`    | unstable                                                                                                                      | init container image tag                             |
+| `initImage.pullPolicy` | Always                                                                                                                    | init container image pull policy                     |
+
 
 #### Memory-qos
 
@@ -151,6 +156,11 @@ along with the default values, for the Topology-aware and Balloons plugins Helm 
 | `image.pullPolicy` | Always                                                                                                                        | image pull policy                                    |
 | `resources.cpu`    | 10m                                                                                                                           | cpu resources for the Pod                            |
 | `resources.memory` | 100Mi                                                                                                                         | memory qouta for the                                 |
+| `nri.patchRuntimeConfig` | false                                                                                                                   | enable NRI in containerd or CRI-O                    |
+| `initImage.name`   | [ghcr.io/containers/nri-plugins/config-manager](ghcr.io/containers/nri-plugins/config-manager)                                | init container image name                            |
+| `initImage.tag`    | unstable                                                                                                                      | init container image tag                             |
+| `initImage.pullPolicy` | Always                                                                                                                    | init container image pull policy                     |
+
 
 ## Manual installation
 


### PR DESCRIPTION
Add init container logic as optional to memtierd and memory-qos plugins Helm charts similarly as in TA and Balloons.
 