### PR TITLE
[release-0.3/#240] operator: ensure to kustomize operator manifests before local deployment 

### DIFF
--- a/deployment/operator/Makefile
+++ b/deployment/operator/Makefile
@@ -181,13 +181,14 @@ uninstall: copy-crds kustomize ## Uninstall CRDs from the K8s cluster specified 
 	$(MAKE) cleanup-crds
 
 .PHONY: deploy
-deploy: kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+deploy: copy-crds kustomize kustomizations ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMAGE}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
+	$(MAKE) cleanup-crds
 
 OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH := $(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')

--- a/deployment/operator/README.md
+++ b/deployment/operator/README.md
@@ -12,7 +12,7 @@ nri-plugin specified in the NriPluginDeployment.
 
 Build the operator image and push it to some registry
 ```shell
-make -C deployment/operator docker-build docker-push IMG="my-registry.com/nri-plugins-operator:unstable"
+make -C deployment/operator docker-build docker-push IMAGE="my-registry.com/nri-plugins-operator:unstable"
 ```
 
 Deploy the operator in your cluster


### PR DESCRIPTION
Backport of #240 

Ensure proper deployment by invoking copy-crds and kustomizations makefile targets alongside the deploy Makefile target. This change guarantees the presence of all necessary CRDs and ensures that kustomization files are appropriately modified before initiating the operator pod.
