### PR TITLE
helm: allow setting NRI plugin index via values.

### DIFF
--- a/deployment/helm/balloons/README.md
+++ b/deployment/helm/balloons/README.md
@@ -98,6 +98,7 @@ customize with their own values, along with the default values.
 | `hostPort`               | 8891                                                                                                                          | metrics port to expose on the host                   |
 | `config`                 | see [helm chart values](tree:/deployment/helm/balloons/values.yaml) for the default configuration                       | plugin configuration data                            |
 | `nri.patchRuntimeConfig` | false                                                                                                                         | enable NRI in containerd or CRI-O                    |
+| `nri.pluginIndex`        | 90                                                                                                                            | NRI plugin index to register with                    |
 | `initImage.name`         | [ghcr.io/containers/nri-plugins/config-manager](https://ghcr.io/containers/nri-plugins/config-manager)                        | init container image name                            |
 | `initImage.tag`          | unstable                                                                                                                      | init container image tag                             |
 | `initImage.pullPolicy`   | Always                                                                                                                        | init container image pull policy                     |

--- a/deployment/helm/balloons/templates/daemonset.yaml
+++ b/deployment/helm/balloons/templates/daemonset.yaml
@@ -54,6 +54,8 @@ spec:
             - /tmp/nri-resource-policy.pid
             - -metrics-interval
             - 5s
+            - --nri-plugin-index
+            - "{{ printf "%02d" .Values.nri.pluginIndex }}"
           ports:
             - containerPort: 8891
               protocol: TCP

--- a/deployment/helm/balloons/values.scheme.json
+++ b/deployment/helm/balloons/values.scheme.json
@@ -41,6 +41,23 @@
                 }
             }
         },
+        "nri": {
+            "type": "object",
+            "required": [
+                "patchRuntimeConfig",
+                "pluginIndex"
+            ],
+            "properties": {
+                "patchRuntimeConfig": {
+                    "type": "boolean"
+                },
+                "pluginIndex": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 99
+                }
+            }
+        },
         "hostPort": {
             "type": "integer"
         }

--- a/deployment/helm/balloons/values.yaml
+++ b/deployment/helm/balloons/values.yaml
@@ -42,6 +42,7 @@ resources:
 
 nri:
   patchRuntimeConfig: false
+  pluginIndex: 90
 
 initContainerImage:
   name: ghcr.io/containers/nri-plugins/nri-config-manager

--- a/deployment/helm/memory-qos/README.md
+++ b/deployment/helm/memory-qos/README.md
@@ -96,6 +96,7 @@ customize with their own values, along with the default values.
 | `resources.cpu`          | 10m                                                                                                                           | cpu resources for the Pod                            |
 | `resources.memory`       | 100Mi                                                                                                                         | memory qouta for the Pod                         |
 | `nri.patchRuntimeConfig` | false                                                                                                                         | enable NRI in containerd or CRI-O                    |
+| `nri.pluginIndex`        | 40                                                                                                                            | NRI plugin index to register with                    |
 | `initImage.name`         | [ghcr.io/containers/nri-plugins/config-manager](https://ghcr.io/containers/nri-plugins/config-manager)                        | init container image name                            |
 | `initImage.tag`          | unstable                                                                                                                      | init container image tag                             |
 | `initImage.pullPolicy`   | Always                                                                                                                        | init container image pull policy                     |

--- a/deployment/helm/memory-qos/templates/daemonset.yaml
+++ b/deployment/helm/memory-qos/templates/daemonset.yaml
@@ -47,7 +47,7 @@ spec:
           command:
             - nri-memory-qos
             - --idx
-            - "40"
+            - "{{ printf "%02d" .Values.nri.pluginIndex }}"
             - --config
             - /etc/nri/memory-qos/config.yaml
             - -v

--- a/deployment/helm/memory-qos/values.scheme.json
+++ b/deployment/helm/memory-qos/values.scheme.json
@@ -39,6 +39,23 @@
                     "type": "integer"
                 }
             }
+        },
+        "nri": {
+            "type": "object",
+            "required": [
+                "patchRuntimeConfig",
+                "pluginIndex"
+            ],
+            "properties": {
+                "patchRuntimeConfig": {
+                    "type": "boolean"
+                },
+                "pluginIndex": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 99
+                }
+            }
         }
     }
  }

--- a/deployment/helm/memory-qos/values.yaml
+++ b/deployment/helm/memory-qos/values.yaml
@@ -14,6 +14,7 @@ resources:
 
 nri:
   patchRuntimeConfig: false
+  pluginIndex: 40
 
 initContainerImage:
   name: ghcr.io/containers/nri-plugins/nri-config-manager

