### PR TITLE
[release-0.3] kustomize: replace patchesStrategicMerge by patches

### DIFF
--- a/deployment/operator/config/default/kustomization.yaml
+++ b/deployment/operator/config/default/kustomization.yaml
@@ -21,10 +21,8 @@ resources:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
-
-
+patches:
+- path: manager_auth_proxy_patch.yaml


### PR DESCRIPTION
Use `patches` instead of `patchesStrategicMerge` with kustomize as `patchesStrategicMerge` is deprecated.

Backport of #242