### PR TITLE
instrumentation: fix resource creation, use parent-based sampler.

### DIFF
--- a/config/crd/bases/config.nri_balloonspolicies.yaml
+++ b/config/crd/bases/config.nri_balloonspolicies.yaml
@@ -222,8 +222,7 @@ spec:
                       tracing data collection. Endpoints are specified as full URLs,
                       or as plain URL schemes which then imply scheme-specific defaults.
                       The supported schemes and their default URLs are: - otlp-http,
-                      http: localhost:4318 - otlp-grpc, grpc: localhost:4317 - jaeger:
-                      $OTEL_EXPORTER_JAEGER_ENDPOINT or http://localhost:14268/api/traces'
+                      http: localhost:4318 - otlp-grpc, grpc: localhost:4317'
                     example: otlp-http://localhost:4318
                     type: string
                 type: object

--- a/config/crd/bases/config.nri_templatepolicies.yaml
+++ b/config/crd/bases/config.nri_templatepolicies.yaml
@@ -102,8 +102,7 @@ spec:
                       tracing data collection. Endpoints are specified as full URLs,
                       or as plain URL schemes which then imply scheme-specific defaults.
                       The supported schemes and their default URLs are: - otlp-http,
-                      http: localhost:4318 - otlp-grpc, grpc: localhost:4317 - jaeger:
-                      $OTEL_EXPORTER_JAEGER_ENDPOINT or http://localhost:14268/api/traces'
+                      http: localhost:4318 - otlp-grpc, grpc: localhost:4317'
                     example: otlp-http://localhost:4318
                     type: string
                 type: object

--- a/config/crd/bases/config.nri_topologyawarepolicies.yaml
+++ b/config/crd/bases/config.nri_topologyawarepolicies.yaml
@@ -114,8 +114,7 @@ spec:
                       tracing data collection. Endpoints are specified as full URLs,
                       or as plain URL schemes which then imply scheme-specific defaults.
                       The supported schemes and their default URLs are: - otlp-http,
-                      http: localhost:4318 - otlp-grpc, grpc: localhost:4317 - jaeger:
-                      $OTEL_EXPORTER_JAEGER_ENDPOINT or http://localhost:14268/api/traces'
+                      http: localhost:4318 - otlp-grpc, grpc: localhost:4317'
                     example: otlp-http://localhost:4318
                     type: string
                 type: object

--- a/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
+++ b/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
@@ -222,8 +222,7 @@ spec:
                       tracing data collection. Endpoints are specified as full URLs,
                       or as plain URL schemes which then imply scheme-specific defaults.
                       The supported schemes and their default URLs are: - otlp-http,
-                      http: localhost:4318 - otlp-grpc, grpc: localhost:4317 - jaeger:
-                      $OTEL_EXPORTER_JAEGER_ENDPOINT or http://localhost:14268/api/traces'
+                      http: localhost:4318 - otlp-grpc, grpc: localhost:4317'
                     example: otlp-http://localhost:4318
                     type: string
                 type: object

--- a/deployment/helm/template/crds/config.nri_templatepolicies.yaml
+++ b/deployment/helm/template/crds/config.nri_templatepolicies.yaml
@@ -102,8 +102,7 @@ spec:
                       tracing data collection. Endpoints are specified as full URLs,
                       or as plain URL schemes which then imply scheme-specific defaults.
                       The supported schemes and their default URLs are: - otlp-http,
-                      http: localhost:4318 - otlp-grpc, grpc: localhost:4317 - jaeger:
-                      $OTEL_EXPORTER_JAEGER_ENDPOINT or http://localhost:14268/api/traces'
+                      http: localhost:4318 - otlp-grpc, grpc: localhost:4317'
                     example: otlp-http://localhost:4318
                     type: string
                 type: object

--- a/deployment/helm/topology-aware/crds/config.nri_topologyawarepolicies.yaml
+++ b/deployment/helm/topology-aware/crds/config.nri_topologyawarepolicies.yaml
@@ -114,8 +114,7 @@ spec:
                       tracing data collection. Endpoints are specified as full URLs,
                       or as plain URL schemes which then imply scheme-specific defaults.
                       The supported schemes and their default URLs are: - otlp-http,