--- a/deployment/helm/memtierd/README.md
+++ b/deployment/helm/memtierd/README.md
@@ -96,6 +96,7 @@ customize with their own values, along with the default values.
 | `resources.memory`       | 100Mi                                                                                                                         | memory qouta for the Pod                         |
 | `outputDir`              | empty string                                                                                                                  | host directory for memtierd.output files             |
 | `nri.patchRuntimeConfig` | false                                                                                                                         | enable NRI in containerd or CRI-O                    |
+| `nri.pluginIndex`        | 45                                                                                                                            | NRI plugin index to register with                    |
 | `initImage.name`         | [ghcr.io/containers/nri-plugins/config-manager](https://ghcr.io/containers/nri-plugins/config-manager)                        | init container image name                            |
 | `initImage.tag`          | unstable                                                                                                                      | init container image tag                             |
 | `initImage.pullPolicy`   | Always                                                                                                                        | init container image pull policy                     |

--- a/deployment/helm/memtierd/templates/daemonset.yaml
+++ b/deployment/helm/memtierd/templates/daemonset.yaml
@@ -48,7 +48,7 @@ spec:
           command:
             - nri-memtierd
             - --idx
-            - "45"
+            - "{{ printf "%02d" .Values.nri.pluginIndex }}"
             - --config
             - /etc/nri/memtierd/config.yaml
             {{- if .Values.outputDir }}

--- a/deployment/helm/memtierd/values.scheme.json
+++ b/deployment/helm/memtierd/values.scheme.json
@@ -39,6 +39,23 @@
                     "type": "integer"
                 }
             }
+        },
+        "nri": {
+            "type": "object",
+            "required": [
+                "patchRuntimeConfig",
+                "pluginIndex"
+            ],
+            "properties": {
+                "patchRuntimeConfig": {
+                    "type": "boolean"
+                },
+                "pluginIndex": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 99
+                }
+            }
         }
     }
  }

--- a/deployment/helm/memtierd/values.yaml
+++ b/deployment/helm/memtierd/values.yaml
@@ -16,6 +16,7 @@ outputDir: ""
 
 nri:
   patchRuntimeConfig: false
+  pluginIndex: 45
 
 initContainerImage:
   name: ghcr.io/containers/nri-plugins/nri-config-manager

--- a/deployment/helm/sgx-epc/README.md
+++ b/deployment/helm/sgx-epc/README.md
@@ -96,8 +96,8 @@ customize with their own values, along with the default values.
 | `resources.cpu`          | 25m                                                                                                                           | cpu resources for the Pod                            |
 | `resources.memory`       | 100Mi                                                                                                                         | memory qouta for the Pod                         |
 | `nri.patchRuntimeConfig` | false                                                                                                                         | enable NRI in containerd or CRI-O                    |
-| `initImage.name`         | [ghcr.io/containers/nri-plugins/config-manager](https://ghcr.io/containers/nri-plugins/config-manager)                                             |
-| init container image name                          |
+| `nri.pluginIndex`        | 40                                                                                                                            | NRI plugin index to register with                    |
+| `initImage.name`         | [ghcr.io/containers/nri-plugins/config-manager](https://ghcr.io/containers/nri-plugins/config-manager)                        | init container image name                            |
 | `initImage.tag`          | unstable                                                                                                                      | init container image tag                             |
 | `initImage.pullPolicy`   | Always                                                                                                                        | init container image pull policy                     |
 | `tolerations`            | []                                                                                                                            | specify taint toleration key, operator and effect    |

--- a/deployment/helm/sgx-epc/templates/daemonset.yaml
+++ b/deployment/helm/sgx-epc/templates/daemonset.yaml
@@ -48,7 +48,7 @@ spec:
           command:
             - nri-sgx-epc
             - --idx
-            - "40"
+            - "{{ printf "%02d" .Values.nri.pluginIndex }}"
           image: {{ .Values.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:

--- a/deployment/helm/sgx-epc/values.scheme.json
+++ b/deployment/helm/sgx-epc/values.scheme.json
@@ -39,6 +39,23 @@
                     "type": "integer"
                 }
             }
+        },
+        "nri": {
+            "type": "object",
+            "required": [
+                "patchRuntimeConfig",
+                "pluginIndex"
+            ],
+            "properties": {
+                "patchRuntimeConfig": {
+                    "type": "boolean"
+                },
+                "pluginIndex": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 99
+                }
+            }
         }
     }
  }

--- a/deployment/helm/sgx-epc/values.yaml
+++ b/deployment/helm/sgx-epc/values.yaml
@@ -14,6 +14,7 @@ resources:
 
 nri:
   patchRuntimeConfig: false
+  pluginIndex: 40
 
 initContainerImage:
   name: ghcr.io/containers/nri-plugins/nri-config-manager

