### PR TITLE
github: bump azure/setup-helm action to v4

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4
         with:
           version: v3.11.2
 

--- a/.github/workflows/package-helm.yaml
+++ b/.github/workflows/package-helm.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4
 
       - name: Package Helm charts
         run: |

--- a/.github/workflows/publish-helm-charts.yaml
+++ b/.github/workflows/publish-helm-charts.yaml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4
 
       - name: Run chart publisher script
         run: ./scripts/build/helm-publisher.sh ${{ join(github.event.release.assets.*.browser_download_url, ' ') }} 


### PR DESCRIPTION
Get rid of warnings in CI logs.