### PR TITLE
[release-0.2] scripts: don't make unknown version invalid (cherry-picked 97a3e65).

### DIFF
--- a/scripts/build/get-buildid
+++ b/scripts/build/get-buildid
@@ -120,7 +120,7 @@ parent_version() {
 }
 
 unknown_version() {
-    VERSION="0.0.0-$(date +%Y%m%d%H%M)"
+    VERSION="v0.0.0-$(date +%Y%m%d%H%M)"
     BUILDID=unknown
 }
 
@@ -145,6 +145,8 @@ package_versions() {
         v[0-9.]*)
             RPM=$VERSION
             DEB=$VERSION
+            ;;
+        v[0-9.]*)
             ;;
         *)
             fail "can't parse version $VERSION"


### PR DESCRIPTION
Make the date-based version generated by unknown_version() 'v'-prefixed, too. Make that version valid again (broken by commit a5f7ddd0a134).