### PR TITLE
.github: package and publish unstable Helm charts in image registry.

### DIFF
--- a/.github/workflows/package-helm.yaml
+++ b/.github/workflows/package-helm.yaml
@@ -4,12 +4,20 @@ on:
   push:
     tags:
       - "v*.*.*"
+    branches:
+      - main
 
 env:
   CHARTS_DIR: deployment/helm/
+  IS_RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') && 'true' || 'false' }}
+  UNSTABLE_CHARTS: unstable-helm-charts
+  REGISTRY: ghcr.io
+  REGISTRY_USER: ${{ github.repository_owner }}
+  REGISTRY_PATH: ${{ github.repository }}
 
 jobs:
   release:
+    if: ${{ github.env.IS_RELEASE == 'true' }}
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -20,7 +28,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4.0.0
 
-      - name: Package Helm charts
+      - name: Package Stable Helm Charts
         run: |
           find "$CHARTS_DIR" -name values.yaml | xargs -I '{}' \
               sed -e s"/pullPolicy:.*/pullPolicy: IfNotPresent/" -i '{}'
@@ -30,10 +38,66 @@ jobs:
             mv $SRC_FILE $DEST_FILE
           done
 
-      - name: Upload Helm packages to GitHub releases
+      - name: Upload Stable Helm Charts to GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           name: ${{ github.ref_name }}
           draft: true
           append_body: true
           files: nri-*helm-chart*.tgz
+
+  unstable:
+    concurrency:
+      group: unstable-helm-charts
+      cancel-in-progress: false
+    if: ${{ github.env.IS_RELEASE != 'true' }}
+    permissions:
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deep Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4.0.0
+
+      - name: Package Unstable Helm Charts
+        id: package-charts
+        run: |
+          # For unstable chart verison we use:
+          #   - chart version: x.y-unstable derived from the latest tag x.y.z
+          #   - image version: 'unstable'.
+          majmin="$(git describe | sed -E 's/v([0-9]*\.[0-9]*).*$/\1/')"
+          CHART_VERSION="${majmin}-unstable"
+          APP_VERSION=unstable
+          # Package charts
+          find "$CHARTS_DIR" -name values.yaml | xargs -I '{}' \
+              sed -e s"/pullPolicy:.*/pullPolicy: Always/" -i '{}'
+          helm package --version "$CHART_VERSION" --app-version $APP_VERSION "$CHARTS_DIR"/*
+          find "$CHARTS_DIR" -name values.yaml | xargs -I '{}' \
+              git checkout '{}'
+          mkdir ../$UNSTABLE_CHARTS
+          find . -name '*.tgz' -print | while read SRC_FILE; do
+            DEST_FILE=$(echo $SRC_FILE | sed 's/v/helm-chart-v/g')
+            mv -v $SRC_FILE ../$UNSTABLE_CHARTS/$DEST_FILE
+          done
+
+      - name: Log In To Registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+              helm registry login ${{ env.REGISTRY }}/${{ env.REGISTRY_PATH }} -u ${{ env.REGISTRY_USER }} --password-stdin
+
+      - name: Push Unstable Helm Charts To Registry
+        shell: bash
+        run: |
+          # Notes:
+          #   Currently we only publish unstable Helm charts from main/HEAD.
+          #   We have no active cleanup of old unstable charts in place. In
+          #   between new tags unstable chart have the same version, though.
+          pushd ../$UNSTABLE_CHARTS
+          for i in ./*.tgz; do
+              helm push $i oci://${{ env.REGISTRY }}/${{ env.REGISTRY_PATH }}
+          done
+          popd

--- a/docs/deployment/helm/index.md
+++ b/docs/deployment/helm/index.md
@@ -1,5 +1,7 @@
 # Helm
 
+## Stable Helm Charts
+
 All the available charts can be found in [artifacthub.io](https://artifacthub.io/packages/search?ts_query_web=nri&verified_publisher=true&official=true&sort=relevance&page=1).
 
 **NOTE:** NRI-plugins Helm installation has been successfully verified in both local clusters and major Cloud Providers' managed clusters, including:
@@ -18,6 +20,26 @@ All the available charts can be found in [artifacthub.io](https://artifacthub.io
         - node image: Azure Linux Container Host, Ubuntu 20.04
 
 While Ubuntu 20.04/22.04 was used across all three CSP environments, it's worth noting that node images are not limited to Ubuntu 20.04/22.04 only. The majority of widely recognized Linux distributions should be suitable for use.
+
+## Unstable Helm Charts
+
+Helm charts are also published from the main/development branch after each merge.
+These charts reference the latest development images tagged as `unstable` and are
+are stored alongside plugin images in the OCI image registry.
+
+### Discovering Unstable Helm Charts
+
+Unstable charts can be discovered using [skopeo](https://github.com/containers/skopeo).
+For instance, one can list the available charts for the balloons plugin using this
+skopeo command:
+`skopeo list-tags docker://ghcr.io/containers/nri-plugins/nri-resource-policy-balloons`
+
+### Using Unstable Helm Charts
+
+Once discovered, unstable Helm charts can be used like any other. For instance, to use
+the `$X.$Y-unstable` version of the chart to install the development version of the
+balloons plugin one can use this command:
+`helm install --devel -n kube-system test oci://ghcr.io/containers/nri-plugins/nri-resource-policy-balloons --version $X.$Y-unstable --set image.tag=unstable --set image.pullPolicy=Always`
 
 ```{toctree}
 ---


### PR DESCRIPTION
This PR publishes unstable Helm Charts by pushing them to the OCI registry, triggered by any push to `main`. The chart version is calculated from the last tag `x.y.z` on `main` then turning it into a chart version `x.y.z+1-unstable`. The image/app version used in the chart is always `unstable`.

[skopeo](https://github.com/containers/skopeo) can be used to list helm charts hosted in an OCI registry. For instance, to list all the available charts for the template policy one can use
`skopeo list-tags docker://ghcr.io/klihub/nri-plugins/helm-charts/nri-resource-policy-template`.

Note that Helm itself is currently unable to search OCI registries, although there is a WiP implementation for Helm OCI registry search here: https://github.com/sabre1041/helm/tree/search-registry. Before this or something similar gets merged, the unstable Helm chart is not discoverable using Helm alone. One has to know both the charts location and its tag to be able to pull or use it. IOW, for instance, with a command like this:
`helm install -n kube-system test oci://ghcr.io/klihub/nri-plugins/helm-charts/nri-resource-policy-template --version v0.4-unstable`