### PR TITLE
.github: install exact golang version if necessary.

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -8,6 +8,9 @@ on:
     tags:
         - v*
 
+env:
+  GO_VERSION: "1.22.1"
+
 concurrency:
   group: gh-pages
 
@@ -19,6 +22,14 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Install exact golang version from release tarball if needed
+      run: |
+        go_version=$(go version | sed 's/^go version //;s/ .*$//')
+        if [ "$go_version" != "${{ env.GO_VERSION }} " ]; then
+            wget https://go.dev/dl/go${{ env.GO_VERSION }}.linux-amd64.tar.gz
+            sudo tar -C /usr/local -xzf go${{ env.GO_VERSION }}.linux-amd64.tar.gz
+            echo "/usr/local/go/bin" >> $GITHUB_PATH
+        fi
     - name: Install build dependencies
       run: |
         pip3 install --user -r docs/requirements.txt


### PR DESCRIPTION
When building and publishing documentation, install golang toolchain from release tarball if necessary.