### PR TITLE
deployment/helm/sgx-epc: fix a small README typo.

### DIFF
--- a/deployment/helm/sgx-epc/README.md
+++ b/deployment/helm/sgx-epc/README.md
@@ -39,7 +39,7 @@ annotations and (a yet to be merged pull request to) the cgroup v2 misc controll
 
 ## Installing the Chart
 
-Path to the chart: `nri-sg-epc`.
+Path to the chart: `nri-sgx-epc`.
 
 ```sh
 helm repo add nri-plugins https://containers.github.io/nri-plugins


### PR DESCRIPTION
 Fix a small typo that got spotted but slipped through the initial review.