### PR TITLE
github: fix publish-helm-charts workflow

### DIFF
--- a/.github/workflows/publish-helm-charts.yaml
+++ b/.github/workflows/publish-helm-charts.yaml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: main
+          fetch-depth: 0
 
       - name: Install Helm
         uses: azure/setup-helm@v3


### PR DESCRIPTION
Set fetch depth to 0 to fetch all refs (including gh-pages that we need).