### PR TITLE
cache: store creation time of pod and containers cache objects

### DIFF
--- a/pkg/resmgr/cache/cache.go
+++ b/pkg/resmgr/cache/cache.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	nri "github.com/containerd/nri/pkg/api"
 	v1 "k8s.io/api/core/v1"
@@ -81,6 +82,8 @@ type Pod interface {
 	GetName() string
 	// GetNamespace returns the namespace of the pod.
 	GetNamespace() string
+	// GetCtime returns the creation time of the pod cache object.
+	GetCtime() time.Time
 	// GetQOSClass returns the PodQOSClass of the pod.
 	GetQOSClass() v1.PodQOSClass
 	// GetLabel returns the value of the given label and whether it was found.
@@ -134,6 +137,7 @@ type pod struct {
 	QOSClass   v1.PodQOSClass        // pod QOS class
 	Affinity   *podContainerAffinity // annotated container affinity
 	prettyName string                // cached PrettyName()
+	ctime      time.Time             // time of pod creation
 }
 
 // ContainerState is the container state in the runtime.
@@ -166,6 +170,8 @@ type Container interface {
 	GetName() string
 	// GetNamespace returns the namespace of the container.
 	GetNamespace() string
+	// GetCtime returns the creation time of the container cache object.
+	GetCtime() time.Time
 	// UpdateState updates the state of the container.
 	UpdateState(ContainerState)
 	// GetState returns the ContainerState of the container.
@@ -320,7 +326,8 @@ type container struct {
 
 	pending map[string]struct{} // controllers with pending changes for this container
 
-	prettyName string // cached PrettyName()
+	prettyName string    // cached PrettyName()
+	ctime      time.Time // creation time of the container cache object
 }
 
 type Mount = nri.Mount

--- a/pkg/resmgr/cache/container.go
+++ b/pkg/resmgr/cache/container.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	resmgr "github.com/containers/nri-plugins/pkg/apis/resmgr/v1alpha1"
 	"github.com/containers/nri-plugins/pkg/cgroups"
@@ -98,6 +99,7 @@ func (cch *cache) createContainer(nriCtr *nri.Container) (*container, error) {
 		Ctr:   nriCtr,
 		State: nriCtr.GetState(),
 		Tags:  make(map[string]string),
+		ctime: time.Now(),
 	}
 
 	c.generateTopologyHints()
@@ -327,6 +329,10 @@ func (c *container) GetNamespace() string {
 		return pod.GetNamespace()
 	}
 	return ""
+}
+
+func (c *container) GetCtime() time.Time {
+	return c.ctime
 }
 
 func (c *container) UpdateState(state ContainerState) {
@@ -1141,4 +1147,19 @@ func CompareCPU(ci, cj Container) int {
 		return +1
 	}
 	return 0
+}
+
+func CompareContainerCtime(ci, cj Container) int {
+	ti, tj := ci.GetCtime(), cj.GetCtime()
+	return ti.Compare(tj)
+}
+
+func ComparePodCtime(ci, cj Container) int {
+	pi, oki := ci.GetPod()
+	pj, okj := cj.GetPod()
+	if !oki || !okj {
+		return 0
+	}
+	ti, tj := pi.GetCtime(), pj.GetCtime()
+	return ti.Compare(tj)
 }

--- a/pkg/resmgr/cache/pod.go
+++ b/pkg/resmgr/cache/pod.go
@@ -16,6 +16,7 @@ package cache
 
 import (
 	"strings"
+	"time"
 
 	nri "github.com/containerd/nri/pkg/api"
 	v1 "k8s.io/api/core/v1"
@@ -30,6 +31,7 @@ func (cch *cache) createPod(nriPod *nri.PodSandbox) *pod {
 	p := &pod{
 		cache: cch,
 		Pod:   nriPod,
+		ctime: time.Now(),
 	}
 
 	if err := p.parseCgroupForQOSClass(); err != nil {
@@ -65,6 +67,10 @@ func (p *pod) GetName() string {
 
 func (p *pod) GetNamespace() string {
 	return p.Pod.GetNamespace()
+}
+
+func (p *pod) GetCtime() time.Time {
+	return p.ctime
 }
 
 func (p *pod) GetLabel(key string) (string, bool) {


### PR DESCRIPTION
Enable sorting containers based on the time when they and their pods have been added to the cache.