### PR TITLE
[release-0.2] deployment: adjust Pod restartPolicy to OnFailure

### DIFF
--- a/deployment/helm/balloons/templates/daemonset.yaml
+++ b/deployment/helm/balloons/templates/daemonset.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
       {{- include "balloons-plugin.labels" . | nindent 8 }}
     spec:
+      restartPolicy: OnFailure
       serviceAccount: nri-resource-policy-balloons
       nodeSelector:
         kubernetes.io/os: "linux"
@@ -22,7 +23,6 @@ spec:
       - name: patch-runtime
         image: {{ .Values.initContainerImage.name }}:{{ .Values.initContainerImage.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
-        restartPolicy: Never
         volumeMounts:
         - name: containerd-config
           mountPath: /etc/containerd

--- a/deployment/helm/memory-qos/templates/daemonset.yaml
+++ b/deployment/helm/memory-qos/templates/daemonset.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
       {{- include "memory-qos.labels" . | nindent 8 }}
     spec:
+      restartPolicy: OnFailure
       nodeSelector:
         kubernetes.io/os: "linux"
       {{- if .Values.nri.patchRuntimeConfig }}
@@ -21,7 +22,6 @@ spec:
       - name: patch-runtime
         image: {{ .Values.initContainerImage.name }}:{{ .Values.initContainerImage.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
-        restartPolicy: Never
         volumeMounts:
         - name: containerd-config
           mountPath: /etc/containerd

--- a/deployment/helm/memtierd/templates/daemonset.yaml
+++ b/deployment/helm/memtierd/templates/daemonset.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
       {{- include "memtierd.labels" . | nindent 8 }}
     spec:
+      restartPolicy: OnFailure
       nodeSelector:
         kubernetes.io/os: "linux"
       hostPID: true
@@ -22,7 +23,6 @@ spec:
       - name: patch-runtime
         image: {{ .Values.initContainerImage.name }}:{{ .Values.initContainerImage.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
-        restartPolicy: Never
         volumeMounts:
         - name: containerd-config
           mountPath: /etc/containerd

--- a/deployment/helm/topology-aware/templates/daemonset.yaml
+++ b/deployment/helm/topology-aware/templates/daemonset.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
       {{- include "topology-aware-plugin.labels" . | nindent 8 }}
     spec:
+      restartPolicy: OnFailure
       serviceAccount: nri-resource-policy-topology-aware
       nodeSelector:
         kubernetes.io/os: "linux"
@@ -22,7 +23,6 @@ spec:
       - name: patch-runtime
         image: {{ .Values.initContainerImage.name }}:{{ .Values.initContainerImage.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
-        restartPolicy: Never
         volumeMounts:
         - name: containerd-config
           mountPath: /etc/containerd


### PR DESCRIPTION
This PR fixes incorrectly used restartPolicy field. It should be at the Pod level and adjusts restartPolicy from default `Always` to `OnFailure`.
Backport of https://github.com/containers/nri-plugins/pull/152