### PR TITLE
deployment: fix trailing whitespace errors.

### DIFF
--- a/deployment/helm/balloons/README.md
+++ b/deployment/helm/balloons/README.md
@@ -44,12 +44,12 @@ Path to the chart: `nri-resource-policy-balloons`
 helm repo add nri-plugins https://containers.github.io/nri-plugins
 helm install my-balloons nri-plugins/nri-resource-policy-balloons --namespace kube-system
 ```
-    
+
 The command above deploys balloons NRI plugin on the Kubernetes cluster within the
 `kube-system` namespace with default configuration. To customize the available parameters
 as described in the [Configuration options]( #configuration-options) below, you have two
 options: you can use the `--set` flag or create a custom values.yaml file and provide it
-using the `-f` flag. For example: 
+using the `-f` flag. For example:
 
 ```sh
 # Install the balloons plugin with custom values provided using the --set option
@@ -90,7 +90,7 @@ along with the default values.
 | `image.tag`              | unstable                                                                                                                      | container image tag                                  |
 | `image.pullPolicy`       | Always                                                                                                                        | image pull policy                                    |
 | `resources.cpu`          | 500m                                                                                                                          | cpu resources for the Pod                            |
-| `resources.memory`       | 512Mi                                                                                                                         | memory qouta for the Pod                             | 
+| `resources.memory`       | 512Mi                                                                                                                         | memory qouta for the Pod                             |
 | `hostPort`               | 8891                                                                                                                          | metrics port to expose on the host                   |
 | `config`                 | <pre><code>ReservedResources:</code><br><code>  cpu: 750m</code></pre>                                                        | plugin configuration data                            |
 | `nri.patchRuntimeConfig` | false                                                                                                                         | enable NRI in containerd or CRI-O                    |

--- a/deployment/helm/memory-qos/README.md
+++ b/deployment/helm/memory-qos/README.md
@@ -50,7 +50,7 @@ The command above deploys memory-qos NRI plugin on the Kubernetes cluster within
 `kube-system` namespace with default configuration. To customize the available parameters
 as described in the [Configuration options]( #configuration-options) below, you have two
 options: you can use the `--set` flag or create a custom values.yaml file and provide it
-using the `-f` flag. For example: 
+using the `-f` flag. For example:
 
 ```sh
 # Install the memory-qos plugin with custom values provided using the --set option

--- a/deployment/helm/memtierd/README.md
+++ b/deployment/helm/memtierd/README.md
@@ -49,7 +49,7 @@ The command above deploys memtierd NRI plugin on the Kubernetes cluster within t
 `kube-system` namespace with default configuration. To customize the available parameters
 as described in the [Configuration options]( #configuration-options) below, you have two
 options: you can use the `--set` flag or create a custom values.yaml file and provide it
-using the `-f` flag. For example: 
+using the `-f` flag. For example:
 
 ```sh
 # Install the memtierd plugin with custom values provided using the --set option

--- a/deployment/helm/topology-aware/README.md
+++ b/deployment/helm/topology-aware/README.md
@@ -50,7 +50,7 @@ The command above deploys topology-aware NRI plugin on the Kubernetes cluster wi
 `kube-system` namespace with default configuration. To customize the available parameters
 as described in the [Configuration options]( #configuration-options) below, you have two
 options: you can use the `--set` flag or create a custom values.yaml file and provide it
-using the `-f` flag. For example: 
+using the `-f` flag. For example:
 
 ```sh
 # Install the topology-aware plugin with custom values provided using the --set option
@@ -91,7 +91,7 @@ along with the default values.
 | `image.tag`              | unstable                                                                                                                      | container image tag                                  |
 | `image.pullPolicy`       | Always                                                                                                                        | image pull policy                                    |
 | `resources.cpu`          | 500m                                                                                                                          | cpu resources for the Pod                            |
-| `resources.memory`       | 512Mi                                                                                                                         | memory qouta for the Pod                             | 
+| `resources.memory`       | 512Mi                                                                                                                         | memory qouta for the Pod                             |
 | `hostPort`               | 8891                                                                                                                          | metrics port to expose on the host                   |
 | `config`                 | <pre><code>ReservedResources:</code><br><code>  cpu: 750m</code></pre>                                                        | plugin configuration data                            |
 | `nri.patchRuntimeConfig` | false                                                                                                                         | enable NRI in containerd or CRI-O                    |


### PR DESCRIPTION
- fix trailing WS errors that slipped through in Helm Chart READMEs