### PR TITLE
RFC WIP: experimenting with building debug binaries and images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,11 @@ LDFLAGS    = \
              -X=github.com/containers/nri-plugins/pkg/version.Build=$(BUILD_BUILDID) \
              -B 0x$(RANDOM_ID)"
 
+ifeq ($(DEBUG),1)
+    GCFLAGS ?= -gcflags "all=-N -l"
+    DOCKER_BUILD_DEBUG := --build-arg DEBUG=1
+endif
+
 # Documentation-related variables
 SPHINXOPTS    ?= -W
 SPHINXBUILD   = sphinx-build
@@ -132,12 +137,12 @@ verify: verify-godeps verify-fmt
 build-plugins: $(foreach bin,$(PLUGINS),$(BIN_PATH)/$(bin))
 
 build-plugins-static:
-	$(MAKE) STATIC=1 build-plugins
+	$(MAKE) STATIC=1 DEBUG=$(DEBUG) build-plugins
 
 build-binaries: $(foreach bin,$(BINARIES),$(BIN_PATH)/$(bin))
 
 build-binaries-static:
-	$(MAKE) STATIC=1 build-binaries
+	$(MAKE) STATIC=1 DEBUG=$(DEBUG) build-binaries
 
 build-images: images
 
@@ -228,6 +233,7 @@ image.%:
 	tag=$(patsubst image.%,%,$@); \
 	    $(DOCKER_BUILD) . -f "$$dir/Dockerfile" \
 	    --build-arg GO_VERSION=$(GO_VERSION) \
+	    $(DOCKER_BUILD_DEBUG) \
 	    -t $(IMAGE_REPO)$$tag:$(IMAGE_VERSION)
 
 image-deployment.nri-resource-policy-% \

--- a/cmd/plugins/balloons/Dockerfile
+++ b/cmd/plugins/balloons/Dockerfile
@@ -2,7 +2,13 @@ ARG GO_VERSION=1.20
 
 FROM golang:${GO_VERSION}-bullseye as builder
 
+ARG DEBUG=0
+
 WORKDIR /go/builder
+
+RUN if [ "$DEBUG" = 1 ]; then \
+        GOBIN=/go/builder/build/bin go install -tags osusergo,netgo -ldflags "-extldflags=-static" github.com/go-delve/delve/cmd/dlv@latest; \
+    fi
 
 # Fetch go dependencies in a separate layer for caching
 COPY go.mod go.sum ./
@@ -13,10 +19,21 @@ RUN go mod download
 COPY . .
 
 RUN make clean
-RUN make PLUGINS=nri-resource-policy-balloons build-plugins-static
+RUN make PLUGINS=nri-resource-policy-balloons DEBUG=$DEBUG V=$DEBUG build-plugins-static
+RUN if [ "$DEBUG" = 0 ]; then \
+        for d in /go/builder/build/bin/dlv /go/builder/pkg /go/builder/cmd /go/pkg /usr/local/go/src ; do \
+            mv $d $d-dont-copy 2>/dev/null; \
+            touch $d; \
+        done; \
+    fi
 
 FROM gcr.io/distroless/static
 
 COPY --from=builder /go/builder/build/bin/nri-resource-policy-balloons /bin/nri-resource-policy-balloons
+COPY --from=builder /go/builder/build/bin/dlv /bin/dlv
+COPY --from=builder /go/builder/pkg /go/builder/pkg
+COPY --from=builder /go/builder/cmd /go/builder/cmd
+COPY --from=builder /go/pkg /go/pkg
+COPY --from=builder /usr/local/go/src /usr/local/go/src
 
 ENTRYPOINT ["/bin/nri-resource-policy-balloons"]


### PR DESCRIPTION
Builds debug versions of binaries and images with make DEBUG=1. When a debug version of an NRI resource policy image is running, you can attach debugger to it with

`kubectl exec -n kube-system -it nri-resource-policy-... -- dlv attach 1`