### PR TITLE
Resize the reserved balloon

### DIFF
--- a/cmd/plugins/balloons/policy/cputree.go
+++ b/cmd/plugins/balloons/policy/cputree.go
@@ -71,6 +71,7 @@ type cpuTreeAllocatorOptions struct {
 	preferSpreadOnPhysicalCores bool
 	preferCloseToDevices        []string
 	preferFarFromDevices        []string
+	virtDevCpusets              map[string][]cpuset.CPUSet
 }
 
 var emptyCpuSet = cpuset.New()
@@ -401,9 +402,13 @@ func (t *cpuTreeNode) SplitLevel(splitLevel CPUTopologyLevel, cpuClassifier func
 // CPU tree branch.
 func (t *cpuTreeNode) NewAllocator(options cpuTreeAllocatorOptions) *cpuTreeAllocator {
 	ta := &cpuTreeAllocator{
-		root:              t,
-		options:           options,
-		cacheCloseCpuSets: map[string][]cpuset.CPUSet{},
+		root:    t,
+		options: options,
+	}
+	if options.virtDevCpusets == nil {
+		ta.cacheCloseCpuSets = map[string][]cpuset.CPUSet{}
+	} else {
+		ta.cacheCloseCpuSets = options.virtDevCpusets
 	}
 	if options.preferSpreadOnPhysicalCores {
 		newTree := t.SplitLevel(CPUTopologyLevelNuma,

--- a/cmd/plugins/balloons/policy/fillmethod.go
+++ b/cmd/plugins/balloons/policy/fillmethod.go
@@ -53,12 +53,6 @@ const (
 	// but refuse to run the container if the balloon cannot be
 	// created.
 	FillNewBalloonMust
-	// FillReservedBalloon: put a container into the reserved
-	// balloon.
-	FillReservedBalloon
-	// FillDefaultBalloon: put a container into the default
-	// balloon.
-	FillDefaultBalloon
 )
 
 var fillMethodNames = map[FillMethod]string{
@@ -71,8 +65,6 @@ var fillMethodNames = map[FillMethod]string{
 	FillSamePod:         "same-pod",
 	FillNewBalloon:      "new-balloon",
 	FillNewBalloonMust:  "new-balloon-must",
-	FillDefaultBalloon:  "default-balloon",
-	FillReservedBalloon: "reserved-balloon",
 }
 
 // String stringifies a FillMethod

--- a/test/e2e/policies.test-suite/balloons/n4c16/test01-basic-placement/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test01-basic-placement/code.var.sh
@@ -12,7 +12,7 @@ cleanup() {
 cleanup
 
 # pod0: run on reserved CPUs
-namespace=kube-system CONTCOUNT=2 create balloons-busybox
+CPUREQ="" RESERVED_CPU=1 namespace=kube-system CONTCOUNT=2 create balloons-busybox
 report allowed
 verify 'cpus["pod0c0"] == cpus["pod0c1"]' \
        'len(cpus["pod0c0"]) == 1'

--- a/test/e2e/policies.test-suite/balloons/n4c16/test03-reserved/balloons-reserved.cfg
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test03-reserved/balloons-reserved.cfg
@@ -11,6 +11,7 @@ config:
       namespaces:
         - my-exact-name
       cpuClass: reserved-class
+      minCPUs: 1
     - name: default
       minCPUs: 1
     - name: full-core


### PR DESCRIPTION
This patch makes the built-in balloon types first-class citizens in their configurability and in CPU allocation order.