-                      http: localhost:4318 - otlp-grpc, grpc: localhost:4317 - jaeger:
-                      $OTEL_EXPORTER_JAEGER_ENDPOINT or http://localhost:14268/api/traces'
+                      http: localhost:4318 - otlp-grpc, grpc: localhost:4317'
                     example: otlp-http://localhost:4318
                     type: string
                 type: object

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/stretchr/testify v1.8.4
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/otel v1.19.0
-	go.opentelemetry.io/otel/exporters/jaeger v1.17.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.19.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.19.0
 	go.opentelemetry.io/otel/sdk v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -356,7 +356,6 @@ github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -385,8 +384,6 @@ go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/otel v1.19.0 h1:MuS/TNf4/j4IXsZuJegVzI1cwut7Qc00344rgH7p8bs=
 go.opentelemetry.io/otel v1.19.0/go.mod h1:i0QyjOq3UPoTzff0PJB2N66fb4S0+rSbSB15/oyH9fY=
-go.opentelemetry.io/otel/exporters/jaeger v1.17.0 h1:D7UpUy2Xc2wsi1Ras6V40q806WM07rqoCWzXu7Sqy+4=
-go.opentelemetry.io/otel/exporters/jaeger v1.17.0/go.mod h1:nPCqOnEH9rNLKqH/+rrUjiMzHJdV1BlpKcTwRTyKkKI=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0 h1:Mne5On7VWdx7omSrSSZvM4Kw7cS7NQkOOmLcgscI51U=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0/go.mod h1:IPtUMKL4O3tH5y+iXVyAXqpAwMuzC1IrxVS81rummfE=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.19.0 h1:3d+S281UTjM+AbF31XSOYn1qXn3BgIdWl8HNEpx08Jk=

--- a/pkg/apis/config/v1alpha1/instrumentation/config.go
+++ b/pkg/apis/config/v1alpha1/instrumentation/config.go
@@ -30,7 +30,6 @@ type Config struct {
 	// URLs are:
 	//   - otlp-http, http: localhost:4318
 	//   - otlp-grpc, grpc: localhost:4317
-	//   - jaeger: $OTEL_EXPORTER_JAEGER_ENDPOINT or http://localhost:14268/api/traces
 	// +optional
 	// +kubebuilder:example="otlp-http://localhost:4318"
 	TracingCollector string `json:"tracingCollector,omitempty"`

--- a/pkg/instrumentation/tracing/tracing.go
+++ b/pkg/instrumentation/tracing/tracing.go
@@ -127,25 +127,19 @@ func (t *tracing) start(options ...Option) error {
 	log.Info("starting tracing exporter...")
 
 	hostname, _ := os.Hostname()
-	resource, err := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
-			append(
-				[]attribute.KeyValue{
-					semconv.ServiceName(t.service),
-					semconv.HostNameKey.String(hostname),
-					semconv.ProcessPIDKey.Int64(int64(os.Getpid())),
-					attribute.String("Version", version.Version),
-					attribute.String("Build", version.Build),
-				},
-				t.identity...,
-			)...,
-		),
+	resource := resource.NewWithAttributes(
+		semconv.SchemaURL,
+		append(
+			[]attribute.KeyValue{
+				semconv.ServiceName(t.service),
+				semconv.HostNameKey.String(hostname),
+				semconv.ProcessPIDKey.Int64(int64(os.Getpid())),
+				attribute.String("Version", version.Version),
+				attribute.String("Build", version.Build),
+			},
+			t.identity...,
+		)...,
 	)
-	if err != nil {
-		return fmt.Errorf("failed to create tracing resource: %w", err)
-	}
 
 	exporter, err := getExporter(t.endpoint)
 	if err != nil {

--- a/pkg/instrumentation/tracing/tracing.go
+++ b/pkg/instrumentation/tracing/tracing.go
@@ -152,7 +152,7 @@ func (t *tracing) start(options ...Option) error {
 			sdktrace.NewBatchSpanProcessor(exporter),
 		),
 		sdktrace.WithSampler(
-			sdktrace.TraceIDRatioBased(t.sampling),
+			sdktrace.ParentBased(sdktrace.TraceIDRatioBased(t.sampling)),
 		),
 	)
 


### PR DESCRIPTION
This patch fixes a few annoyances in our current OpenTelemetry instrumentation code. In particular, it
- drops support for the discontinued Jaeger-specific exporter
- avoid using resource.Merge() for creating our otel resource
- uses a parent-based probabilistic sampler to span sampling