### PR TITLE
Makefile: stop image building on docker/compiler errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,9 +229,9 @@ image.%:
 	esac; \
 	bin=$(patsubst image.%,%,$@); \
 	tag=$(patsubst image.%,%,$@); \
-	    $(DOCKER_BUILD) . -f "$$dir/Dockerfile" \
+	$(DOCKER_BUILD) . -f "$$dir/Dockerfile" \
 	    --build-arg GO_VERSION=$(GO_VERSION) \
-	    -t $(IMAGE_REPO)$$tag:$(IMAGE_VERSION); \
+	    -t $(IMAGE_REPO)$$tag:$(IMAGE_VERSION) || exit $$?; \
 	NRI_IMAGE_INFO=`$(DOCKER) images --filter=reference=$${tag} --format '{{.ID}} {{.Repository}}:{{.Tag}} (created {{.CreatedSince}}, {{.CreatedAt}})' | head -n 1`; \
 	NRI_IMAGE_ID=`awk '{print $$1}' <<< "$${NRI_IMAGE_INFO}"`; \
 	NRI_IMAGE_REPOTAG=`awk '{print $$2}' <<< "$${NRI_IMAGE_INFO}"`; \


### PR DESCRIPTION
Lost some hair, if possible, when debugging an image in e2e vm with most recent tags on it, but still containing old code. New code had not compiled, but I failed to notice the error as `make images` happily passed.