### PR TITLE
cache, resmgr: expose key evaluation, implement key substitution.

### DIFF
--- a/cmd/plugins/topology-aware/policy/mocks_test.go
+++ b/cmd/plugins/topology-aware/policy/mocks_test.go
@@ -335,7 +335,10 @@ func (m *mockContainer) GetEffectiveAnnotation(key string) (string, bool) {
 	}
 	return pod.GetEffectiveAnnotation(key, m.name)
 }
-func (m *mockContainer) Eval(string) interface{} {
+func (m *mockContainer) EvalKey(string) interface{} {
+	panic("unimplemented")
+}
+func (m *mockContainer) EvalRef(string) (string, bool) {
 	panic("unimplemented")
 }
 func (m *mockContainer) String() string {
@@ -488,7 +491,10 @@ func (m *mockPod) ScopeExpression() *resmgr.Expression {
 func (m *mockPod) String() string {
 	return "mockPod"
 }
-func (m *mockPod) Eval(string) interface{} {
+func (m *mockPod) EvalKey(string) interface{} {
+	panic("unimplemented")
+}
+func (m *mockPod) EvalRef(string) (string, bool) {
 	panic("unimplemented")
 }
 func (m *mockPod) GetProcesses(bool) ([]string, error) {

--- a/cmd/plugins/topology-aware/policy/mocks_test.go
+++ b/cmd/plugins/topology-aware/policy/mocks_test.go
@@ -341,6 +341,10 @@ func (m *mockContainer) EvalKey(string) interface{} {
 func (m *mockContainer) EvalRef(string) (string, bool) {
 	panic("unimplemented")
 }
+func (m *mockContainer) Expand(string, bool) (string, error) {
+	panic("unimplemented")
+}
+
 func (m *mockContainer) String() string {
 	return "mockContainer"
 }
@@ -495,6 +499,9 @@ func (m *mockPod) EvalKey(string) interface{} {
 	panic("unimplemented")
 }
 func (m *mockPod) EvalRef(string) (string, bool) {
+	panic("unimplemented")
+}
+func (m *mockPod) Expand(string, bool) (string, error) {
 	panic("unimplemented")
 }
 func (m *mockPod) GetProcesses(bool) ([]string, error) {

--- a/pkg/apis/resmgr/v1alpha1/evaluable.go
+++ b/pkg/apis/resmgr/v1alpha1/evaluable.go
@@ -16,5 +16,8 @@ package resmgr
 
 // Evaluable is the interface objects need to implement to be evaluable against Expressions.
 type Evaluable interface {
-	Eval(string) interface{}
+	// EvalKey returns the value of a simple/single key.
+	EvalKey(string) interface{}
+	// EvalRef returns the value of a (potentially joint) key (reference).
+	EvalRef(string) (string, bool)
 }

--- a/pkg/apis/resmgr/v1alpha1/expression.go
+++ b/pkg/apis/resmgr/v1alpha1/expression.go
@@ -122,7 +122,7 @@ func (e *Expression) Evaluate(subject Evaluable) bool {
 		return true
 	}
 
-	value, ok := e.KeyValue(subject)
+	value, ok := KeyValue(e.Key, subject)
 	result := false
 
 	switch e.Op {
@@ -173,14 +173,19 @@ func (e *Expression) Evaluate(subject Evaluable) bool {
 	return result
 }
 
-// KeyValue extracts the value of the expresssion key from a container.
-func (e *Expression) KeyValue(subject Evaluable) (string, bool) {
-	log.Debug("looking up %q @ %s...", e.Key, subject)
+// String returns the expression as a string.
+func (e *Expression) String() string {
+	return fmt.Sprintf("<%s %s %s>", e.Key, e.Op, strings.Join(e.Values, ","))
+}
+
+// KeyValue extracts the value of the expression in the scope of the given subject.
+func KeyValue(key string, subject Evaluable) (string, bool) {
+	log.Debug("looking up %q @ %s...", key, subject)
 
 	value := ""
 	ok := false
 
-	keys, vsep := splitKeys(e.Key)
+	keys, vsep := splitKeys(key)
 	if len(keys) == 1 {
 		value, ok, _ = ResolveRef(subject, keys[0])
 	} else {
@@ -193,7 +198,7 @@ func (e *Expression) KeyValue(subject Evaluable) (string, bool) {
 		value = strings.Join(vals, vsep)
 	}
 
-	log.Debug("%q @ %s => %q, %v", e.Key, subject, value, ok)
+	log.Debug("%q @ %s => %q, %v", key, subject, value, ok)
 
 	return value, ok
 }
@@ -261,7 +266,7 @@ func ResolveRef(subject Evaluable, spec string) (string, bool, error) {
 		switch v := obj.(type) {
 		case Evaluable:
 			pref, rest, _ := strings.Cut(key, "/")
-			obj = v.Eval(pref)
+			obj = v.EvalKey(pref)
 			key = rest
 
 		case map[string]string:
@@ -294,11 +299,6 @@ func ResolveRef(subject Evaluable, spec string) (string, bool, error) {
 	log.Debug("resolved %q in %s => %s", spec, subject, s)
 
 	return s, true, nil
-}
-
-// String returns the expression as a string.
-func (e *Expression) String() string {
-	return fmt.Sprintf("<%s %s %s>", e.Key, e.Op, strings.Join(e.Values, ","))
 }
 
 // exprError returns a formatted error specific to expressions.

--- a/pkg/apis/resmgr/v1alpha1/expression.go
+++ b/pkg/apis/resmgr/v1alpha1/expression.go
@@ -301,6 +301,102 @@ func ResolveRef(subject Evaluable, spec string) (string, bool, error) {
 	return s, true, nil
 }
 
+// Expand performs non-recursive key substitution on strings containing 0 or
+// more well-formed or plain (${key}, $key) references, replacing each key
+// with its value when evaluated against the given subject. If mustResolve is
+// true, unresolvable references are flagged as an error. Otherwise they are
+// replaced by an empty string.
+func Expand(src string, subject Evaluable, mustResolve bool) (string, error) {
+	var (
+		result = &strings.Builder{}
+		buf    = result
+		key    *strings.Builder
+		curly  bool
+	)
+
+	substKeyValue := func() error {
+		val, ok := subject.EvalRef(key.String())
+		if !ok && mustResolve {
+			return fmt.Errorf("invalid substitution %q, unresolvable key %q",
+				src, key.String())
+		}
+
+		result.WriteString(val)
+		return nil
+	}
+
+	for i, c := range src {
+		if buf != key {
+			switch c {
+			case '$':
+				key = &strings.Builder{}
+				buf = key
+			default:
+				buf.WriteRune(c)
+			}
+			continue
+		}
+
+		// buf == key
+		switch c {
+		case '$':
+			if curly {
+				return "", fmt.Errorf("invalid substitution %q, unterminated '}' (at %q)",
+					src, src[i:])
+			}
+
+			if buf.Len() == 0 {
+				result.WriteByte('$')
+				key = nil
+				buf = result
+				continue
+			}
+
+			if err := substKeyValue(); err != nil {
+				return "", err
+			}
+
+			buf.Reset()
+
+		case '{':
+			if curly || buf.Len() != 0 {
+				return "", fmt.Errorf("invalid substitution %q, unexpected '{' (at %q)",
+					src, src[i:])
+			}
+			curly = true
+
+		case '}':
+			if !curly || buf.Len() == 0 {
+				return "", fmt.Errorf("invalid substitution %q, unexpected '}' (at %q)",
+					src, src[i:])
+			}
+
+			if err := substKeyValue(); err != nil {
+				return "", err
+			}
+
+			curly = false
+			key = nil
+			buf = result
+
+		default:
+			buf.WriteRune(c)
+		}
+	}
+
+	if buf == key {
+		if curly || buf.Len() == 0 {
+			return "", fmt.Errorf("invalid substitution %q, unterminated reference", src)
+		}
+
+		if err := substKeyValue(); err != nil {
+			return "", err
+		}
+	}
+
+	return result.String(), nil
+}
+
 // exprError returns a formatted error specific to expressions.
 func exprError(format string, args ...interface{}) error {
 	return fmt.Errorf("expression: "+format, args...)

--- a/pkg/apis/resmgr/v1alpha1/expression_test.go
+++ b/pkg/apis/resmgr/v1alpha1/expression_test.go
@@ -43,7 +43,7 @@ func newEvaluable(name, ns, qos string, labels, tags map[string]string, p Evalua
 	}
 }
 
-func (e *evaluable) Eval(key string) interface{} {
+func (e *evaluable) EvalKey(key string) interface{} {
 	switch key {
 	case KeyName:
 		return e.name
@@ -63,6 +63,10 @@ func (e *evaluable) Eval(key string) interface{} {
 	default:
 		return fmt.Errorf("evaluable: cannot evaluate %q", key)
 	}
+}
+
+func (e *evaluable) EvalRef(key string) (string, bool) {
+	return KeyValue(key, e)
 }
 
 func (e *evaluable) String() string {
@@ -174,10 +178,68 @@ func TestResolveRefAndKeyValue(t *testing.T) {
 					Op:     Equals,
 					Values: []string{},
 				}
-				value, _ = expr.KeyValue(tc.subject)
+				value, _ = KeyValue(expr.Key, tc.subject)
 				if value != tc.keyvalues[i] {
 					t.Errorf("KeyValue %s@%q: expected %v, got %v",
 						tc.subject, tc.keys[i], tc.keyvalues[i], value)
+				}
+			}
+		})
+	}
+}
+
+func TestEvalRef(t *testing.T) {
+	defer logger.Flush()
+
+	podLabels := map[string]string{"l1": "pl1", "l2": "pl2", "l5": "pl5", "io.t/l1": "pio.t/l1"}
+	pod := newEvaluable("pod1", "pod1-ns", "pod1-qos", podLabels, nil, nil)
+	ctrLabels := map[string]string{"l1": "cl1", "l2": "cl2", "l3": "cl3"}
+	ctr := newEvaluable("ctr1", "ctr1-ns", "ctr1-qos", ctrLabels, nil, pod)
+
+	tcases := []struct {
+		name   string
+		keys   []string
+		values []string
+		ok     []bool
+	}{
+		{
+			name: "test resolving references",
+			keys: []string{
+				"name", "namespace", "qosclass",
+				"labels/l1", "labels/l2", "labels/l3", "labels/l4",
+				"pod/labels/l1", "pod/labels/l2", "pod/labels/l3", "pod/labels/l4", "pod/labels/l5",
+				"pod/labels/io.t/l", "pod/labels/io.t/l1",
+				":,-pod/qosclass,pod/namespace,pod/name,name",
+			},
+			values: []string{
+				"ctr1", "ctr1-ns", "ctr1-qos",
+				"cl1", "cl2", "cl3", "",
+				"pl1", "pl2", "", "", "pl5",
+				"", "pio.t/l1",
+				"pod1-qos-pod1-ns-pod1-ctr1",
+			},
+			ok: []bool{
+				true, true, true,
+				true, true, true, false,
+				true, true, false, false, true,
+				false, true,
+				true,
+			},
+		},
+	}
+
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i := range tc.keys {
+				value, ok := ctr.EvalRef(tc.keys[i])
+				if !ok && tc.ok[i] {
+					t.Errorf("EvalRef %q for %s should have given %q, but failed",
+						tc.keys[i], ctr, tc.values[i])
+					continue
+				}
+				if value != tc.values[i] || ok != tc.ok[i] {
+					t.Errorf("EvalRef %q for %s: expected %v, %v got %v, %v",
+						tc.keys[i], ctr, tc.values[i], tc.ok[i], value, ok)
 				}
 			}
 		})
@@ -376,7 +438,7 @@ func TestMatching(t *testing.T) {
 				results := []string{}
 				for _, s := range tc.subjects {
 					if expr.Evaluate(s) {
-						results = append(results, s.Eval("name").(string))
+						results = append(results, s.EvalKey("name").(string))
 					}
 				}
 				expected := strings.Join(tc.expected[i], ",")

--- a/pkg/apis/resmgr/v1alpha1/expression_test.go
+++ b/pkg/apis/resmgr/v1alpha1/expression_test.go
@@ -598,3 +598,131 @@ func TestValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestExpand(t *testing.T) {
+	defer logger.Flush()
+
+	podLabels := map[string]string{"l1": "pl1v", "l2": "pl2v", "l5": "pl5v", "io.t/l1": "pio.t-l1v"}
+	pod := newEvaluable("pod1", "pod1-ns", "pod1-qos", podLabels, nil, nil)
+	ctrLabels := map[string]string{"l1": "cl1", "l2": "cl2", "l3": "cl3"}
+	ctr := newEvaluable("ctr1", "ctr1-ns", "ctr1-qos", ctrLabels, nil, pod)
+
+	tcases := []struct {
+		name        string
+		source      string
+		mustResolve bool
+		result      string
+		fail        bool
+	}{
+		{
+			name:   "single well-formed key",
+			source: "${pod/qosclass}",
+			result: "pod1-qos",
+		},
+		{
+			name:   "multiple well-formed keys concatenated",
+			source: "${pod/namespace}${pod/name}${pod/qosclass}",
+			result: "pod1-nspod1pod1-qos",
+		},
+		{
+			name:   "multiple well-formed keys, with non-empty separators",
+			source: "${pod/labels/io.t/l1}:${pod/labels/l2}",
+			result: "pio.t-l1v:pl2v",
+		},
+		{
+			name:   "single plain key",
+			source: "$pod/qosclass",
+			result: "pod1-qos",
+		},
+		{
+			name:   "multiple plain keys",
+			source: "$pod/namespace$pod/name$pod/qosclass",
+			result: "pod1-nspod1pod1-qos",
+		},
+		{
+			name:   "multiple plain keys concatenated",
+			source: "$pod/labels/io.t/l1$pod/labels/l2",
+			result: "pio.t-l1vpl2v",
+		},
+		{
+			name:   "unresolvable keys",
+			source: "${pod/foobar}${xyzzy}",
+			result: "",
+		},
+		{
+			name:   "mixed resolvable and unresolvable keys",
+			source: "${pod/labels/l5}$foobar${pod/name}",
+			result: "pl5vpod1",
+		},
+		{
+			name:        "unresolvable keys, with mustResolve set",
+			source:      "${pod/foobar}${xyzzy}",
+			mustResolve: true,
+			result:      "",
+			fail:        true,
+		},
+		{
+			name:   "multiple literal $s",
+			source: "$$$$$$",
+			result: "$$$",
+		},
+		{
+			name:   "trailing literal $",
+			source: "foobar$$",
+			result: "foobar$",
+		},
+		{
+			name:   "trailing incorrect $",
+			source: "foobar$",
+			result: "",
+			fail:   true,
+		},
+		{
+			name:   "unterminated reference",
+			source: "${foobar",
+			result: "",
+			fail:   true,
+		},
+		{
+			name:   "unterminated reference",
+			source: "${foobar$barfoo",
+			result: "",
+			fail:   true,
+		},
+		{
+			name:   "unterminated reference",
+			source: "${foobar",
+			result: "",
+			fail:   true,
+		},
+		{
+			name:   "invalid reference, unexpected {",
+			source: "${foo{bar}",
+			result: "",
+			fail:   true,
+		},
+		{
+			name:   "invalid reference, unexpected }",
+			source: "$foo}",
+			result: "",
+			fail:   true,
+		},
+		{
+			name:   "non-variable curly braces",
+			source: "{}$pod/name",
+			result: "{}pod1",
+		},
+	}
+
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := Expand(tc.source, ctr, tc.mustResolve)
+			if !tc.fail {
+				require.Equal(t, tc.result, result)
+				require.Nil(t, err)
+			} else {
+				require.NotNil(t, err)
+			}
+		})
+	}
+}

--- a/pkg/resmgr/cache/cache.go
+++ b/pkg/resmgr/cache/cache.go
@@ -116,6 +116,9 @@ type Pod interface {
 	// Pods can be subject for expression evaluation.
 	resmgr.Evaluable
 
+	// Expand a string with possible key references.
+	Expand(string, bool) (string, error)
+
 	// We have String() for pods.
 	fmt.Stringer
 
@@ -199,6 +202,9 @@ type Container interface {
 
 	// Containers can be subject for expression evaluation.
 	resmgr.Evaluable
+
+	// Expand a string with possible key references.
+	Expand(string, bool) (string, error)
 
 	// We have String() for containers.
 	fmt.Stringer

--- a/pkg/resmgr/cache/container.go
+++ b/pkg/resmgr/cache/container.go
@@ -1025,6 +1025,11 @@ func (c *container) EvalRef(key string) (string, bool) {
 	return resmgr.KeyValue(key, c)
 }
 
+// Expand a string with possible key references.
+func (c *container) Expand(src string, mustResolve bool) (string, error) {
+	return resmgr.Expand(src, c, mustResolve)
+}
+
 // CompareContainersFn compares two containers by some arbitrary property.
 // It returns a negative integer, 0, or a positive integer, depending on
 // whether the first container is considered smaller, equal, or larger than

--- a/pkg/resmgr/cache/container.go
+++ b/pkg/resmgr/cache/container.go
@@ -994,7 +994,8 @@ func (c *container) String() string {
 	return c.PrettyName()
 }
 
-func (c *container) Eval(key string) interface{} {
+// EvalKey returns the value of a key for expression evaluation.
+func (c *container) EvalKey(key string) interface{} {
 	switch key {
 	case resmgr.KeyPod:
 		pod, ok := c.GetPod()
@@ -1017,6 +1018,11 @@ func (c *container) Eval(key string) interface{} {
 	default:
 		return cacheError("%s: Container cannot evaluate of %q", c.PrettyName(), key)
 	}
+}
+
+// EvalRef evaluates the value of a key reference for this container.
+func (c *container) EvalRef(key string) (string, bool) {
+	return resmgr.KeyValue(key, c)
 }
 
 // CompareContainersFn compares two containers by some arbitrary property.

--- a/pkg/resmgr/cache/pod.go
+++ b/pkg/resmgr/cache/pod.go
@@ -181,8 +181,8 @@ func (p *pod) ScopeExpression() *resmgr.Expression {
 	}
 }
 
-// Eval returns the value of a key for expression evaluation.
-func (p *pod) Eval(key string) interface{} {
+// EvalKey returns the value of a key for expression evaluation.
+func (p *pod) EvalKey(key string) interface{} {
 	switch key {
 	case resmgr.KeyName:
 		return p.GetName()
@@ -199,6 +199,11 @@ func (p *pod) Eval(key string) interface{} {
 	default:
 		return cacheError("Pod cannot evaluate of %q", key)
 	}
+}
+
+// EvalRef evaluates the value of a key reference for this pod.
+func (p *pod) EvalRef(key string) (string, bool) {
+	return resmgr.KeyValue(key, p)
 }
 
 func (p *pod) String() string {

--- a/pkg/resmgr/cache/pod.go
+++ b/pkg/resmgr/cache/pod.go
@@ -206,6 +206,11 @@ func (p *pod) EvalRef(key string) (string, bool) {
 	return resmgr.KeyValue(key, p)
 }
 
+// Expand a string with possible key references.
+func (p *pod) Expand(src string, mustResolve bool) (string, error) {
+	return resmgr.Expand(src, p, mustResolve)
+}
+
 func (p *pod) String() string {
 	return p.PrettyName()
 }


### PR DESCRIPTION
Expose evaluating pod and container key references using the newly added `EvalRef()` Evaluable interface. This lets one evaluate values of key references, something which previously was only done as part of evaluating expressions. Also, introduce `Substitute()` which takes a source string and performs key substitution on it wrt. a subject, using the new `EvalRef()`, to resolve key references in plain ('$key') or well-formed ('${key}') notation.
