### PR TITLE
fixes: install containerd from release tarball for e2e tests.

### DIFF
--- a/test/e2e/files/Vagrantfile.in
+++ b/test/e2e/files/Vagrantfile.in
@@ -15,12 +15,16 @@ HOSTNAME = "SERVER_NAME"
 N = 1
 
 CRI_RUNTIME = "#{ENV['k8scri']}"
+CRIO_RELEASE = "1.28.1"
 CRIO_SRC = ""
+CONTAINERD_RELEASE = ""
 CONTAINERD_SRC = ""
 
 if CRI_RUNTIME == "containerd"
+  CONTAINERD_RELEASE = "#{ENV['containerd_release']}"
   CONTAINERD_SRC = "#{ENV['containerd_src']}"
 else
+  CRIO_RELEASE = "#{ENV['crio_release']}"
   CRIO_SRC = "#{ENV['crio_src']}"
 end
 
@@ -82,7 +86,9 @@ Vagrant.configure("2") do |config|
       http_proxy: "#{ENV['HTTP_PROXY']}",
       no_proxy: "#{ENV['NO_PROXY']}",
       cri_runtime: CRI_RUNTIME,
+      containerd_release: CONTAINERD_RELEASE,
       containerd_src: CONTAINERD_SRC,
+      crio_release: CRIO_RELEASE,
       crio_src: CRIO_SRC,
       nri_resource_policy_src: NRI_RESOURCE_POLICY_SRC,
       outdir: OUTPUT_DIR,

--- a/test/e2e/files/containerd.service
+++ b/test/e2e/files/containerd.service
@@ -19,7 +19,7 @@ After=network.target local-fs.target
 
 [Service]
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/bin/containerd
+ExecStart=/usr/local/bin/containerd
 
 Type=notify
 Delegate=yes

--- a/test/e2e/files/crio.service
+++ b/test/e2e/files/crio.service
@@ -4,7 +4,7 @@ Documentation=https://cri-o.io
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/crio
+ExecStart=/usr/local/bin/crio
 
 Delegate=yes
 KillMode=process

--- a/test/e2e/playbook/provision.yaml
+++ b/test/e2e/playbook/provision.yaml
@@ -6,6 +6,10 @@
     - cri_runtime: "{{ cri_runtime }}"
     - is_containerd: false
     - is_crio: false
+    - containerd_release: "{{ containerd_release }}"
+    - is_containerd_src: false
+    - crio_release: "{{ crio_release }}"
+    - is_crio_src: false
 
   tasks:
     - set_fact:
@@ -119,27 +123,47 @@
           - tomli_w
         state: present
 
-    # We need quite recent containerd that has NRI support so use the one
-    # that is compiled from sources.
-    - name: copy containerd sources
-      copy: src="{{ item }}" dest="/usr/bin" mode=0755
+    # Install containerd from a release tarball to /usr/local.
+    - name: Install containerd binaries from release tarball
+      ansible.builtin.unarchive:
+        src: "https://github.com/containerd/containerd/releases/download/v{{ containerd_release }}/containerd-{{ containerd_release }}-linux-amd64.tar.gz"
+        dest: /usr/local
+        remote_src: yes
+      when: is_containerd and containerd_src == ""
+
+    # Install containerd binaries from compiled sources.
+    - name: Install containerd binaries from compiled sources
+      copy: src="{{ item }}" dest="/usr/local/bin" mode=0755
       with_items:
         - "{{ containerd_src }}/bin/ctr"
         - "{{ containerd_src }}/bin/containerd"
         - "{{ containerd_src }}/bin/containerd-shim"
         - "{{ containerd_src }}/bin/containerd-shim-runc-v1"
         - "{{ containerd_src }}/bin/containerd-shim-runc-v2"
-      when: is_containerd
+      when: is_containerd and containerd_src != ""
 
-    # We need quite recent cri-o that has NRI support so use the one
-    # that is compiled from sources.
-    - name: copy cri-o sources
-      copy: src="{{ item }}" dest="/usr/bin" mode=0755
+    # Install CRI-O from a release tarball to /usr/local.
+    - block:
+      - name: Fetch and extract CRI-O release tarball
+        ansible.builtin.unarchive:
+          src: "https://storage.googleapis.com/cri-o/artifacts/cri-o.amd64.v{{ crio_release }}.tar.gz"
+          dest: /usr/local
+          remote_src: yes
+
+      - name: Install CRI-O binaries from release tarball
+        ansible.builtin.shell:
+          cmd: ./install
+          chdir: /usr/local/cri-o
+      when: is_crio and crio_src == ""
+
+    # Install CRI-O binaries from compiled sources.
+    - name: Install CRI-O binaries from compiled sources
+      copy: src="{{ item }}" dest="/usr/local/bin" mode=0755
       with_items:
         - "{{ crio_src }}/bin/crio"
         - "{{ crio_src }}/bin/crio-status"
         - "{{ crio_src }}/bin/pinns"
-      when: is_crio
+      when: is_crio and crio_src != ""
 
     - name: setup runtime systemd file
       copy:

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -47,11 +47,20 @@ else
     k8scri_sock="/var/run/crio/crio.sock"
 fi
 
