### PR TITLE
[release-0.2] always use DirectoryOrCreate for /var/run/nri

### DIFF
--- a/deployment/helm/memory-qos/templates/daemonset.yaml
+++ b/deployment/helm/memory-qos/templates/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
       - name: nrisockets
         hostPath:
           path: /var/run/nri
-          type: Directory
+          type: DirectoryOrCreate
       {{- if .Values.nri.patchRuntimeConfig }}
       - name: containerd-config
         hostPath:

--- a/deployment/helm/memtierd/templates/daemonset.yaml
+++ b/deployment/helm/memtierd/templates/daemonset.yaml
@@ -76,7 +76,7 @@ spec:
       - name: nrisockets
         hostPath:
           path: /var/run/nri
-          type: Directory
+          type: DirectoryOrCreate
       - name: host-bitmap
         hostPath:
           path: /sys/kernel/mm/page_idle/bitmap


### PR DESCRIPTION
Use DirectoryOrCreate hostPath type for /var/run/nri. This should fix failures when NRI in the runtime is enabled by the config-manager init-container, so the /var/run/nri does not exist yet.

Backport of https://github.com/containers/nri-plugins/pull/162