### PR TITLE
.github: use release-* release branch pattern.

### DIFF
--- a/.github/workflows/project-checks.yaml
+++ b/.github/workflows/project-checks.yaml
@@ -4,12 +4,12 @@ on:
   push:
     branches:
       - main
-      - "release/**"
+      - "release-*"
       - "test/**"
   pull_request:
     branches:
       - main
-      - "release/**"
+      - "release-*"
 
 env:
   GO_VERSION: "1.20.10"

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - release-**
+      - release-*
     tags:
       - v*
 


### PR DESCRIPTION
Use `release-*` release branch pattern in all workflows (where release branches are referenced).