### PR TITLE
docs: update the main readme with the list of available plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,18 @@ This repository contains a collection of community maintained NRI plugins.
 
 Currently following plugins are available:
 
-| Name           | Type |
-|----------------|:-----:|
-| [Topology Aware][1] |  resource policy |
-| [Balloons][1]       |  resource policy |
+| Name                | Type              |
+|---------------------|:-----------------:|
+| [Topology Aware][1] | resource policy   |
+| [Balloons][2]       | resource policy   |
+| [Memtierd][3]       | memory management |
+| [Memory-qos][4]     | memory management |
+| [SGX-EPC][5]        | memory management |
+
+[1]: https://containers.github.io/nri-plugins/stable/docs/resource-policy/policy/topology-aware.html
+[2]: https://containers.github.io/nri-plugins/stable/docs/resource-policy/policy/balloons.html
+[3]: https://containers.github.io/nri-plugins/stable/docs/memory/memtierd.html
+[4]: https://containers.github.io/nri-plugins/stable/docs/memory/memory-qos.html
+[5]: https://containers.github.io/nri-plugins/stable/docs/memory/sgx-epc.html
 
 See the [NRI plugins documentation](https://containers.github.io/nri-plugins/) for more information.
-
-[1]: http://github.com/containers/nri-plugins/blob/main/docs/resource-policy/README.md


### PR DESCRIPTION
Updates README.md to include recently added plugins memtierd, memory-qos and sgx-epc.