### PR TITLE
[release-0.3/#231] fixes: rename default config group label, support/fall back to deprecated labels.

### DIFF
--- a/deployment/helm/balloons/README.md
+++ b/deployment/helm/balloons/README.md
@@ -97,6 +97,7 @@ customize with their own values, along with the default values.
 | `resources.memory`       | 512Mi                                                                                                                         | memory qouta for the Pod                             |
 | `hostPort`               | 8891                                                                                                                          | metrics port to expose on the host                   |
 | `config`                 | see [helm chart values](tree:/deployment/helm/balloons/values.yaml) for the default configuration                       | plugin configuration data                            |
+| `configGroupLabel`       | config.nri/group                                                                                                        | node label for grouping configuration                |
 | `nri.patchRuntimeConfig` | false                                                                                                                         | enable NRI in containerd or CRI-O                    |
 | `nri.pluginIndex`        | 90                                                                                                                            | NRI plugin index to register with                    |
 | `initImage.name`         | [ghcr.io/containers/nri-plugins/config-manager](https://ghcr.io/containers/nri-plugins/config-manager)                        | init container image name                            |

--- a/deployment/helm/balloons/templates/daemonset.yaml
+++ b/deployment/helm/balloons/templates/daemonset.yaml
@@ -56,6 +56,10 @@ spec:
             - 5s
             - --nri-plugin-index
             - "{{ printf "%02d" .Values.nri.pluginIndex }}"
+            {{- if .Values.configGroupLabel }}
+            - --config-group-label
+            - {{ .Values.configGroupLabel }}
+            {{- end }}
           ports:
             - containerPort: 8891
               protocol: TCP

--- a/deployment/helm/balloons/values.schema.json
+++ b/deployment/helm/balloons/values.schema.json
@@ -44,6 +44,9 @@
                 }
             }
         },
+        "configGroupLabel": {
+            "type": "string"
+        },
         "resources": {
             "type": "object",
             "required": [

--- a/deployment/helm/balloons/values.yaml
+++ b/deployment/helm/balloons/values.yaml
@@ -31,6 +31,8 @@ config:
     reportPeriod: 60s
     samplingRatePerMillion: 0
 
+# configGroupLabel: config.nri/group
+
 plugin-test:
   enableAPIs: false
 

--- a/deployment/helm/template/README.md
+++ b/deployment/helm/template/README.md
@@ -97,6 +97,7 @@ customize with their own values, along with the default values.
 | `resources.memory`       | 512Mi                                                                                                                         | memory qouta for the Pod                             |
 | `hostPort`               | 8891                                                                                                                          | metrics port to expose on the host                   |
 | `config`                 | see [helm chart values](tree:/deployment/helm/template/values.yaml) for the default configuration                       | plugin configuration data                            |
+| `configGroupLabel`       | config.nri/group                                                                                                        | node label for grouping configuration                |
 | `nri.patchRuntimeConfig` | false                                                                                                                         | enable NRI in containerd or CRI-O                    |
 | `nri.pluginIndex`        | 90                                                                                                                            | NRI plugin index to register with                    |
 | `initImage.name`         | [ghcr.io/containers/nri-plugins/config-manager](https://ghcr.io/containers/nri-plugins/config-manager)                                | init container image name                            |

--- a/deployment/helm/template/templates/daemonset.yaml
+++ b/deployment/helm/template/templates/daemonset.yaml
@@ -49,6 +49,10 @@ spec:
             - 5s
             - --nri-plugin-index
             - "{{ printf "%02d" .Values.nri.pluginIndex }}"
+            {{- if .Values.configGroupLabel }}
+            - --config-group-label
+            - {{ .Values.configGroupLabel }}
+            {{- end }}
           ports:
             - containerPort: 8891
               protocol: TCP

--- a/deployment/helm/template/values.schema.json
+++ b/deployment/helm/template/values.schema.json
@@ -44,6 +44,9 @@
                 }
             }
         },
+        "configGroupLabel": {
+            "type": "string"
+        },
         "resources": {
             "type": "object",
             "required": [

--- a/deployment/helm/template/values.yaml
+++ b/deployment/helm/template/values.yaml
@@ -19,6 +19,8 @@ config:
     reportPeriod: 60s
     samplingRatePerMillion: 0
 
+# configGroupLabel: config.nri/group
+
 plugin-test:
     enableAPIs: false
 

--- a/deployment/helm/topology-aware/README.md
+++ b/deployment/helm/topology-aware/README.md
@@ -98,6 +98,7 @@ customize with their own values, along with the default values.
 | `resources.memory`       | 512Mi                                                                                                                         | memory qouta for the Pod                             |
 | `hostPort`               | 8891                                                                                                                          | metrics port to expose on the host                   |
 | `config`                 | see [helm chart values](tree:/deployment/helm/topology-aware/values.yaml) for the default configuration                       | plugin configuration data                            |
+| `configGroupLabel`       | config.nri/group                                                                                                        | node label for grouping configuration                |
 | `nri.patchRuntimeConfig` | false                                                                                                                         | enable NRI in containerd or CRI-O                    |
 | `nri.pluginIndex`        | 90                                                                                                                            | NRI plugin index to register with                    |
 | `initImage.name`         | [ghcr.io/containers/nri-plugins/config-manager](https://ghcr.io/containers/nri-plugins/config-manager)                        | init container image name                            |

--- a/deployment/helm/topology-aware/templates/daemonset.yaml
+++ b/deployment/helm/topology-aware/templates/daemonset.yaml
@@ -56,6 +56,10 @@ spec:
             - 5s
             - --nri-plugin-index
             - "{{ printf "%02d" .Values.nri.pluginIndex }}"
+            {{- if .Values.configGroupLabel }}
+            - --config-group-label
+            - {{ .Values.configGroupLabel }}
+            {{- end }}
           ports:
             - containerPort: 8891
               protocol: TCP

--- a/deployment/helm/topology-aware/values.schema.json
+++ b/deployment/helm/topology-aware/values.schema.json
@@ -44,6 +44,9 @@
                 }
             }
         },
