### PR TITLE
operator: point containerImage tag to the latest release (v0.3.2)

### DIFF
--- a/deployment/operator/Makefile
+++ b/deployment/operator/Makefile
@@ -35,7 +35,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
 # ghcr.io/containers/nri-plugins-operator-bundle:$VERSION and ghcr.io/containers/nri-plugins-operator-catalog:$VERSION.
-IMAGE_TAG_BASE ?= ghcr.io/containers/nri-plugins-operator
+IMAGE_TAG_BASE ?= ghcr.io/containers/nri-plugins/nri-plugins-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)

--- a/deployment/operator/config/manager/kustomization.yaml
+++ b/deployment/operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/containers/nri-plugins-operator
-  newTag: unstable
+  newTag: v0.3.2

--- a/deployment/operator/config/manifests/bases/nri-plugins-operator.clusterserviceversion.yaml
+++ b/deployment/operator/config/manifests/bases/nri-plugins-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     certified: "false"
-    containerImage: ghcr.io/containers/nri-plugins/nri-plugins-operator:unstable
+    containerImage: ghcr.io/containers/nri-plugins/nri-plugins-operator:v0.3.2
     description: An operator that installs Node Resource Interface reference plugins.
     repository: https://github.com/containers/nri-plugins-operator
     support: "false"

--- a/hack/release-helper.sh
+++ b/hack/release-helper.sh
@@ -22,6 +22,8 @@ fi
 version=$1
 shift 1
 
+container_image=ghcr.io/containers/nri-plugins/nri-plugins-operator:$version
+
 if ! [[ $version =~ ^v[0-9]+\.[0-9]+\..+$ ]]; then
     echo -e "ERROR: invalid VERSION '$version'"
     exit 1
@@ -34,3 +36,9 @@ find deployment/helm -name Chart.yaml | xargs -I '{}' \
 find deployment/helm -name values.yaml | xargs -I '{}' \
     sed -e s"/pullPolicy:.*/pullPolicy: IfNotPresent/" -i '{}'
 
+# Patch deployment templates
+echo Patching kustomize templates to use $container_image
+find deployment/operator/config/manifests/bases -name nri-plugins-operator.clusterserviceversion.yaml | xargs -I '{}' \
+    sed -E -e s",^([[:space:]]+)containerImage:.+$,\1containerImage: $container_image," -i '{}'
+find deployment/operator/config/manager -name kustomization.yaml | xargs -I '{}' \
+    sed -E -e s",^([[:space:]]+)newTag:.+$,\1newTag: $version," -i '{}'


### PR DESCRIPTION
Ensure that we `sed` the image tag to the next release tag before pushing a new tag.
This will ensure that when new tag is pushed and image build is started, our images 
will have the right manifests. 