### PR TITLE
helm: add workaround for Helm int/float snafu.

### DIFF
--- a/deployment/helm/balloons/templates/daemonset.yaml
+++ b/deployment/helm/balloons/templates/daemonset.yaml
@@ -55,7 +55,7 @@ spec:
             - -metrics-interval
             - 5s
             - --nri-plugin-index
-            - "{{ printf "%02d" .Values.nri.pluginIndex }}"
+            - "{{ .Values.nri.pluginIndex | int | printf "%02d"  }}"
             {{- if .Values.configGroupLabel }}
             - --config-group-label
             - {{ .Values.configGroupLabel }}

--- a/deployment/helm/memory-qos/templates/daemonset.yaml
+++ b/deployment/helm/memory-qos/templates/daemonset.yaml
@@ -47,7 +47,7 @@ spec:
           command:
             - nri-memory-qos
             - --idx
-            - "{{ printf "%02d" .Values.nri.pluginIndex }}"
+            - "{{ .Values.nri.pluginIndex | int | printf "%02d"  }}"
             - --config
             - /etc/nri/memory-qos/config.yaml
             - -v

--- a/deployment/helm/memtierd/templates/daemonset.yaml
+++ b/deployment/helm/memtierd/templates/daemonset.yaml
@@ -48,7 +48,7 @@ spec:
           command:
             - nri-memtierd
             - --idx
-            - "{{ printf "%02d" .Values.nri.pluginIndex }}"
+            - "{{ .Values.nri.pluginIndex | int | printf "%02d"  }}"
             - --config
             - /etc/nri/memtierd/config.yaml
             {{- if .Values.outputDir }}

--- a/deployment/helm/sgx-epc/templates/daemonset.yaml
+++ b/deployment/helm/sgx-epc/templates/daemonset.yaml
@@ -48,7 +48,7 @@ spec:
           command:
             - nri-sgx-epc
             - --idx
-            - "{{ printf "%02d" .Values.nri.pluginIndex }}"
+            - "{{ .Values.nri.pluginIndex | int | printf "%02d"  }}"
           image: {{ .Values.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:

--- a/deployment/helm/template/templates/daemonset.yaml
+++ b/deployment/helm/template/templates/daemonset.yaml
@@ -48,7 +48,7 @@ spec:
             - -metrics-interval
             - 5s
             - --nri-plugin-index
-            - "{{ printf "%02d" .Values.nri.pluginIndex }}"
+            - "{{ .Values.nri.pluginIndex | int | printf "%02d"  }}"
             {{- if .Values.configGroupLabel }}
             - --config-group-label
             - {{ .Values.configGroupLabel }}

--- a/deployment/helm/topology-aware/templates/daemonset.yaml
+++ b/deployment/helm/topology-aware/templates/daemonset.yaml
@@ -55,7 +55,7 @@ spec:
             - -metrics-interval
             - 5s
             - --nri-plugin-index
-            - "{{ printf "%02d" .Values.nri.pluginIndex }}"
+            - "{{ .Values.nri.pluginIndex | int | printf "%02d"  }}"
             {{- if .Values.configGroupLabel }}
             - --config-group-label
             - {{ .Values.configGroupLabel }}


### PR DESCRIPTION
Helm is struggling with a regression where integer values get converted to float64 and therefore fail to get later properly injected into templates. For us this hits our integer [nri.]pluginIndex values.

Add a workaround to first force plugin indices to integers before injecting them through templates.
See https://github.com/helm/helm/commit/44a81f63 for more details.

The other alternative considered was this in `values.schema.json`:
```
                "pluginIndex": {
                    "type": "string",
                    "pattern": "^[0-9][0-9]$"
                }
```
Since indices are integers and the above alternative would have also required us to always quote indices in `values.yaml`, this simpler choice of representing integer indices as integer values was chosen. 