+        "configGroupLabel": {
+            "type": "string"
+        },
         "resources": {
             "type": "object",
             "required": [

--- a/deployment/helm/topology-aware/values.yaml
+++ b/deployment/helm/topology-aware/values.yaml
@@ -19,6 +19,8 @@ config:
     reportPeriod: 60s
     samplingRatePerMillion: 0
 
+# configGroupLabel: config.nri/group
+
 plugin-test:
   enableAPIs: false
 

--- a/docs/resource-policy/configuration.md
+++ b/docs/resource-policy/configuration.md
@@ -15,7 +15,7 @@ The names of these custom resources are
 3. `default`: secondary: secondary default node configuration
 
 You can assign a node to a configuration group by setting the
-`group.config.nri` label on the node to the name of the configuration
+`config.nri/group` label on the node to the name of the configuration
 group. You can remove a node from its group by deleting the node group
 label.
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -211,6 +211,16 @@ func (a *Agent) Start(notifyFn NotifyFn) error {
 			}
 			if e.Type == watch.Added || e.Type == watch.Modified {
 				group, _ := e.Object.(*corev1.Node).Labels[a.groupLabel]
+				if group == "" {
+					for _, l := range deprecatedGroupLabels {
+						group, _ = e.Object.(*corev1.Node).Labels[l]
+						if group != "" {
+							log.Warnf("Using DEPRECATED config group label %q", l)
+							log.Warnf("Please switch to using label %q instead", a.groupLabel)
+							break
+						}
+					}
+				}
 				if err = a.setupGroupConfigWatch(group); err != nil {
 					log.Errorf("%v", err)
 				}
@@ -607,6 +617,11 @@ var (
 	defaultGroupLabel string
 	defaultKubeConfig string
 	defaultConfigFile string
+
+	deprecatedGroupLabels = []string{
+		"group.config.nri",
+		"resource-policy.nri.io/group",
+	}
 )
 
 func init() {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -118,7 +118,7 @@ var (
 // always used for the node. Otherwise either a group-specific or the default
 // configuration is used depending on whether the node belongs to a group. A
 // node can be assigned to a group by setting the group label on the node. By
-// default this group label is 'group.config.nri'.
+// default this group label is 'config.nri/group'.
 type Agent struct {
 	nodeName   string // kubernetes node name, defaults to $NODE_NAME
 	namespace  string // config resource namespace
@@ -610,7 +610,7 @@ var (
 )
 
 func init() {
-	groupLabel := "group." + cfgapi.SchemeGroupVersion.Group
+	groupLabel := cfgapi.SchemeGroupVersion.Group + "/group"
 
 	flag.StringVar(&defaultNamespace, "config-namespace", "kube-system",
 		"namespace for configuration CustomResources")

--- a/sample-configs/balloons-config.yaml
+++ b/sample-configs/balloons-config.yaml
@@ -20,7 +20,7 @@ metadata:
   #   name: group.group-0
   # Then label the nodes and remove any node-specific configuration:
   #   for node in node-{A,B,C}; do
-  #     kubectl label node $node group.config.nri=group-0
+  #     kubectl label node $node config.nri/group=group-0
   #     kubectl delete -n $NAMESPACE balloonspolicies.config.nri/$node || :
   #   done
   #

--- a/sample-configs/template-config.yaml
+++ b/sample-configs/template-config.yaml
@@ -20,7 +20,7 @@ metadata:
   #   name: group.group-0
   # Then label the nodes and remove any node-specific configuration:
   #   for node in node-{A,B,C}; do
-  #     kubectl label node $node group.config.nri=group-0
+  #     kubectl label node $node config.nri/group=group-0
   #     kubectl delete -n $NAMESPACE balloonspolicies.config.nri/$node || :
   #   done
   #

--- a/sample-configs/topologyaware-config.yaml
+++ b/sample-configs/topologyaware-config.yaml
@@ -20,7 +20,7 @@ metadata:
   #   name: group.group-0
   # Then label the nodes and remove any node-specific configuration:
   #   for node in node-{A,B,C}; do
-  #     kubectl label node $node group.config.nri=group-0
+  #     kubectl label node $node config.nri/group=group-0
   #     kubectl delete -n $NAMESPACE balloonspolicies.config.nri/$node || :
   #   done
   #


### PR DESCRIPTION
Backport of #231 to the 0.3 release branch.