### PR TITLE
[release-0.2] drop DaemonSet unsupported OnFailure restartPolicy

### DIFF
--- a/deployment/helm/balloons/templates/daemonset.yaml
+++ b/deployment/helm/balloons/templates/daemonset.yaml
@@ -14,7 +14,6 @@ spec:
       labels:
       {{- include "balloons-plugin.labels" . | nindent 8 }}
     spec:
-      restartPolicy: OnFailure
       serviceAccount: nri-resource-policy-balloons
       nodeSelector:
         kubernetes.io/os: "linux"

--- a/deployment/helm/memory-qos/templates/daemonset.yaml
+++ b/deployment/helm/memory-qos/templates/daemonset.yaml
@@ -14,7 +14,6 @@ spec:
       labels:
       {{- include "memory-qos.labels" . | nindent 8 }}
     spec:
-      restartPolicy: OnFailure
       nodeSelector:
         kubernetes.io/os: "linux"
       {{- if .Values.nri.patchRuntimeConfig }}

--- a/deployment/helm/memtierd/templates/daemonset.yaml
+++ b/deployment/helm/memtierd/templates/daemonset.yaml
@@ -14,7 +14,6 @@ spec:
       labels:
       {{- include "memtierd.labels" . | nindent 8 }}
     spec:
-      restartPolicy: OnFailure
       nodeSelector:
         kubernetes.io/os: "linux"
       hostPID: true

--- a/deployment/helm/topology-aware/templates/daemonset.yaml
+++ b/deployment/helm/topology-aware/templates/daemonset.yaml
@@ -14,7 +14,6 @@ spec:
       labels:
       {{- include "topology-aware-plugin.labels" . | nindent 8 }}
     spec:
-      restartPolicy: OnFailure
       serviceAccount: nri-resource-policy-topology-aware
       nodeSelector:
         kubernetes.io/os: "linux"


### PR DESCRIPTION
The DaemonSet controller currently only supports the `Always` restart policy, which is set by default. This commit addresses the issue of incorrectly set `OnFailure` restart policy in DaemonSet objects of plugins, ensuring that only the `Always` restart policy is used as intended.

Ref: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#pod-template
Backport of https://github.com/containers/nri-plugins/pull/155