### PR TITLE
cache: support annotations to preserve CPU and memory pinning

### DIFF
--- a/pkg/resmgr/cache/cache.go
+++ b/pkg/resmgr/cache/cache.go
@@ -59,6 +59,11 @@ const (
 
 	// TopologyHintsKey can be used to opt out from automatic topology hint generation.
 	TopologyHintsKey = "topologyhints" + "." + kubernetes.ResmgrKeyNamespace
+
+	// PreserveCpuKey means that CPU resources should not be touched.
+	PreserveCpuKey = "cpu.preserve." + kubernetes.ResmgrKeyNamespace
+	// PreserveMemoryKey means that memory resources should not be touched.
+	PreserveMemoryKey = "memory.preserve." + kubernetes.ResmgrKeyNamespace
 )
 
 // PodState is the pod state in the runtime.
@@ -244,6 +249,13 @@ type Container interface {
 	GetMemoryLimit() int64
 	// GetMemorySwap gets the swap limit in bytes for the container.
 	GetMemorySwap() int64
+
+	// PreserveCpuResources() returns true if CPU resources of the
+	// container must not be changed.
+	PreserveCpuResources() bool
+	// PreserveMemoryResources() returns true if memory resources
+	// of the container must not be changed.
+	PreserveMemoryResources() bool
 
 	// GetPendingAdjusmentn clears and returns any pending adjustment for the container.
 	GetPendingAdjustment() *nri.ContainerAdjustment

--- a/pkg/resmgr/cache/container.go
+++ b/pkg/resmgr/cache/container.go
@@ -761,6 +761,16 @@ func (c *container) GetMemorySwap() int64 {
 	return c.Ctr.GetLinux().GetResources().GetMemory().GetSwap().GetValue()
 }
 
+func (c *container) PreserveCpuResources() bool {
+	value, ok := c.GetEffectiveAnnotation(PreserveCpuKey)
+	return ok && value == "true"
+}
+
+func (c *container) PreserveMemoryResources() bool {
+	value, ok := c.GetEffectiveAnnotation(PreserveMemoryKey)
+	return ok && value == "true"
+}
+
 var (
 	// More complext rules, for Kubelet secrets and config maps
 	ignoredTopologyPathRegexps = []*regexp.Regexp{


### PR DESCRIPTION
Add "ignore" annotation to enable special containers to opt out from resource allocation of any resource policy. Resource policies can find these containers and their resource requirements from the cache, but they are not requested to allocate, update or release resources of these containers during their lifecycle and on policy Sync().