### PR TITLE
e2e: pull busybox from quay.io instead of dockerhub.

### DIFF
--- a/test/e2e/files/besteffort.yaml.in
+++ b/test/e2e/files/besteffort.yaml.in
@@ -17,7 +17,7 @@ spec:
   containers:
   $(for contnum in $(seq 1 ${CONTCOUNT}); do echo "
   - name: ${NAME}c$(( contnum - 1 ))
-    image: busybox
+    image: quay.io/prometheus/busybox
     imagePullPolicy: IfNotPresent
     command:
       - sh

--- a/test/e2e/files/burstable.yaml.in
+++ b/test/e2e/files/burstable.yaml.in
@@ -17,7 +17,7 @@ spec:
   containers:
   $(for contnum in $(seq 1 ${CONTCOUNT}); do echo "
   - name: ${NAME}c$(( contnum - 1 ))
-    image: busybox
+    image: quay.io/prometheus/busybox
     imagePullPolicy: IfNotPresent
     command:
       - sh

--- a/test/e2e/files/guaranteed.yaml.in
+++ b/test/e2e/files/guaranteed.yaml.in
@@ -18,7 +18,7 @@ spec:
   initContainers:
   $(for contnum in $(seq 1 ${ICONTCOUNT}); do echo "
   - name: ${NAME}c$(( contnum - 1 ))i
-    image: busybox
+    image: quay.io/prometheus/busybox
     imagePullPolicy: IfNotPresent
     command:
       - sh
@@ -36,7 +36,7 @@ spec:
   containers:
   $(for contnum in $(seq 1 ${CONTCOUNT}); do echo "
   - name: ${NAME}c$(( contnum - 1 ))
-    image: busybox
+    image: quay.io/prometheus/busybox
     imagePullPolicy: IfNotPresent
     command:
       - sh

--- a/test/e2e/files/nri-memory-qos-test-pod.yaml
+++ b/test/e2e/files/nri-memory-qos-test-pod.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   containers:
   - name: c0-lowprio
-    image: busybox
+    image: quay.io/prometheus/busybox
     imagePullPolicy: IfNotPresent
     command:
       - sh
@@ -29,7 +29,7 @@ spec:
       limits:
         memory: 100M
   - name: c1-normal
-    image: busybox
+    image: quay.io/prometheus/busybox
     imagePullPolicy: IfNotPresent
     command:
       - sh
@@ -41,7 +41,7 @@ spec:
       limits:
         memory: 100M
   - name: c2-noswap
-    image: busybox
+    image: quay.io/prometheus/busybox
     imagePullPolicy: IfNotPresent
     command:
       - sh

--- a/test/e2e/files/nri-memtierd-test-pod.yaml
+++ b/test/e2e/files/nri-memtierd-test-pod.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   containers:
   - name: c0-lowprio
-    image: busybox
+    image: quay.io/prometheus/busybox
     imagePullPolicy: IfNotPresent
     command:
       - sh
@@ -35,7 +35,7 @@ spec:
       limits:
         memory: 100M
   - name: c1-normal
-    image: busybox
+    image: quay.io/prometheus/busybox
     imagePullPolicy: IfNotPresent
     command:
       - sh
@@ -47,7 +47,7 @@ spec:
       limits:
         memory: 100M
   - name: c2-noswap
-    image: busybox
+    image: quay.io/prometheus/busybox
     imagePullPolicy: IfNotPresent
     command:
       - sh

--- a/test/e2e/policies.test-suite/balloons/balloons-busybox.yaml.in
+++ b/test/e2e/policies.test-suite/balloons/balloons-busybox.yaml.in
@@ -15,7 +15,7 @@ spec:
   containers:
   $(for contnum in $(seq 1 ${CONTCOUNT}); do echo "
   - name: ${NAME}c$(( contnum - 1 ))
-    image: busybox
+    image: quay.io/prometheus/busybox
     imagePullPolicy: IfNotPresent
     command:
       - sh

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test03-simple-affinity/guaranteed+affinity.yaml.in
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test03-simple-affinity/guaranteed+affinity.yaml.in
@@ -12,7 +12,7 @@ spec:
   containers:
   $(for contnum in $(seq 1 ${CONTCOUNT}); do echo "
   - name: ${NAME}c$(( contnum - 1 ))
-    image: busybox
+    image: quay.io/prometheus/busybox
     imagePullPolicy: IfNotPresent
     command:
       - sh

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test07-mixed-allocations/guaranteed-annotated.yaml.in
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test07-mixed-allocations/guaranteed-annotated.yaml.in
@@ -14,7 +14,7 @@ spec:
   containers:
   $(for contnum in $(seq 1 ${CONTCOUNT}); do echo "
   - name: ${NAME}c$(( contnum - 1 ))
-    image: busybox
+    image: quay.io/prometheus/busybox
     imagePullPolicy: IfNotPresent
     command:
       - sh

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test11-reserved-cpu-annotations/reserved-annotated.yaml.in
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test11-reserved-cpu-annotations/reserved-annotated.yaml.in
@@ -14,7 +14,7 @@ spec:
   containers:
   $(for contnum in $(seq 1 ${CONTCOUNT}); do echo "
   - name: ${NAME}c$(( contnum - 1 ))
-    image: busybox
+    image: quay.io/prometheus/busybox
     imagePullPolicy: IfNotPresent
     command:
       - sh


### PR DESCRIPTION
Pull busybox from quay.io/prometheus to avoid dockerhub rate limiting pull errors causing false test failures.