### PR TITLE
balloons: use new config more consistently, fix incorrect test config keys.

### DIFF
--- a/cmd/plugins/balloons/policy/balloons-policy.go
+++ b/cmd/plugins/balloons/policy/balloons-policy.go
@@ -1065,6 +1065,12 @@ func (p *balloons) setConfig(bpoptions *BalloonsOptions) error {
 		topologyBalancing:           bpoptions.AllocatorTopologyBalancing,
 		preferSpreadOnPhysicalCores: bpoptions.PreferSpreadOnPhysicalCores,
 	})
+
+	// We can't delay taking new configuration into use beyond this point,
+	// because p.newBalloon() dereferences our options via p.bpoptions, so
+	// it would end up using the old configuration.
+	p.bpoptions = *bpoptions
+
 	// Instantiate built-in reserved and default balloons.
 	reservedBalloon, err := p.newBalloon(p.reservedBalloonDef, false)
 	if err != nil {
@@ -1101,8 +1107,7 @@ func (p *balloons) setConfig(bpoptions *BalloonsOptions) error {
 	for blnIdx, bln := range p.balloons {
 		log.Info("- balloon %d: %s", blnIdx, bln)
 	}
-	// No errors in balloon creation, take new configuration into use.
-	p.bpoptions = *bpoptions
+
 	p.updatePinning(p.shareIdleCpus(p.freeCpus, cpuset.New())...)
 	// (Re)configures all CPUs in balloons.
 	p.resetCpuClass()

--- a/test/e2e/policies.test-suite/balloons/balloons-configmap.yaml.in
+++ b/test/e2e/policies.test-suite/balloons/balloons-configmap.yaml.in
@@ -24,7 +24,7 @@ data:
         - Name: btype0
           MinCPUs: ${BTYPE0_MINCPUS:-2}
           MaxCPUs: ${BTYPE0_MAXCPUS:-2}
-          AllocationPriority: ${BTYPE0_ALLOCATIONPRIORITY:-0}
+          AllocatorPriority: ${BTYPE0_ALLOCATORPRIORITY:-0}
           CPUClass: ${BTYPE0_CPUCLASS:-classA}
           PreferNewBalloons: ${BTYPE0_PREFERNEWBALLOONS:-true}
           PreferSpreadingPods: ${BTYPE0_PREFERSPREADINGPODS:-false}
@@ -36,7 +36,7 @@ data:
             - ${BTYPE1_NAMESPACE0:-btype1ns0}
           MinCPUs: ${BTYPE1_MINCPUS:-1}
           MaxCPUs: ${BTYPE1_MAXCPUS:-1}
-          AllocatorPriority: ${BTYPE1_ALLOCATIONPRIORITY:-1}
+          AllocatorPriority: ${BTYPE1_ALLOCATORPRIORITY:-1}
           CPUClass: ${BTYPE1_CPUCLASS:-classB}
           PreferNewBalloons: ${BTYPE1_PREFERNEWBALLOONS:-false}
           PreferSpreadingPods: ${BTYPE1_PREFERSPREADINGPODS:-true}

--- a/test/e2e/policies.test-suite/balloons/n4c16/test08-numa/balloons-numa.cfg
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test08-numa/balloons-numa.cfg
@@ -17,7 +17,7 @@ policy:
         # Prevent a balloon to be inflated larger than a NUMA node
         MinCPUs: 0
         MaxCPUs: 4
-        AllocationPriority: 0
+        AllocatorPriority: 0
         PreferNewBalloons: false
 instrumentation:
   HTTPEndpoint: ":8891"

--- a/test/e2e/policies.test-suite/balloons/nri-resource-policy.cfg
+++ b/test/e2e/policies.test-suite/balloons/nri-resource-policy.cfg
@@ -17,7 +17,7 @@ policy:
       - Name: two-cpu
         MinCPUs: 2
         MaxCPUs: 2
-        AllocationPriority: 0
+        AllocatorPriority: 0
         CPUClass: class2
         PreferNewBalloons: true
 


### PR DESCRIPTION
Don't delay updating stored configuration when reconfiguring the policy. Some functions in the call-tree (for instance `newBalloon()`), use the stored options, so they could end up using old data otherwise.

Additionally, fix a few incorrect keys (`AllocationPriority` should be `AllocatorPriority`) in the balloons tests.

@askervin I bumped into this while fixing failing tests for #164 and I realized it is present also in current main/HEAD.   
This patch might not be a fully proper fix (I didn't try to check all the implications). This change might alter behavior on the reconfiguration error code paths, albeit that should be fixed (at least in principle) by the subsequent successful (re)application of the previous configuration, triggered externally by resmgr... Still, I think we probably prefer the more correct behavior on the normal/errorfree code paths.