--- a/deployment/helm/template/README.md
+++ b/deployment/helm/template/README.md
@@ -98,6 +98,7 @@ customize with their own values, along with the default values.
 | `hostPort`               | 8891                                                                                                                          | metrics port to expose on the host                   |
 | `config`                 | see [helm chart values](tree:/deployment/helm/template/values.yaml) for the default configuration                       | plugin configuration data                            |
 | `nri.patchRuntimeConfig` | false                                                                                                                         | enable NRI in containerd or CRI-O                    |
+| `nri.pluginIndex`        | 90                                                                                                                            | NRI plugin index to register with                    |
 | `initImage.name`         | [ghcr.io/containers/nri-plugins/config-manager](https://ghcr.io/containers/nri-plugins/config-manager)                                | init container image name                            |
 | `initImage.tag`          | unstable                                                                                                                      | init container image tag                             |
 | `initImage.pullPolicy`   | Always                                                                                                                        | init container image pull policy                     |

--- a/deployment/helm/template/templates/daemonset.yaml
+++ b/deployment/helm/template/templates/daemonset.yaml
@@ -47,6 +47,8 @@ spec:
             - /tmp/nri-resource-policy.pid
             - -metrics-interval
             - 5s
+            - --nri-plugin-index
+            - "{{ printf "%02d" .Values.nri.pluginIndex }}"
           ports:
             - containerPort: 8891
               protocol: TCP

--- a/deployment/helm/template/values.scheme.json
+++ b/deployment/helm/template/values.scheme.json
@@ -41,6 +41,23 @@
                 }
             }
         },
+        "nri": {
+            "type": "object",
+            "required": [
+                "patchRuntimeConfig",
+                "pluginIndex"
+            ],
+            "properties": {
+                "patchRuntimeConfig": {
+                    "type": "boolean"
+                },
+                "pluginIndex": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 99
+                }
+            }
+        },
         "hostPort": {
             "type": "integer"
         }

--- a/deployment/helm/template/values.yaml
+++ b/deployment/helm/template/values.yaml
@@ -30,6 +30,7 @@ resources:
 
 nri:
   patchRuntimeConfig: false
+  nriPluginIndex: 90
 
 initContainerImage:
   name: ghcr.io/containers/nri-plugins/nri-config-manager

--- a/deployment/helm/topology-aware/README.md
+++ b/deployment/helm/topology-aware/README.md
@@ -99,6 +99,7 @@ customize with their own values, along with the default values.
 | `hostPort`               | 8891                                                                                                                          | metrics port to expose on the host                   |
 | `config`                 | see [helm chart values](tree:/deployment/helm/topology-aware/values.yaml) for the default configuration                       | plugin configuration data                            |
 | `nri.patchRuntimeConfig` | false                                                                                                                         | enable NRI in containerd or CRI-O                    |
+| `nri.pluginIndex`        | 90                                                                                                                            | NRI plugin index to register with                    |
 | `initImage.name`         | [ghcr.io/containers/nri-plugins/config-manager](https://ghcr.io/containers/nri-plugins/config-manager)                        | init container image name                            |
 | `initImage.tag`          | unstable                                                                                                                      | init container image tag                             |
 | `initImage.pullPolicy`   | Always                                                                                                                        | init container image pull policy                     |

--- a/deployment/helm/topology-aware/templates/daemonset.yaml
+++ b/deployment/helm/topology-aware/templates/daemonset.yaml
@@ -54,6 +54,8 @@ spec:
             - /tmp/nri-resource-policy.pid
             - -metrics-interval
             - 5s
+            - --nri-plugin-index
+            - "{{ printf "%02d" .Values.nri.pluginIndex }}"
           ports:
             - containerPort: 8891
               protocol: TCP

--- a/deployment/helm/topology-aware/values.scheme.json
+++ b/deployment/helm/topology-aware/values.scheme.json
@@ -41,6 +41,23 @@
                 }
             }
         },
+        "nri": {
+            "type": "object",
+            "required": [
+                "patchRuntimeConfig",
+                "pluginIndex"
+            ],
+            "properties": {
+                "patchRuntimeConfig": {
+                    "type": "boolean"
+                },
+                "pluginIndex": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 99
+                }
+            }
+        },
         "hostPort": {
             "type": "integer"
         }

--- a/deployment/helm/topology-aware/values.yaml
+++ b/deployment/helm/topology-aware/values.yaml
@@ -30,6 +30,7 @@ resources:
 
 nri:
   patchRuntimeConfig: false
+  pluginIndex: 90
 
 initContainerImage:
   name: ghcr.io/containers/nri-plugins/nri-config-manager


### PR DESCRIPTION
Update helm charts to allow setting the index our plugins use to register with NRI. The plugin-specific defaults remain the same.