-# Assume containerd sources are found in parent dir of this repo.
-# If that is not the case, set containerd_src when calling the e2e script.
-# Same for cri-o if using that.
-export containerd_src=${containerd_src:-"$SRC_DIR"/../containerd}
-export crio_src=${crio_src:-"$SRC_DIR"/../cri-o}
+# If we run tests with containerd as the runtime, we install it
+# from a release tarball with the version given below... unless
+# a source directory is given, which is then expected to contain
+# a compiled version of containerd which we should install.
+export containerd_release=1.7.6
+export containerd_src=${containerd_src:-}
+
+
+# If we run tests with CRI-O as the runtime, we install it from
+# a release tarball with the version given below... unless a
+# source directory is given, which is then expected to contain
+# a compiled version of CRI-O which we should install.
+export crio_release=1.28.1
+export crio_src=${crio_src:-}
 
 # Default topology if not given. The run_tests.sh script will figure out
 # the topology from the test directory structure and contents.
@@ -102,9 +111,13 @@ echo "    Output dir      = $OUTPUT_DIR"
 echo "    Test output dir = $TEST_OUTPUT_DIR"
 echo "    NRI dir         = $nri_resource_policy_src"
 if [ "$k8scri" == "containerd" ]; then
-    echo "    Containerd dir  = $containerd_src"
+    echo "    Containerd"
+    echo "      release       = $containerd_release"
+    echo "      sources       = $containerd_src"
 else
-    echo "    CRI-O dir       = $crio_src"
+    echo "    CRI-O"
+    echo "      release       = $crio_release"
+    echo "      sources       = $crio_src"
 fi
 echo "    Policy          = $POLICY"
 echo "    Topology        = $topology"

--- a/test/self-hosted-runner/docker/runner-in-container.sh
+++ b/test/self-hosted-runner/docker/runner-in-container.sh
@@ -52,7 +52,7 @@ sudo -n -u runner vagrant box add --name generic/fedora37 /mnt/vagrant/generic-f
 
 cd /mnt/actions-runner
 
-sudo --preserve-env=http_proxy,https_proxy,no_proxy,HTTP_PROXY,HTTPS_PROXY,NO_PROXY,containerd_src,dns_nameserver,dns_search_domain \
+sudo --preserve-env=http_proxy,https_proxy,no_proxy,HTTP_PROXY,HTTPS_PROXY,NO_PROXY,containerd_version,dns_nameserver,dns_search_domain \
      -n -u runner ./run.sh &
 
 wait

--- a/test/self-hosted-runner/env.in
+++ b/test/self-hosted-runner/env.in
@@ -22,7 +22,3 @@ no_proxy="$NO_PROXY"
 # Optional DNS settings
 DNS_SEARCH_DOMAIN=""
 DNS_NAMESERVER=""
-
-# Assume containerd sources are found in <this-repo-root-dir>/../containerd
-# The value here is relative path from test/self-hosted-runner/ directory.
-CONTAINERD_SRC=../../../containerd/

--- a/test/self-hosted-runner/runner.sh
+++ b/test/self-hosted-runner/runner.sh
@@ -61,12 +61,6 @@ fi
 
 echo "Work directory set to $PREFIX"
 
-if [ ! -f "$CONTAINERD_SRC/bin/ctr" ]; then
-    echo "########"
-    echo "WARNING: containerd sources / binaries not found in $CONTAINERD_SRC"
-    echo "########"
-fi
-
 get_runner_token() {
     local payload sig access_token app_private_key
 
@@ -164,7 +158,6 @@ start_docker_container() {
 	   -v "${PREFIX}/mnt/actions-runner:/mnt/actions-runner" \
 	   -v "${PREFIX}/mnt/vagrant:/mnt/vagrant:ro" \
 	   -v "${PREFIX}/mnt/env:/mnt/env:ro" \
-	   -v "${CONTAINERD_SRC}:/mnt/containerd:ro" \
 	   -v "/var/run/docker.sock:/var/run/docker.sock" \
 	   --device=/dev/kvm \
 	   --env-file "${PREFIX}/mnt/env" \
@@ -189,7 +182,6 @@ while [ $STOPPED -eq 0 ]; do
     # is exported to the container.
     echo dns_nameserver="$DNS_NAMESERVER" > ${PREFIX}/mnt/env
     echo dns_search_domain="$DNS_SEARCH_DOMAIN" >> ${PREFIX}/mnt/env
-    echo containerd_src=/mnt/containerd >> ${PREFIX}/mnt/env
     echo HTTP_PROXY="$HTTP_PROXY" >> ${PREFIX}/mnt/env
     echo HTTPS_PROXY="$HTTPS_PROXY" >> ${PREFIX}/mnt/env
     echo NO_PROXY="$NO_PROXY" >> ${PREFIX}/mnt/env


### PR DESCRIPTION
By default, install containerd from a release tarball, instead of expecting a compiled source tree and copying it from there.

Notes: This is still mark a draft, because I'd still need to
- plug back in support for installing from sources to allow testing against an unreleased source tree
- make similar changes for CRI-O