### PR TITLE
.github: add workflow for rejecting PRs that introduce whitespace errors.

### DIFF
--- a/.github/workflows/project-checks.yaml
+++ b/.github/workflows/project-checks.yaml
@@ -30,6 +30,15 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: Check PR for whitespace errors
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          if ! git diff-index --check origin/${{ github.base_ref }} --; then
+              echo "This PR would introduce the errors shown above."
+              echo "Please fix them and update the PR."
+              exit 1
+          fi
+
       - name: Verify dependencies
         run: |
           make verify-godeps


### PR DESCRIPTION
This PR adds a workflow to check and reject PRs that introduce whitespace errors. The method used to check for whitespace errors is a minimalistic `git diff-index --check` against the base ref of the PR.