### PR TITLE
e2e: fix k8s Fedora repo

### DIFF
--- a/test/e2e/files/Vagrantfile.in
+++ b/test/e2e/files/Vagrantfile.in
@@ -14,6 +14,7 @@ HOSTNAME = "SERVER_NAME"
 # How many nodes to create
 N = 1
 
+K8S_RELEASE = "#{ENV['k8s_release']}"
 CRI_RUNTIME = "#{ENV['k8scri']}"
 CRIO_RELEASE = "1.28.1"
 CRIO_SRC = ""
@@ -88,6 +89,7 @@ Vagrant.configure("2") do |config|
       https_proxy: "#{ENV['HTTPS_PROXY']}",
       http_proxy: "#{ENV['HTTP_PROXY']}",
       no_proxy: "#{ENV['NO_PROXY']}",
+      k8s_release: K8S_RELEASE,
       cri_runtime: CRI_RUNTIME,
       containerd_release: CONTAINERD_RELEASE,
       containerd_src: CONTAINERD_SRC,

--- a/test/e2e/playbook/provision.yaml
+++ b/test/e2e/playbook/provision.yaml
@@ -5,6 +5,7 @@
   become_user: root
   vars:
     cri_runtime: "{{ cri_runtime }}"
+    k8s_release: "{{ k8s_release }}"
     is_containerd: false
     is_crio: false
     containerd_release: "{{ containerd_release }}"
@@ -66,8 +67,8 @@
     - name: Add yum repository for Kubernetes
       ansible.builtin.yum_repository:
         description: Kubernetes repository
-        baseurl: "https://packages.cloud.google.com/yum/repos/kubernetes-el7-$basearch"
-        gpgkey: "https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg"
+        baseurl: "https://pkgs.k8s.io/core:/stable:/v{{ k8s_release }}/rpm"
+        gpgkey: "https://pkgs.k8s.io/core:/stable:/v{{ k8s_release }}/rpm/repodata/repomd.xml.key"
         state: present
         name: kubernetes
       when: ansible_facts['distribution'] == "Fedora"

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -23,6 +23,17 @@ export cni_plugin=${cni_plugin:-cilium}
 export cni_release=${cni_release:-latest}
 TOPOLOGY_DIR=${TOPOLOGY_DIR:=e2e}
 
+export k8s_release=${k8s_release:-"latest"}
+if [[ "$k8s_release" == "latest" ]]; then
+    # Detect latest k8s major.minor non-alpha release.
+    k8s_release="$(curl --silent https://github.com/kubernetes/kubernetes/releases | awk 'BEGIN{RS="\"";FS="tree/v"}/kubernetes\/tree/{print $2}' | grep -v alpha | awk -F. '{print $1"."$2}' | sort -uVr | head -n 1)"
+    if ! [[ "$k8s_release" == [1-9].[1-9]* ]]; then
+        echo "failed to detect k8s_release latest"
+        exit 1
+    fi
+    export k8s_release
+fi
+
 source "$LIB_DIR"/vm.bash
 
 export vm_name=${vm_name:=$(vm-create-name "$k8scri" "$(basename "$TOPOLOGY_DIR")" ${distro})}
@@ -108,6 +119,7 @@ fi
 echo
 echo "    VM              = $vm_name"
 echo "    Distro          = $distro"
+echo "    Kubernetes      = $k8s_release"
 echo "    Runtime         = $k8scri"
 echo "    Output dir      = $OUTPUT_DIR"
 echo "    Test output dir = $TEST_OUTPUT_DIR"


### PR DESCRIPTION
- Automatically detect latest stable k8s release. This becomes necessary because new repository URLs contain the version number.
- Allow user to override k8s version to be installed.