### PR TITLE
fixes: fix image tagging scheme in publishing workflow.

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -53,7 +53,7 @@ jobs:
                       tag=unstable
                       ;;
                   refs/heads/release-*)
-                      tag="${GITREF#refs/heads/release-}-unstable"
+                      tag="v${GITREF#refs/heads/release-}-unstable"
                       ;;
                   *)
                       echo "error: can't determine tag."

--- a/scripts/build/get-buildid
+++ b/scripts/build/get-buildid
@@ -67,11 +67,10 @@ dotgit_version() {
     fi
 
     case "$_v" in
-        v*) _v="${_v#v}"
-            ;;
+        v*) ;;
         *)
             _count=$(git rev-list --count HEAD)
-            _v="0.0.0-$_count-g$_id$_dirty"
+            _v="v0.0.0-$_count-g$_id$_dirty"
             ;;
     esac
 
@@ -127,7 +126,7 @@ unknown_version() {
 
 package_versions() {
     case "$VERSION" in
-        [0-9.]**-g[0-9a-f]*)
+        v[0-9.]**-g[0-9a-f]*)
             local _full="$VERSION"
             local _numeric=${_full%%-*}
             local _cntsha1=${_full#*-}
@@ -143,7 +142,7 @@ package_versions() {
             RPM=$(echo "$VERSION" | tr '+-' '_')
             DEB=$VERSION
             ;;
-        [0-9.]*)
+        v[0-9.]*)
             RPM=$VERSION
             DEB=$VERSION
             ;;


### PR DESCRIPTION
- use 'v'-prefixed image version tags
- use 'v'-prefixed versions in binaries