### PR TITLE
test/e2e: test VM provisioning fixes

### DIFF
--- a/test/e2e/playbook/provision.yaml
+++ b/test/e2e/playbook/provision.yaml
@@ -176,6 +176,20 @@
         - "{{ crio_src }}/contrib/crio.service"
       when: is_crio and crio_src != ""
 
+    - block:
+      - name: Remove CRI-O crun configuration
+        ansible.builtin.file:
+          state: absent
+          path: /etc/crio/crio.conf.d/10-crun.conf
+
+      - name: Make runc the default CRI-O runtime
+        ansible.builtin.copy:
+          dest: /etc/crio/crio.conf.d/10-runc.conf
+          content: |
+            [crio.runtime]
+            default_runtime = "runc"
+      when: is_crio
+
     - name: Install containerd systemd service file
       ansible.builtin.get_url:
         url: "{{ containerd_service_file }}"

--- a/test/e2e/playbook/provision.yaml
+++ b/test/e2e/playbook/provision.yaml
@@ -342,8 +342,10 @@
           remote_src: yes
 
       - name: Run cilium installer
-        ansible.builtin.shell:
-          cmd: cilium install --wait
+        ansible.builtin.shell: "{{ item }}"
+        with_items:
+          - cilium install --wait
+          - cilium status --wait
       when: cni_plugin == "cilium"
 
     - block:


### PR DESCRIPTION
This PR fixes the following problems in end-to-end test VM provisioning
- configure runc instead of crun as the default runtime for CRI-O
- wait for cilium installation before provisioning is considered done