### PR TITLE
operator: switch to community defined category

### DIFF
--- a/deployment/operator/Makefile
+++ b/deployment/operator/Makefile
@@ -98,7 +98,7 @@ bundle: copy-crds kustomize operator-sdk ## Generate bundle manifests and metada
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
-	OPERATOR_BUNDLE_CATEGORIES=categories.json $(OPERATOR_SDK) bundle validate ./bundle \
+	$(OPERATOR_SDK) bundle validate ./bundle \
 	--select-optional name=operatorhub \
 	--select-optional suite=operatorframework \
 	--select-optional name=good-practices \

--- a/deployment/operator/categories.json
+++ b/deployment/operator/categories.json
@@ -1,7 +1,0 @@
-{
-    "categories":[
-       "Performance",
-       "System components"
-    ]
- }
- 

--- a/deployment/operator/config/manifests/bases/nri-plugins-operator.clusterserviceversion.yaml
+++ b/deployment/operator/config/manifests/bases/nri-plugins-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    categories: Performance
+    categories: OpenShift Optional
     certified: "false"
     containerImage: ghcr.io/containers/nri-plugins/nri-plugins-operator:unstable
     description: An operator that installs Node Resource Interface reference plugins.


### PR DESCRIPTION
https://github.com/k8s-operatorhub/community-operators doesn't support adding custom categories and such dropping using custom categories and switching to Openshift Optional to pass CI checks in https://github.com/k8s-operatorhub/community-operators/pull/3685.