### PR TITLE
[release-0.2] images: fix the tagging docker images build from new tags

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -47,7 +47,7 @@ jobs:
               echo "  - digging out tag from git ref $GITREF..."
               case $GITREF in
                   refs/tags/v*)
-                      tag="${GITREF#refs/tags/v}"
+                      tag="${GITREF#refs/tags/}"
                       ;;
                   refs/heads/main)
                       tag=unstable


### PR DESCRIPTION
When docker image build  workflow is triggered based on the new tag push which usually includes v as prefix, the workflow drops the v prefix. As such, when `v0.2.0` tag is pushed to GitHub, we end up with `0.2.0` tags in the docker images. This commit fixes the workflow to keep the v prefix. Currently, our deployments are tagging `v0.2.0` tags for the plugins while published images don't include the `v` and deployment are failing.