### PR TITLE
[release-0.2] helm: add an option to set tolerations (backport of #157)

### DIFF
--- a/deployment/helm/balloons/templates/daemonset.yaml
+++ b/deployment/helm/balloons/templates/daemonset.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
       {{- include "balloons-plugin.labels" . | nindent 8 }}
     spec:
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccount: nri-resource-policy-balloons
       nodeSelector:
         kubernetes.io/os: "linux"

--- a/deployment/helm/balloons/values.yaml
+++ b/deployment/helm/balloons/values.yaml
@@ -22,9 +22,17 @@ resources:
 nri:
   patchRuntimeConfig: false
 
-
 initContainerImage:
   name: ghcr.io/containers/nri-plugins/nri-config-manager
   # If not defined Chart.AppVersion will be used
   #tag: unstable
   pullPolicy: IfNotPresent
+
+tolerations: []
+#
+# Example:
+#
+# tolerations:
+# - key: "node-role.kubernetes.io/control-plane"
+#   operator: "Exists"
+#   effect: "NoSchedule"

--- a/deployment/helm/memory-qos/templates/daemonset.yaml
+++ b/deployment/helm/memory-qos/templates/daemonset.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
       {{- include "memory-qos.labels" . | nindent 8 }}
     spec:
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       nodeSelector:
         kubernetes.io/os: "linux"
       {{- if .Values.nri.patchRuntimeConfig }}

--- a/deployment/helm/memory-qos/values.yaml
+++ b/deployment/helm/memory-qos/values.yaml
@@ -20,3 +20,12 @@ initContainerImage:
   # If not defined Chart.AppVersion will be used
   #tag: unstable
   pullPolicy: IfNotPresent
+
+tolerations: []
+#
+# Example:
+#
+# tolerations:
+# - key: "node-role.kubernetes.io/control-plane"
+#   operator: "Exists"
+#   effect: "NoSchedule"

--- a/deployment/helm/memtierd/templates/daemonset.yaml
+++ b/deployment/helm/memtierd/templates/daemonset.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
       {{- include "memtierd.labels" . | nindent 8 }}
     spec:
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       nodeSelector:
         kubernetes.io/os: "linux"
       hostPID: true

--- a/deployment/helm/memtierd/values.yaml
+++ b/deployment/helm/memtierd/values.yaml
@@ -22,3 +22,12 @@ initContainerImage:
   # If not defined Chart.AppVersion will be used
   #tag: unstable
   pullPolicy: IfNotPresent
+
+tolerations: []
+#
+# Example:
+#
+# tolerations:
+# - key: "node-role.kubernetes.io/control-plane"
+#   operator: "Exists"
+#   effect: "NoSchedule"

--- a/deployment/helm/topology-aware/templates/daemonset.yaml
+++ b/deployment/helm/topology-aware/templates/daemonset.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
       {{- include "topology-aware-plugin.labels" . | nindent 8 }}
     spec:
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccount: nri-resource-policy-topology-aware
       nodeSelector:
         kubernetes.io/os: "linux"

--- a/deployment/helm/topology-aware/values.yaml
+++ b/deployment/helm/topology-aware/values.yaml
@@ -27,3 +27,13 @@ initContainerImage:
   # If not defined Chart.AppVersion will be used
   #tag: unstable
   pullPolicy: IfNotPresent
+
+tolerations: []
+#
+# Example:
+#
+# tolerations:
+# - key: "node-role.kubernetes.io/control-plane"
+#   operator: "Exists"
+#   effect: "NoSchedule"
+

--- a/docs/resource-policy/installation.md
+++ b/docs/resource-policy/installation.md
@@ -64,12 +64,30 @@ following components: DaemonSet, ConfigMap, CustomResourceDefinition, and RBAC-r
 1. Install the plugin. Replace release version with the desired version. If you wish to
    provide custom values to the Helm chart, refer to the [table](#helm-parameters) below,
    which describes the available parameters that can be modified before installation.
-   It's important to note that specifying the namespace (using `--namespace` or `-n`) is
-   crucial when installing the Helm chart. If no namespace is specified, the manifests
-   will be installed in the default namespace.
+   Parameters can be specified either using the --set option or through the -f flag along
+   with the custom values.yaml file. It's important to note that specifying the namespace
+   (using `--namespace` or `-n`) is crucial when installing the Helm chart. If no namespace
+   is specified, the manifests will be installed in the default namespace.
 
     ```sh
+    # Install the topology-aware plugin with default values
     helm install topology-aware nri-plugins/nri-resource-policy-topology-aware --namespace kube-system
+
+    # Install the topology-aware plugin with custom values provided using the --set option
+    helm install topology-aware nri-plugins/nri-resource-policy-topology-aware --namespace kube-system --set nri.patchRuntimeConfig=true
+
+    # Install the topology-aware plugin with custom values specified in a custom values.yaml file
+    cat <<EOF > myPath/values.yaml
+    nri:
+      patchRuntimeConfig: true
+
+    tolerations:
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: "Exists"
+      effect: "NoSchedule"
+    EOF
+
+    helm install topology-aware nri-plugins/nri-resource-policy-topology-aware --namespace kube-system -f myPath/values.yaml
     ```
 
     The helm repository is named `nri-plugins`, and in step 1, you have the
@@ -122,6 +140,7 @@ Path to the chart: `nri-resource-policy-topology-aware`
 | `initImage.name`   | [ghcr.io/containers/nri-plugins/config-manager](ghcr.io/containers/nri-plugins/config-manager)                                | init container image name                            |
 | `initImage.tag`    | unstable                                                                                                                      | init container image tag                             |
 | `initImage.pullPolicy` | Always                                                                                                                    | init container image pull policy                     |
+| `tolerations`      | []                                                                                                                            | specify taint toleration key, operator and effect    |
 
 #### Balloons
 
@@ -140,6 +159,7 @@ Path to the chart: `nri-resource-policy-balloons`
 | `initImage.name`   | [ghcr.io/containers/nri-plugins/config-manager](ghcr.io/containers/nri-plugins/config-manager)                                | init container image name                            |
 | `initImage.tag`    | unstable                                                                                                                      | init container image tag                             |
 | `initImage.pullPolicy` | Always                                                                                                                    | init container image pull policy                     |
+| `tolerations`      | []                                                                                                                            | specify taint toleration key, operator and effect    |
 
 #### Memtierd
 
@@ -157,6 +177,7 @@ Path to the chart: `nri-memtierd`
 | `initImage.name`   | [ghcr.io/containers/nri-plugins/config-manager](ghcr.io/containers/nri-plugins/config-manager)                                | init container image name                            |
 | `initImage.tag`    | unstable                                                                                                                      | init container image tag                             |
 | `initImage.pullPolicy` | Always                                                                                                                    | init container image pull policy                     |
+| `tolerations`      | []                                                                                                                            | specify taint toleration key, operator and effect    |
 
 
 #### Memory-qos
@@ -174,6 +195,7 @@ Path to the chart: `nri-memory-qos`
 | `initImage.name`   | [ghcr.io/containers/nri-plugins/config-manager](ghcr.io/containers/nri-plugins/config-manager)                                | init container image name                            |
 | `initImage.tag`    | unstable                                                                                                                      | init container image tag                             |
 | `initImage.pullPolicy` | Always                                                                                                                    | init container image pull policy                     |
+| `tolerations`      | []                                                                                                                            | specify taint toleration key, operator and effect    |
 
 
 ## Manual installation


### PR DESCRIPTION
In some clusters, some of the Nodes might have taints which may avoid NRI plugins DaemonSet Pods not to get scheduled on those Nodes. Having an option to pass custom tolerations to plugins DaemonSet object would help to ensure that Pods get scheduled on all the desired Nodes.