### PR TITLE
balloons: fix unit tests

### DIFF
--- a/cmd/plugins/balloons/policy/cputree_test.go
+++ b/cmd/plugins/balloons/policy/cputree_test.go
@@ -584,7 +584,7 @@ func TestWalk(t *testing.T) {
 		foundLevel := CPUTopologyLevelUndefined
 		rv := tree.DepthFirstWalk(func(tn *cpuTreeNode) error {
 			foundName = tn.name
-			foundLevel = tn.level
+			foundLevel = string(tn.level)
 			return nil
 		})
 		if rv != nil {
@@ -667,49 +667,6 @@ func TestCpuLocations(t *testing.T) {
 		t.Errorf("expected len(systemlocations[4]) 4, got %d", len(systemlocations[4]))
 		return
 	}
-}
-
-func TestCPUTopologyLevel(t *testing.T) {
-	var lvl CPUTopologyLevel
-	if lvl != CPUTopologyLevelUndefined {
-		t.Errorf("unexpected default inital value for lvl: %s, expected undefined", lvl)
-	}
-	if err := lvl.UnmarshalJSON([]byte("\"\"")); err != nil || lvl != CPUTopologyLevelUndefined {
-		t.Errorf("unexpected outcome unmarshalling topology level: \"\", error: %s, result: %s", err, lvl)
-	}
-	if err := lvl.UnmarshalJSON([]byte("\"system\"")); err != nil || lvl != CPUTopologyLevelSystem {
-		t.Errorf("unexpected outcome unmarshalling topology level: system, error: %s, result: %s", err, lvl)
-	}
-	if err := lvl.UnmarshalJSON([]byte("\"NUMA\"")); err != nil || lvl != CPUTopologyLevelNuma {
-		t.Errorf("unexpected outcome unmarshalling topology level: \"NUMA\", error: %s, result: %s", err, lvl)
-	}
-	if err := lvl.UnmarshalJSON([]byte("\"undefined\"")); err == nil {
-		t.Errorf("unexpected outcome unmarshalling topology level: \"undefined\", error: %s, result: %s", err, lvl)
-	}
-	if err := lvl.UnmarshalJSON([]byte("system")); err == nil {
-		t.Errorf("unexpected non-error outcome unmarshalling topology level: system, error: %s, result: %s", err, lvl)
-	}
-	if err := lvl.UnmarshalJSON([]byte("0")); err == nil {
-		t.Errorf("unexpected non-error outcome unmarshalling topology level: 0, error: %s, result: %s", err, lvl)
-	}
-	if err := lvl.UnmarshalJSON([]byte("\"4\"")); err == nil {
-		t.Errorf("unexpected non-error outcome unmarshalling topology level: \"0\", error: %s, result: %s", err, lvl)
-	}
-	if undefBytes, err := CPUTopologyLevelUndefined.MarshalJSON(); err != nil {
-		t.Errorf("unexpected error marshaling undefined: %s", err)
-	} else {
-		if err = lvl.UnmarshalJSON(undefBytes); err != nil || lvl != CPUTopologyLevelUndefined {
-			t.Errorf("unexpected outcome unmarshaling marshaled undefined: error: %s, result: %s", err, lvl)
-		}
-	}
-	if threadBytes, err := CPUTopologyLevelThread.MarshalJSON(); err != nil {
-		t.Errorf("unexpected error marshaling thread: %s", err)
-	} else {
-		if err = lvl.UnmarshalJSON(threadBytes); err != nil || lvl != CPUTopologyLevelThread {
-			t.Errorf("unexpected outcome unmarshaling marshaled thread: error: %s, result: %s", err, lvl)
-		}
-	}
-
 }
 
 func TestSplitLevel(t *testing.T) {


### PR DESCRIPTION
- CPUTopologyLevel is now a cfgapi type, there is no more custom parser to be tested.