### PR TITLE
cache, resmgr: add EvalRef(), implement key substitution.

### DIFF
--- a/cmd/plugins/topology-aware/policy/mocks_test.go
+++ b/cmd/plugins/topology-aware/policy/mocks_test.go
@@ -335,7 +335,10 @@ func (m *mockContainer) GetEffectiveAnnotation(key string) (string, bool) {
 	}
 	return pod.GetEffectiveAnnotation(key, m.name)
 }
-func (m *mockContainer) Eval(string) interface{} {
+func (m *mockContainer) EvalKey(string) interface{} {
+	panic("unimplemented")
+}
+func (m *mockContainer) EvalRef(string) (string, bool) {
 	panic("unimplemented")
 }
 func (m *mockContainer) String() string {
@@ -488,7 +491,10 @@ func (m *mockPod) ScopeExpression() *resmgr.Expression {
 func (m *mockPod) String() string {
 	return "mockPod"
 }
-func (m *mockPod) Eval(string) interface{} {
+func (m *mockPod) EvalKey(string) interface{} {
+	panic("unimplemented")
+}
+func (m *mockPod) EvalRef(string) (string, bool) {
 	panic("unimplemented")
 }
 func (m *mockPod) GetProcesses(bool) ([]string, error) {

--- a/pkg/apis/resmgr/v1alpha1/evaluable.go
+++ b/pkg/apis/resmgr/v1alpha1/evaluable.go
@@ -16,5 +16,8 @@ package resmgr
 
 // Evaluable is the interface objects need to implement to be evaluable against Expressions.
 type Evaluable interface {
-	Eval(string) interface{}
+	// EvalKey returns the value of a simple/single key.
+	EvalKey(string) interface{}
+	// EvalRef returns the value of a (potentially joint) key (reference).
+	EvalRef(string) (string, bool)
 }

--- a/pkg/apis/resmgr/v1alpha1/expression.go
+++ b/pkg/apis/resmgr/v1alpha1/expression.go
@@ -122,7 +122,7 @@ func (e *Expression) Evaluate(subject Evaluable) bool {
 		return true
 	}
 
-	value, ok := e.KeyValue(subject)
+	value, ok := KeyValue(e.Key, subject)
 	result := false
 
 	switch e.Op {
@@ -173,14 +173,19 @@ func (e *Expression) Evaluate(subject Evaluable) bool {
 	return result
 }
 
-// KeyValue extracts the value of the expresssion key from a container.
-func (e *Expression) KeyValue(subject Evaluable) (string, bool) {
-	log.Debug("looking up %q @ %s...", e.Key, subject)
+// String returns the expression as a string.
+func (e *Expression) String() string {
+	return fmt.Sprintf("<%s %s %s>", e.Key, e.Op, strings.Join(e.Values, ","))
+}
+
+// KeyValue extracts the value of the expression in the scope of the given subject.
+func KeyValue(key string, subject Evaluable) (string, bool) {
+	log.Debug("looking up %q @ %s...", key, subject)
 
 	value := ""
 	ok := false
 
-	keys, vsep := splitKeys(e.Key)
+	keys, vsep := splitKeys(key)
 	if len(keys) == 1 {
 		value, ok, _ = ResolveRef(subject, keys[0])
 	} else {
@@ -193,7 +198,7 @@ func (e *Expression) KeyValue(subject Evaluable) (string, bool) {
 		value = strings.Join(vals, vsep)
 	}
 
-	log.Debug("%q @ %s => %q, %v", e.Key, subject, value, ok)
+	log.Debug("%q @ %s => %q, %v", key, subject, value, ok)
 
 	return value, ok
 }
@@ -261,7 +266,7 @@ func ResolveRef(subject Evaluable, spec string) (string, bool, error) {
 		switch v := obj.(type) {
 		case Evaluable:
 			pref, rest, _ := strings.Cut(key, "/")
-			obj = v.Eval(pref)
+			obj = v.EvalKey(pref)
 			key = rest
 
 		case map[string]string:
@@ -294,11 +299,6 @@ func ResolveRef(subject Evaluable, spec string) (string, bool, error) {
 	log.Debug("resolved %q in %s => %s", spec, subject, s)
 
 	return s, true, nil
-}
-
-// String returns the expression as a string.
-func (e *Expression) String() string {
-	return fmt.Sprintf("<%s %s %s>", e.Key, e.Op, strings.Join(e.Values, ","))
 }
 
 // exprError returns a formatted error specific to expressions.

--- a/pkg/apis/resmgr/v1alpha1/expression_test.go
+++ b/pkg/apis/resmgr/v1alpha1/expression_test.go
@@ -43,7 +43,7 @@ func newEvaluable(name, ns, qos string, labels, tags map[string]string, p Evalua
 	}
 }
 
-func (e *evaluable) Eval(key string) interface{} {
+func (e *evaluable) EvalKey(key string) interface{} {
 	switch key {
 	case KeyName:
 		return e.name
@@ -63,6 +63,10 @@ func (e *evaluable) Eval(key string) interface{} {
 	default:
 		return fmt.Errorf("evaluable: cannot evaluate %q", key)
 	}
+}
+
+func (e *evaluable) EvalRef(key string) (string, bool) {
+	return KeyValue(key, e)
 }
 
 func (e *evaluable) String() string {
@@ -174,10 +178,68 @@ func TestResolveRefAndKeyValue(t *testing.T) {
 					Op:     Equals,
 					Values: []string{},
 				}
-				value, _ = expr.KeyValue(tc.subject)
+				value, _ = KeyValue(expr.Key, tc.subject)
 				if value != tc.keyvalues[i] {
 					t.Errorf("KeyValue %s@%q: expected %v, got %v",
 						tc.subject, tc.keys[i], tc.keyvalues[i], value)
+				}
+			}
+		})
+	}
+}
+
+func TestEvalRef(t *testing.T) {
+	defer logger.Flush()
+
+	podLabels := map[string]string{"l1": "pl1", "l2": "pl2", "l5": "pl5", "io.t/l1": "pio.t/l1"}
+	pod := newEvaluable("pod1", "pod1-ns", "pod1-qos", podLabels, nil, nil)
+	ctrLabels := map[string]string{"l1": "cl1", "l2": "cl2", "l3": "cl3"}
+	ctr := newEvaluable("ctr1", "ctr1-ns", "ctr1-qos", ctrLabels, nil, pod)
+
+	tcases := []struct {
+		name   string
+		keys   []string
+		values []string
+		ok     []bool
+	}{
+		{
+			name: "test resolving references",
+			keys: []string{
+				"name", "namespace", "qosclass",
+				"labels/l1", "labels/l2", "labels/l3", "labels/l4",
+				"pod/labels/l1", "pod/labels/l2", "pod/labels/l3", "pod/labels/l4", "pod/labels/l5",
+				"pod/labels/io.t/l", "pod/labels/io.t/l1",
+				":,-pod/qosclass,pod/namespace,pod/name,name",
+			},
+			values: []string{
+				"ctr1", "ctr1-ns", "ctr1-qos",
+				"cl1", "cl2", "cl3", "",
+				"pl1", "pl2", "", "", "pl5",
+				"", "pio.t/l1",
+				"pod1-qos-pod1-ns-pod1-ctr1",
+			},
+			ok: []bool{
+				true, true, true,
+				true, true, true, false,
+				true, true, false, false, true,
+				false, true,
+				true,
+			},
+		},
+	}
+
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i := range tc.keys {
+				value, ok := ctr.EvalRef(tc.keys[i])
+				if !ok && tc.ok[i] {
+					t.Errorf("EvalRef %q for %s should have given %q, but failed",
+						tc.keys[i], ctr, tc.values[i])
+					continue
+				}
+				if value != tc.values[i] || ok != tc.ok[i] {
+					t.Errorf("EvalRef %q for %s: expected %v, %v got %v, %v",
+						tc.keys[i], ctr, tc.values[i], tc.ok[i], value, ok)
 				}
 			}
 		})
@@ -376,7 +438,7 @@ func TestMatching(t *testing.T) {
 				results := []string{}
 				for _, s := range tc.subjects {
 					if expr.Evaluate(s) {
-						results = append(results, s.Eval("name").(string))
+						results = append(results, s.EvalKey("name").(string))
 					}
 				}
 				expected := strings.Join(tc.expected[i], ",")

--- a/pkg/resmgr/cache/container.go
+++ b/pkg/resmgr/cache/container.go
@@ -994,7 +994,7 @@ func (c *container) String() string {
 	return c.PrettyName()
 }
 
-func (c *container) Eval(key string) interface{} {
+func (c *container) EvalKey(key string) interface{} {
 	switch key {
 	case resmgr.KeyPod:
 		pod, ok := c.GetPod()
@@ -1017,6 +1017,11 @@ func (c *container) Eval(key string) interface{} {
 	default:
 		return cacheError("%s: Container cannot evaluate of %q", c.PrettyName(), key)
 	}
+}
+
+// Eval evaluates a potentially joint key for the container.
+func (c *container) EvalRef(key string) (string, bool) {
+	return resmgr.KeyValue(key, c)
 }
 
 // CompareContainersFn compares two containers by some arbitrary property.

--- a/pkg/resmgr/cache/pod.go
+++ b/pkg/resmgr/cache/pod.go
@@ -181,8 +181,8 @@ func (p *pod) ScopeExpression() *resmgr.Expression {
 	}
 }
 
-// Eval returns the value of a key for expression evaluation.
-func (p *pod) Eval(key string) interface{} {
+// EvalKey returns the value of a key for expression evaluation.
+func (p *pod) EvalKey(key string) interface{} {
 	switch key {
 	case resmgr.KeyName:
 		return p.GetName()
@@ -199,6 +199,11 @@ func (p *pod) Eval(key string) interface{} {
 	default:
 		return cacheError("Pod cannot evaluate of %q", key)
 	}
+}
+
+// EvalRef evaluates a potentially joint key for the pod.
+func (p *pod) EvalRef(key string) (string, bool) {
+	return resmgr.KeyValue(key, p)
 }
 
 func (p *pod) String() string {


### PR DESCRIPTION
Expose evaluation of (potentially joint) pod and container key references using the newly added EvalRef() Evaluable interface. This allows one to evaluate the values of key references which originally were only used in expressions without having to put an expression around such references.

Additionally, introduce Substitute(source string, subject Evaluable) which takes a source string and perform substitution on it using a subject to resolve key references for plain '$key' or well-formed '${key}' references.

@askervin This is what I cooked up for the new balloons feature we discussed today in our face-to-face session. This should allow using shell-like substitutions in the balloons configuration.