### PR TITLE
helm: fix invalid nri-plugin-index that causes plugins to crash

### DIFF
--- a/deployment/helm/balloons/templates/daemonset.yaml
+++ b/deployment/helm/balloons/templates/daemonset.yaml
@@ -55,7 +55,7 @@ spec:
             - -metrics-interval
             - 5s
             - --nri-plugin-index
-            - "{{ printf "%02d" .Values.nri.pluginIndex }}"
+            - "{{ printf "%02.0f" .Values.nri.pluginIndex }}"
             {{- if .Values.configGroupLabel }}
             - --config-group-label
             - {{ .Values.configGroupLabel }}

--- a/deployment/helm/memory-qos/templates/daemonset.yaml
+++ b/deployment/helm/memory-qos/templates/daemonset.yaml
@@ -47,7 +47,7 @@ spec:
           command:
             - nri-memory-qos
             - --idx
-            - "{{ printf "%02d" .Values.nri.pluginIndex }}"
+            - "{{ printf "%02.0f" .Values.nri.pluginIndex }}"
             - --config
             - /etc/nri/memory-qos/config.yaml
             - -v

--- a/deployment/helm/memtierd/templates/daemonset.yaml
+++ b/deployment/helm/memtierd/templates/daemonset.yaml
@@ -48,7 +48,7 @@ spec:
           command:
             - nri-memtierd
             - --idx
-            - "{{ printf "%02d" .Values.nri.pluginIndex }}"
+            - "{{ printf "%02.0f" .Values.nri.pluginIndex }}"
             - --config
             - /etc/nri/memtierd/config.yaml
             {{- if .Values.outputDir }}

--- a/deployment/helm/sgx-epc/templates/daemonset.yaml
+++ b/deployment/helm/sgx-epc/templates/daemonset.yaml
@@ -48,7 +48,7 @@ spec:
           command:
             - nri-sgx-epc
             - --idx
-            - "{{ printf "%02d" .Values.nri.pluginIndex }}"
+            - "{{ printf "%02.0f" .Values.nri.pluginIndex }}"
           image: {{ .Values.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:

--- a/deployment/helm/template/templates/daemonset.yaml
+++ b/deployment/helm/template/templates/daemonset.yaml
@@ -48,7 +48,7 @@ spec:
             - -metrics-interval
             - 5s
             - --nri-plugin-index
-            - "{{ printf "%02d" .Values.nri.pluginIndex }}"
+            - "{{ printf "%02.0f" .Values.nri.pluginIndex }}"
             {{- if .Values.configGroupLabel }}
             - --config-group-label
             - {{ .Values.configGroupLabel }}

--- a/deployment/helm/topology-aware/templates/daemonset.yaml
+++ b/deployment/helm/topology-aware/templates/daemonset.yaml
@@ -55,7 +55,7 @@ spec:
             - -metrics-interval
             - 5s
             - --nri-plugin-index
-            - "{{ printf "%02d" .Values.nri.pluginIndex }}"
+            - "{{ printf "%02.0f" .Values.nri.pluginIndex }}"
             {{- if .Values.configGroupLabel }}
             - --config-group-label
             - {{ .Values.configGroupLabel }}


### PR DESCRIPTION
Original printf format "%02d" argument for --nri-plugin-index produced argument value "%!d(float64=90)", if nri.pluginIndex was 90. As helm handles the value 90 as float64, use format "%02.0f" instead.