### PR TITLE
e2e: fix balloons test CPU frequencies

### DIFF
--- a/test/e2e/policies.test-suite/balloons/balloons-config.yaml.in
+++ b/test/e2e/policies.test-suite/balloons/balloons-config.yaml.in
@@ -65,15 +65,15 @@ spec:
     cpu:
       classes:
         default:
-          minFreq: ${CPU_DEFAULT_MIN:-800}
-          maxFreq: ${CPU_DEFAULT_MAX:-2800}
+          minFreq: ${CPU_DEFAULT_MIN:-800000}
+          maxFreq: ${CPU_DEFAULT_MAX:-2800000}
         classA:
-          minFreq: ${CPU_CLASSA_MIN:-900}
-          maxFreq: ${CPU_CLASSA_MAX:-2900}
+          minFreq: ${CPU_CLASSA_MIN:-900000}
+          maxFreq: ${CPU_CLASSA_MAX:-2900000}
         classB:
-          minFreq: ${CPU_CLASSB_MIN:-1000}
-          maxFreq: ${CPU_CLASSB_MAX:-3000}
+          minFreq: ${CPU_CLASSB_MIN:-1000000}
+          maxFreq: ${CPU_CLASSB_MAX:-3000000}
         classC:
-          minFreq: ${CPU_CLASSC_MIN:-1100}
-          maxFreq: ${CPU_CLASSC_MAX:-3100}
+          minFreq: ${CPU_CLASSC_MIN:-1100000}
+          maxFreq: ${CPU_CLASSC_MAX:-3100000}
           energyPerformancePreference: ${CPU_CLASSC_EPP:-1}

--- a/test/e2e/policies.test-suite/balloons/helm-config.yaml
+++ b/test/e2e/policies.test-suite/balloons/helm-config.yaml
@@ -59,19 +59,19 @@ config:
     cpu:
       classes:
         default:
-          minFreq: 800
-          maxFreq: 2800
+          minFreq: 800000
+          maxFreq: 2800000
         class2:
-          minFreq: 900
-          maxFreq: 2900
+          minFreq: 900000
+          maxFreq: 2900000
         class3:
-          minFreq: 1000
-          maxFreq: 3000
+          minFreq: 1000000
+          maxFreq: 3000000
         class4:
-          minFreq: 1100
-          maxFreq: 3100
+          minFreq: 1100000
+          maxFreq: 3100000
           energyPerformancePreference: 1
         class5:
-          minFreq: 1200
-          maxFreq: 3200
+          minFreq: 1200000
+          maxFreq: 3200000
           energyPerformancePreference: 2


### PR DESCRIPTION
Use kHZ instead of MHz in minFreq and maxFreq as required in the real interface. Using wrong units in the tests did not fail because configuring CPU frequencies with any values does not really work in our test VMs. However, using wrong units in tests is misleading for anyone who tries to use similar configuration on bare metal.