### PR TITLE
build/docs: make site-build work again from git worktrees.

### DIFF
--- a/scripts/build/get-buildid
+++ b/scripts/build/get-buildid
@@ -117,7 +117,7 @@ parent_version() {
 }
 
 unknown_version() {
-    VERSION="0.0.0-$(date +%Y%m%d%H%M)"
+    VERSION="v0.0.0-$(date +%Y%m%d%H%M)"
     BUILDID=unknown
 }
 
@@ -136,6 +136,8 @@ package_versions() {
                 VERSION="$VERSION-$_cnt-g$_sha1"
             fi
             VERSION=$VERSION$_dirty
+            ;;
+        v[0-9.]*)
             ;;
         *)
             fail "can't parse version $VERSION"


### PR DESCRIPTION
Fix up careless commit a5f7ddd0a134 which broke `make site-build`... when run from a git worktree.
