### PR TITLE
test/e2e: fix vagrant usage, make cilium version configurable.

### DIFF
--- a/test/e2e/files/Makefile.in
+++ b/test/e2e/files/Makefile.in
@@ -1,3 +1,7 @@
+ifneq ($(V),1)
+.SILENT:
+endif
+
 all: up
 
 install: .plugins.installed.stamp
@@ -6,7 +10,7 @@ install: .plugins.installed.stamp
 	vagrant plugin install dotenv
 	vagrant plugin install vagrant-proxyconf
 	vagrant plugin install vagrant-qemu
-	$(Q)if [ ! -f "$@" ]; then \
+	if [ ! -f "$@" ]; then \
 	    touch "$@"; \
 	fi;
 
@@ -19,8 +23,14 @@ up:
 down:
 	vagrant halt
 
-ssh: up
-	vagrant ssh
+ssh:
+	if [ -f .ssh-config ]; then \
+	    if ! ssh -F .ssh-config vagrant@node; then \
+	        $(MAKE) up && ssh -F .ssh-config vagrant@node; \
+	    fi \
+	else \
+	    vagrant up && vagrant ssh; \
+	fi
 
 status:
 	vagrant status

--- a/test/e2e/files/Vagrantfile.in
+++ b/test/e2e/files/Vagrantfile.in
@@ -29,6 +29,7 @@ else
 end
 
 CNI_PLUGIN = "#{ENV['cni_plugin']}"
+CNI_RELEASE = "#{ENV['cni_release']}"
 
 NRI_RESOURCE_POLICY_SRC = "#{ENV['nri_resource_policy_src']}"
 OUTPUT_DIR = "#{ENV['OUTPUT_DIR']}"
@@ -93,6 +94,7 @@ Vagrant.configure("2") do |config|
       crio_release: CRIO_RELEASE,
       crio_src: CRIO_SRC,
       cni_plugin: CNI_PLUGIN,
+      cni_release: CNI_RELEASE,
       nri_resource_policy_src: NRI_RESOURCE_POLICY_SRC,
       outdir: OUTPUT_DIR,
     }

--- a/test/e2e/lib/vm.bash
+++ b/test/e2e/lib/vm.bash
@@ -77,7 +77,7 @@ vm-setup() {
 	    -e "s/QEMU_MEM/$MEM/" \
 	    -e "s/QEMU_SMP/$CPU/" \
 	    -e "s/QEMU_EXTRA_ARGS/$EXTRA_ARGS/" \
-	    "$files/Vagrantfile.in" > "$vagrantdir/Vagrantfile"
+	    "$files/Vagrantfile.in" > "$vagrantdir/Vagrantfile.erb"
     fi
 
     if [ ! -f "$vagrantdir/Makefile" ]; then
@@ -110,7 +110,7 @@ vm-setup() {
      make install
 
      if [ ! -d .vagrant ]; then
-	 vagrant init $distro
+	 vagrant init --template Vagrantfile $distro || error "failed to vagrant init $distro"
      fi
 
      # If you want to force provisioning of already provisioned vm,
@@ -119,10 +119,10 @@ vm-setup() {
      # cannot be called second time. But this could be used
      # if the provisioning failed before kubernetes was setup.
      if [ ! -z "$provision" ]; then
-	 vagrant provision
+	 vagrant provision || error "failed to provision VM"
      fi
 
-     vagrant up --provider qemu
+     vagrant up --provider qemu || error "failed to bring up VM"
      vagrant ssh-config > .ssh-config
 
      # Add hostname alias to the ssh config so that we can ssh

--- a/test/e2e/playbook/provision.yaml
+++ b/test/e2e/playbook/provision.yaml
@@ -13,7 +13,8 @@
     - crio_tarball: "https://storage.googleapis.com/cri-o/artifacts/cri-o.amd64.v{{ crio_release }}.tar.gz"
     - dns_nameserver: "{{ dns_nameserver }}"
     - cni_plugin: "{{ cni_plugin }}"
-
+    - cni_release: "{{ cni_release }}"
+    - cilium_tarball: ""
 
   tasks:
     - set_fact:
@@ -334,19 +335,30 @@
         - kubectl taint nodes --all node-role.kubernetes.io/control-plane- || true
         - kubectl taint nodes --all node-role.kubernetes.io/master- || true
 
-    - block:
-      - name: Fetch and extract cilium (installer) release tarball
-        ansible.builtin.unarchive:
-          src: "https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz"
-          dest: /usr/local/bin
-          remote_src: yes
-
-      - name: Run cilium installer
-        ansible.builtin.shell: "{{ item }}"
-        with_items:
-          - cilium install --wait
-          - cilium status --wait
+    - name: Install cilium CNI plugin
       when: cni_plugin == "cilium"
+      block:
+        - name: "Use irregular download path if cilium release is latest"
+          when: cni_release == "latest"
+          ansible.builtin.set_fact:
+            cilium_tarball: https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz
+
+        - name: "Use regular download path if cilium release is not latest"
+          when: cni_release != "latest"
+          ansible.builtin.set_fact:
+            cilium_tarball: https://github.com/cilium/cilium-cli/releases/download/{{ cni_release }}/cilium-linux-amd64.tar.gz
+
+        - name: "Fetch and extract {{ cni_release }} cilium (installer) release tarball"
+          ansible.builtin.unarchive:
+            src: "{{ cilium_tarball }}"
+            dest: /usr/local/bin
+            remote_src: true
+
+        - name: Run cilium installer
+          ansible.builtin.command: "{{ item }}"
+          with_items:
+            - cilium install --wait
+            - cilium status --wait
 
     - block:
       - name: Copy CNI bridge plugin configuration

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -20,6 +20,7 @@ export COMMAND_OUTPUT_DIR="$TEST_OUTPUT_DIR"/commands
 distro=${distro:-$DEFAULT_DISTRO}
 export k8scri=${k8scri:-"containerd"}
 export cni_plugin=${cni_plugin:-cilium}
+export cni_release=${cni_release:-latest}
 TOPOLOGY_DIR=${TOPOLOGY_DIR:=e2e}
 
 source "$LIB_DIR"/vm.bash


### PR DESCRIPTION
This PR fixes a number of problems related to vagrant setup and usage in the e2e tests. In particular:

- use Vagrantfile.in as a vagrant ERB template instead of a pre-created Vagrantfile (which latest vagrant init rejects)
- check vagrant status and fail tests if vagrant (init, provision, or up) commands fail
- try using ssh directly, falling back to vagrant ssh only if this fails
- allow default (latest) cilium version to be overridden for tests

These commits have been split out from #164 as a self-contained and largely unrelated set that can be reviewed and merged separately.