### PR TITLE
topology-aware: configurable allocation priority

### DIFF
--- a/cmd/plugins/topology-aware/policy/coldstart_test.go
+++ b/cmd/plugins/topology-aware/policy/coldstart_test.go
@@ -95,7 +95,8 @@ func TestColdStart(t *testing.T) {
 				allocations: allocations{
 					grants: make(map[string]Grant, 0),
 				},
-				options: &policyapi.BackendOptions{},
+				options:      &policyapi.BackendOptions{},
+				cpuAllocator: &mockCPUAllocator{},
 			}
 			policy.allocations.policy = policy
 			policy.options.SendEvent = sendEvent

--- a/cmd/plugins/topology-aware/policy/mocks_test.go
+++ b/cmd/plugins/topology-aware/policy/mocks_test.go
@@ -20,7 +20,9 @@ import (
 
 	nri "github.com/containerd/nri/pkg/api"
 	resmgr "github.com/containers/nri-plugins/pkg/apis/resmgr/v1alpha1"
+	"github.com/containers/nri-plugins/pkg/cpuallocator"
 	"github.com/containers/nri-plugins/pkg/resmgr/cache"
+	"github.com/containers/nri-plugins/pkg/sysfs"
 	system "github.com/containers/nri-plugins/pkg/sysfs"
 	"github.com/containers/nri-plugins/pkg/topology"
 	"github.com/containers/nri-plugins/pkg/utils/cpuset"
@@ -103,6 +105,22 @@ func (p *mockCPUPackage) DieNodeIDs(idset.ID) []idset.ID {
 	return []idset.ID{}
 }
 
+func (p *mockCPUPackage) DieClusterIDs(idset.ID) []idset.ID {
+	return []idset.ID{}
+}
+
+func (p *mockCPUPackage) DieClusterCPUSet(idset.ID, idset.ID) cpuset.CPUSet {
+	return cpuset.New()
+}
+
+func (p *mockCPUPackage) LogicalDieClusterIDs(idset.ID) []idset.ID {
+	return []idset.ID{}
+}
+
+func (p *mockCPUPackage) LogicalDieClusterCPUSet(idset.ID, idset.ID) cpuset.CPUSet {
+	return cpuset.New()
+}
+
 func (p *mockCPUPackage) SstInfo() *sst.SstPackageInfo {
 	return &sst.SstPackageInfo{}
 }
@@ -156,6 +174,33 @@ func (c *mockCPU) SstClos() int {
 	return -1
 }
 
+func (c *mockCPU) CacheCount() int {
+	return 0
+}
+func (c *mockCPU) GetCaches() []*sysfs.Cache {
+	panic("unimplemented")
+}
+func (c *mockCPU) GetCachesByLevel(int) []*sysfs.Cache {
+	panic("unimplemented")
+}
+func (c *mockCPU) GetCacheByIndex(int) *sysfs.Cache {
+	panic("unimplemented")
+}
+func (c *mockCPU) GetLastLevelCaches() []*sysfs.Cache {
+	panic("unimplemented")
+}
+func (c *mockCPU) GetLastLevelCacheCPUSet() cpuset.CPUSet {
+	panic("unimplemented")
+}
+
+func (c *mockCPU) ClusterID() int {
+	return 0
+}
+
+func (c *mockCPU) CoreKind() sysfs.CoreKind {
+	return sysfs.PerformanceCore
+}
+
 type mockSystem struct {
 	isolatedCPU  int
 	nodes        []system.Node
@@ -187,6 +232,27 @@ func (fake *mockSystem) Discover(flags system.DiscoveryFlag) error {
 }
 func (fake *mockSystem) Package(idset.ID) system.CPUPackage {
 	return &mockCPUPackage{}
+}
+func (fake *mockSystem) PossibleCPUs() cpuset.CPUSet {
+	return fake.CPUSet()
+}
+func (fake *mockSystem) PresentCPUs() cpuset.CPUSet {
+	return fake.CPUSet()
+}
+func (fake *mockSystem) OnlineCPUs() cpuset.CPUSet {
+	return fake.CPUSet()
+}
+func (fake *mockSystem) IsolatedCPUs() cpuset.CPUSet {
+	return fake.Isolated()
+}
+func (fake *mockSystem) OfflineCPUs() cpuset.CPUSet {
+	return cpuset.New()
+}
+func (fake *mockSystem) CoreKindCPUs(sysfs.CoreKind) cpuset.CPUSet {
+	return cpuset.New()
+}
+func (fake *mockSystem) AllThreadsForCPUs(cpuset.CPUSet) cpuset.CPUSet {
+	return cpuset.New()
 }
 func (fake *mockSystem) Offlined() cpuset.CPUSet {
 	return cpuset.New()
@@ -629,3 +695,21 @@ func (m *mockCache) OpenFile(string, string, os.FileMode) (*os.File, error) {
 func (m *mockCache) WriteFile(string, string, os.FileMode, []byte) error {
 	panic("unimplemented")
 }
+
+type mockCPUAllocator struct{}
+
+func (m *mockCPUAllocator) AllocateCpus(from *cpuset.CPUSet, cnt int, prefer cpuallocator.CPUPriority) (cpuset.CPUSet, error) {
+	return cpuset.New(0), nil
+}
+
+func (m *mockCPUAllocator) ReleaseCpus(from *cpuset.CPUSet, cnt int, prefer cpuallocator.CPUPriority) (cpuset.CPUSet, error) {
+	return cpuset.New(0), nil
+}
+
+func (m *mockCPUAllocator) GetCPUPriorities() map[cpuallocator.CPUPriority]cpuset.CPUSet {
+	return map[cpuallocator.CPUPriority]cpuset.CPUSet{}
+}
+
+var (
+	_ cpuallocator.CPUAllocator = &mockCPUAllocator{}
+)

--- a/cmd/plugins/topology-aware/policy/pod-preferences_test.go
+++ b/cmd/plugins/topology-aware/policy/pod-preferences_test.go
@@ -1038,7 +1038,7 @@ func TestCpuAllocationPreferences(t *testing.T) {
 			}
 			opt.PreferIsolated, opt.PreferShared = tc.preferIsolated, tc.preferShared
 			opt.ReservedPoolNamespaces = tc.reservedPoolNamespaces
-			full, fraction, isolate, cpuType := cpuAllocationPreferences(tc.pod, tc.container)
+			full, fraction, isolate, cpuType, _ := cpuAllocationPreferences(tc.pod, tc.container)
 			if full != tc.expectedFull || fraction != tc.expectedFraction ||
 				isolate != tc.expectedIsolate || cpuType != tc.expectedCpuType {
 				t.Errorf("Expected (%v, %v, %v, %s), but got (%v, %v, %v, %s)",

--- a/cmd/plugins/topology-aware/policy/pools_test.go
+++ b/cmd/plugins/topology-aware/policy/pools_test.go
@@ -230,11 +230,12 @@ func TestMemoryLimitFiltering(t *testing.T) {
 				sys: &mockSystem{
 					nodes: tc.numaNodes,
 				},
-				pools:       tc.nodes,
-				cache:       &mockCache{},
-				root:        tc.nodes[0],
-				nodeCnt:     len(tc.nodes),
-				allocations: allocations{},
+				pools:        tc.nodes,
+				cache:        &mockCache{},
+				root:         tc.nodes[0],
+				nodeCnt:      len(tc.nodes),
+				allocations:  allocations{},
+				cpuAllocator: &mockCPUAllocator{},
 			}
 			// back pointers
 			for _, node := range tc.nodes {

--- a/config/crd/bases/config.nri_topologyawarepolicies.yaml
+++ b/config/crd/bases/config.nri_topologyawarepolicies.yaml
@@ -94,6 +94,19 @@ spec:
                     - classes
                     type: object
                 type: object
+              defaultCPUPriority:
+                default: none
+                description: |-
+                  DefaultCPUPriority (high, normal, low, none) is the preferred CPU
+                  priority for allocated CPUs when a container has not been annotated
+                  with any other CPU preference.
+                  Notes: Currently this option only affects exclusive CPU allocations.
+                enum:
+                - high
+                - normal
+                - low
+                - none
+                type: string
               instrumentation:
                 description: Config provides runtime configuration for instrumentation.
                 properties:

--- a/deployment/helm/balloons/README.md
+++ b/deployment/helm/balloons/README.md
@@ -95,6 +95,7 @@ customize with their own values, along with the default values.
 | `image.pullPolicy`       | Always                                                                                                                        | image pull policy                                    |
 | `resources.cpu`          | 500m                                                                                                                          | cpu resources for the Pod                            |
 | `resources.memory`       | 512Mi                                                                                                                         | memory qouta for the Pod                             |
+| `extraEnv`               | {}                                                                                                                            | extra environment variables to inject (string map)   |
 | `hostPort`               | 8891                                                                                                                          | metrics port to expose on the host                   |
 | `config`                 | see [helm chart values](tree:/deployment/helm/balloons/values.yaml) for the default configuration                       | plugin configuration data                            |
 | `configGroupLabel`       | config.nri/group                                                                                                        | node label for grouping configuration                |

--- a/deployment/helm/balloons/templates/daemonset.yaml
+++ b/deployment/helm/balloons/templates/daemonset.yaml
@@ -70,6 +70,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          {{- range $name, $value := .Values.extraEnv }}
+          - name: {{ $name }}
+            value: {{ $value }}
+          {{- end }}
           {{- if ".Values.plugin-test.enableAPIs" }}
           - name: ENABLE_TEST_APIS
             value: "1"

--- a/deployment/helm/balloons/values.yaml
+++ b/deployment/helm/balloons/values.yaml
@@ -33,6 +33,11 @@ config:
 
 # configGroupLabel: config.nri/group
 
+# Extra environment variables to inject.
+# extraEnv:
+#   VAR1: VAL1
+#   VAR2: VAL2
+
 plugin-test:
   enableAPIs: false
 

--- a/deployment/helm/template/README.md
+++ b/deployment/helm/template/README.md
@@ -95,6 +95,7 @@ customize with their own values, along with the default values.
 | `image.pullPolicy`       | Always                                                                                                                        | image pull policy                                    |
 | `resources.cpu`          | 500m                                                                                                                          | cpu resources for the Pod                            |
 | `resources.memory`       | 512Mi                                                                                                                         | memory qouta for the Pod                             |
+| `extraEnv`               | {}                                                                                                                            | extra environment variables to inject (string map)   |
 | `hostPort`               | 8891                                                                                                                          | metrics port to expose on the host                   |
 | `config`                 | see [helm chart values](tree:/deployment/helm/template/values.yaml) for the default configuration                       | plugin configuration data                            |
 | `configGroupLabel`       | config.nri/group                                                                                                        | node label for grouping configuration                |

--- a/deployment/helm/template/templates/daemonset.yaml
+++ b/deployment/helm/template/templates/daemonset.yaml
@@ -63,6 +63,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          {{- range $name, $value := .Values.extraEnv }}
+          - name: {{ $name }}
+            value: {{ $value }}
+          {{- end }}
           {{- if ".Values.plugin-test.enableAPIs" }}
           - name: ENABLE_TEST_APIS
             value: "1"

--- a/deployment/helm/template/values.yaml
+++ b/deployment/helm/template/values.yaml
@@ -21,6 +21,11 @@ config:
 
 # configGroupLabel: config.nri/group
 
+# Extra environment variables to inject.
+# extraEnv:
+#   VAR1: VAL1
+#   VAR2: VAL2
+
 plugin-test:
     enableAPIs: false
 

--- a/deployment/helm/topology-aware/README.md
+++ b/deployment/helm/topology-aware/README.md
@@ -96,6 +96,7 @@ customize with their own values, along with the default values.
 | `image.pullPolicy`       | Always                                                                                                                        | image pull policy                                    |
 | `resources.cpu`          | 500m                                                                                                                          | cpu resources for the Pod                            |
 | `resources.memory`       | 512Mi                                                                                                                         | memory qouta for the Pod                             |
+| `extraEnv`               | {}                                                                                                                            | extra environment variables to inject (string map)   |
 | `hostPort`               | 8891                                                                                                                          | metrics port to expose on the host                   |
 | `config`                 | see [helm chart values](tree:/deployment/helm/topology-aware/values.yaml) for the default configuration                       | plugin configuration data                            |
 | `configGroupLabel`       | config.nri/group                                                                                                        | node label for grouping configuration                |

--- a/deployment/helm/topology-aware/crds/config.nri_topologyawarepolicies.yaml
+++ b/deployment/helm/topology-aware/crds/config.nri_topologyawarepolicies.yaml
@@ -94,6 +94,19 @@ spec:
                     - classes
                     type: object
                 type: object
+              defaultCPUPriority:
+                default: none
+                description: |-
+                  DefaultCPUPriority (high, normal, low, none) is the preferred CPU
+                  priority for allocated CPUs when a container has not been annotated
+                  with any other CPU preference.
+                  Notes: Currently this option only affects exclusive CPU allocations.
+                enum:
+                - high
+                - normal
+                - low
+                - none
+                type: string
               instrumentation:
                 description: Config provides runtime configuration for instrumentation.
                 properties:

--- a/deployment/helm/topology-aware/templates/daemonset.yaml
+++ b/deployment/helm/topology-aware/templates/daemonset.yaml
@@ -70,6 +70,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          {{- range $name, $value := .Values.extraEnv }}
+          - name: {{ $name }}
+            value: {{ $value }}
+          {{- end }}
           {{- if ".Values.plugin-test.enableAPIs" }}
           - name: ENABLE_TEST_APIS
             value: "1"

--- a/deployment/helm/topology-aware/values.yaml
+++ b/deployment/helm/topology-aware/values.yaml
@@ -21,6 +21,11 @@ config:
 
 # configGroupLabel: config.nri/group
 
+# Extra environment variables to inject.
+#extraEnv:
+#   VAR1: VAL1
+#   VAR2: VAL2
+
 plugin-test:
   enableAPIs: false
 

--- a/docs/resource-policy/developers-guide/cpu-allocator.md
+++ b/docs/resource-policy/developers-guide/cpu-allocator.md
@@ -17,7 +17,8 @@ The CPU allocator also does automatic CPU prioritization by detecting CPU
 features and their configuration parameters. Currently, NRI Resource Policy
 supports CPU priority detection based on the `intel_pstate` scaling
 driver in the Linux CPUFreq subsystem, and, Intel Speed Select Technology
-(SST).
+(SST), or based on the detected core types on hybrid CPU architecture
+systems.
 
 CPUs are divided into three priority classes, i.e. *high*, *normal* and *low*.
 Policies utilizing the CPU allocator may choose to prefer certain priority
@@ -59,3 +60,10 @@ correspondingly.
 
 CPU cores with high EPP priority (relative to the other cores in the system)
 will be marked as high priority cores.
+
+### Hybrid CPU Architecture
+
+On systems with a hybrid CPU architecture, where some cores are optimized for
+performance and others for power consumption, performance optimized cores are
+classified as high priority CPUs while energy efficient cores as low priority
+CPUs.

--- a/docs/resource-policy/policy/topology-aware.md
+++ b/docs/resource-policy/policy/topology-aware.md
@@ -139,6 +139,12 @@ behavior. These options can be supplied as part of the effective
 - `colocateNamespaces`
   - whether try to allocate containers in a namespace to the same or close by
     topology pools
+- `defaultCPUPriority`
+  - is the default CPU prioritization, used when a container has not been
+    annotated with any other CPU preferences. The possible values are: `high`,
+    `normal`, `low`, and `none`. Currently this option only affects exclusive
+    CPU allocations. For a more detailed discussion of CPU prioritization see
+    the [cpu allocator](../developers-guide/cpu-allocator.md) documentation.
 
 ## Policy CPU Allocation Preferences
 
@@ -225,7 +231,7 @@ preferences the policy would otherwise apply to them. These Pod annotations
 can be given both with per pod and per container resolution. If for any
 container both of these exist, the container-specific one takes precedence.
 
-### Shared, Exclusive, and Isolated CPU Preference
+### Shared, Exclusive, and Isolated CPU Preference, CPU Priorities
 
 A container can opt in to or opt out from shared CPU allocation using the
 following Pod annotation.
@@ -239,6 +245,9 @@ metadata:
     prefer-shared-cpus.resource-policy.nri.io/pod: "true"
     # selectively opt out container C2 from shared CPU core allocation
     prefer-shared-cpus.resource-policy.nri.io/container.C2: "false"
+    # prefer low-prio CPUs for all others except the 'pump' container
+    prefer-cpu-priority.resource-policy.nri.io/pod: low
+    prefer-cpu-priority.resource-policy.nri.io/container.pump: high
 ```
 
 Opting in to exclusive allocation happens by opting out from shared allocation,

--- a/pkg/apis/config/v1alpha1/resmgr/policy/topologyaware/config.go
+++ b/pkg/apis/config/v1alpha1/resmgr/policy/topologyaware/config.go
@@ -15,7 +15,10 @@
 package topologyaware
 
 import (
+	"strings"
+
 	policy "github.com/containers/nri-plugins/pkg/apis/config/v1alpha1/resmgr/policy"
+	"github.com/containers/nri-plugins/pkg/cpuallocator"
 )
 
 type (
@@ -32,6 +35,27 @@ const (
 	AmountQuantity = policy.AmountQuantity
 	AmountCPUSet   = policy.AmountCPUSet
 )
+
+type CPUPriority string
+
+const (
+	PriorityHigh   CPUPriority = "high"
+	PriorityNormal CPUPriority = "normal"
+	PriorityLow    CPUPriority = "low"
+	PriorityNone   CPUPriority = "none"
+)
+
+func (p CPUPriority) Value() cpuallocator.CPUPriority {
+	switch strings.ToLower(string(p)) {
+	case string(PriorityHigh):
+		return cpuallocator.PriorityHigh
+	case string(PriorityNormal):
+		return cpuallocator.PriorityNormal
+	case string(PriorityLow):
+		return cpuallocator.PriorityLow
+	}
+	return cpuallocator.PriorityNone
+}
 
 // +k8s:deepcopy-gen=true
 // +optional
@@ -77,4 +101,12 @@ type Config struct {
 	// of it.
 	// +kubebuilder:validation:Required
 	ReservedResources Constraints `json:"reservedResources"`
+	// DefaultCPUPriority (high, normal, low, none) is the preferred CPU
+	// priority for allocated CPUs when a container has not been annotated
+	// with any other CPU preference.
+	// Notes: Currently this option only affects exclusive CPU allocations.
+	// +kubebuilder:validation:Enum=high;normal;low;none
+	// +kubebuilder:default=none
+	// +kubebuilder:validation:Format:string
+	DefaultCPUPriority CPUPriority `json:"defaultCPUPriority,omitempty"`
 }

--- a/pkg/cpuallocator/allocator.go
+++ b/pkg/cpuallocator/allocator.go
@@ -65,6 +65,7 @@ type allocatorHelper struct {
 type CPUAllocator interface {
 	AllocateCpus(from *cpuset.CPUSet, cnt int, prefer CPUPriority) (cpuset.CPUSet, error)
 	ReleaseCpus(from *cpuset.CPUSet, cnt int, prefer CPUPriority) (cpuset.CPUSet, error)
+	GetCPUPriorities() map[CPUPriority]cpuset.CPUSet
 }
 
 type CPUPriority int
@@ -674,6 +675,16 @@ func (ca *cpuAllocator) ReleaseCpus(from *cpuset.CPUSet, cnt int, prefer CPUPrio
 	ca.Debug("ReleaseCpus(#%s, %d) => kept: #%s, released: #%s", oset, cnt, from, result)
 
 	return result, err
+}
+
+// GetCPUPriorities returns the CPUSets for the discovered priorities.
+func (ca *cpuAllocator) GetCPUPriorities() map[CPUPriority]cpuset.CPUSet {
+	prios := make(map[CPUPriority]cpuset.CPUSet)
+	for prio := CPUPriority(0); prio < NumCPUPriorities; prio++ {
+		cset := ca.topologyCache.cpuPriorities[prio]
+		prios[prio] = cset.Clone()
+	}
+	return prios
 }
 
 func newTopologyCache(sys sysfs.System) topologyCache {

--- a/test/e2e/policies.test-suite/topology-aware/helm-config.yaml.in
+++ b/test/e2e/policies.test-suite/topology-aware/helm-config.yaml.in
@@ -24,3 +24,10 @@ config:
     source: true
     klog:
       skip_headers: true
+
+$([ -n "${!EXTRA_ENV_*}" ] && echo "
+extraEnv:
+  $(for var in ${!EXTRA_ENV_*}; do [[ "${!var}" != "" ]] && echo "
+  ${var#EXTRA_ENV_}: ${!var}
+  "; done)
+")

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test08-cpuprio-allocation/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test08-cpuprio-allocation/code.var.sh
@@ -1,0 +1,55 @@
+# Test that guaranteed and burstable pods get the CPUs they require
+# when there are enough CPUs available.
+
+# Override CPU type detection, to detect 2 low-power CPUs
+helm-terminate
+EXTRA_ENV_OVERRIDE_SYS_ATOM_CPUS="4-5" helm_config=$(instantiate helm-config.yaml) helm-launch topology-aware
+
+# pod0
+# 3 containers, one with normal CPU preference, two with low-prio CPU.
+ANN0="prefer-cpu-priority.resource-policy.nri.io/container.pod0c0: low"
+ANN2="prefer-cpu-priority.resource-policy.nri.io/container.pod0c2: low"
+CONTCOUNT=3 CPU=1 create guaranteed
+report allowed
+
+verify \
+    'cpus["pod0c0"] == {"cpu04"}' \
+    'cpus["pod0c1"] not in [ {"cpu04"}, {"cpu05"} ]' \
+    'cpus["pod0c2"] == {"cpu05"}'
+
+vm-command "kubectl delete pods --all --now"
+
+# Override CPU type detection, to detect 3 high-perf CPUs (one extra
+# for the reserved CPU allocation for which we currently always prefer
+# normal prio CPUs).
+helm-terminate
+EXTRA_ENV_OVERRIDE_SYS_CORE_CPUS="0-1,4-5" helm_config=$(instantiate helm-config.yaml) helm-launch topology-aware
+
+# pod1
+# 3 containers, default with low-prio CPU preference, two with high-prio CPU.
+ANN0="prefer-cpu-priority.resource-policy.nri.io/pod: low"
+ANN0="prefer-cpu-priority.resource-policy.nri.io/container.pod1c0: high"
+ANN2="prefer-cpu-priority.resource-policy.nri.io/container.pod1c2: high"
+CONTCOUNT=3 CPU=1 create guaranteed
+report allowed
+
+# cpu00 will be allocated for the reserved pool. Our two high-prio
+# containers should first take cpu04 (preferred NUMA node with fewer
+# containers, lower of the available normal prio cpu04-cpu-5), then
+# should take cpu01 (lower ID of NUMA nodes with equal score). The
+# low-prio container in between should take some other CPU that
+# cpu1,4,5.
+#
+# However, the only CPU allocation detail of interest here is that
+# we want normal prio CPUs (in the lack of high-prio ones) for our
+# containers annotated with high-prio CPU preference. So only check
+# for that instead of pretending to both understand and remember
+# all the various preference details of the allocation pool selection
+# and allocation logic.
+
+verify \
+    'cpus["pod1c0"] in     [ {"cpu01"}, {"cpu04"}, {"cpu05"} ]' \
+    'cpus["pod1c1"] not in [ {"cpu01"}, {"cpu04"}, {"cpu05"} ]' \
+    'cpus["pod1c2"] in     [ {"cpu01"}, {"cpu04"}, {"cpu05"} ]' \
+
+vm-command "kubectl delete pods --all --now"


### PR DESCRIPTION
Add support for configuring the default CPU priority preference and annotating pod-/container-level CPU priority preferences. These determine the preferred priority for CPUs when doing fully or partially exclusive CPU allocation. Priorities are calculated for such allocations and passed on to the CPU allocator which then tries to fulfill these preferences.

With this PR in place, it should be possible on hybrid core architecture systems to configure the policy to prefer allocating energy-efficient cores by default and performance optimized cores to containers annotated with such a preference, or vice versa. Additionally, due to the recently introduced (CPU) cluster-awareness in the CPU allocator, this policy should now do exclusive allocations in a (CPU) cluster-aware fashion, preferring to allocate one or more full CPU clusters  when the requested number of CPUs allows this to happen.