### PR TITLE
build: docker-build with correct version in git worktrees.

### DIFF
--- a/cmd/plugins/balloons/Dockerfile
+++ b/cmd/plugins/balloons/Dockerfile
@@ -2,6 +2,9 @@ ARG GO_VERSION=1.22
 
 FROM golang:${GO_VERSION}-bullseye as builder
 
+ARG IMAGE_VERSION
+ARG BUILD_VERSION
+ARG BUILD_BUILDID
 WORKDIR /go/builder
 
 # Fetch go dependencies in a separate layer for caching
@@ -13,7 +16,7 @@ RUN go mod download
 COPY . .
 
 RUN make clean
-RUN make PLUGINS=nri-resource-policy-balloons build-plugins-static
+RUN make IMAGE_VERSION=${IMAGE_VERSION} BUILD_VERSION=${BUILD_VERSION} BUILD_BUILDID=${BUILD_BUILDID} PLUGINS=nri-resource-policy-balloons build-plugins-static
 
 FROM gcr.io/distroless/static
 

--- a/cmd/plugins/memory-qos/Dockerfile
+++ b/cmd/plugins/memory-qos/Dockerfile
@@ -2,6 +2,9 @@ ARG GO_VERSION=1.22
 
 FROM golang:${GO_VERSION}-bullseye as builder
 
+ARG IMAGE_VERSION
+ARG BUILD_VERSION
+ARG BUILD_BUILDID
 WORKDIR /go/builder
 
 # Fetch go dependencies in a separate layer for caching
@@ -13,7 +16,7 @@ RUN go mod download
 COPY . .
 
 RUN make clean
-RUN make PLUGINS=nri-memory-qos build-plugins-static
+RUN make IMAGE_VERSION=${IMAGE_VERSION} BUILD_VERSION=${BUILD_VERSION} BUILD_BUILDID=${BUILD_BUILDID} PLUGINS=nri-memory-qos build-plugins-static
 
 FROM gcr.io/distroless/static
 

--- a/cmd/plugins/memtierd/Dockerfile
+++ b/cmd/plugins/memtierd/Dockerfile
@@ -1,5 +1,8 @@
 FROM golang:1.22-bullseye as builder
 
+ARG IMAGE_VERSION
+ARG BUILD_VERSION
+ARG BUILD_BUILDID
 WORKDIR /go/builder
 
 RUN GOBIN=/bin go install -tags osusergo,netgo -ldflags "-extldflags=-static" github.com/intel/memtierd/cmd/memtierd@v0.1.1
@@ -13,7 +16,7 @@ RUN go mod download
 COPY . .
 
 RUN make clean
-RUN make PLUGINS=nri-memtierd build-plugins-static
+RUN make IMAGE_VERSION=${IMAGE_VERSION} BUILD_VERSION=${BUILD_VERSION} BUILD_BUILDID=${BUILD_BUILDID} PLUGINS=nri-memtierd build-plugins-static
 
 FROM gcr.io/distroless/static
 ENV PATH=/bin

--- a/cmd/plugins/sgx-epc/Dockerfile
+++ b/cmd/plugins/sgx-epc/Dockerfile
@@ -2,6 +2,9 @@ ARG GO_VERSION=1.22
 
 FROM golang:${GO_VERSION}-bullseye as builder
 
+ARG IMAGE_VERSION
+ARG BUILD_VERSION
+ARG BUILD_BUILDID
 WORKDIR /go/builder
 
 # Fetch go dependencies in a separate layer for caching
@@ -13,7 +16,7 @@ RUN go mod download
 COPY . .
 
 RUN make clean
-RUN make PLUGINS=nri-sgx-epc build-plugins-static
+RUN make IMAGE_VERSION=${IMAGE_VERSION} BUILD_VERSION=${BUILD_VERSION} BUILD_BUILDID=${BUILD_BUILDID} PLUGINS=nri-sgx-epc build-plugins-static
 
 FROM gcr.io/distroless/static
 

--- a/cmd/plugins/template/Dockerfile
+++ b/cmd/plugins/template/Dockerfile
@@ -2,6 +2,9 @@ ARG GO_VERSION=1.22
 
 FROM golang:${GO_VERSION}-bullseye as builder
 
+ARG IMAGE_VERSION
+ARG BUILD_VERSION
+ARG BUILD_BUILDID
 WORKDIR /go/builder
 
 # Fetch go dependencies in a separate layer for caching
@@ -13,7 +16,7 @@ RUN go mod download
 COPY . .
 
 RUN make clean
-RUN make PLUGINS=nri-resource-policy-template build-plugins-static
+RUN make IMAGE_VERSION=${IMAGE_VERSION} BUILD_VERSION=${BUILD_VERSION} BUILD_BUILDID=${BUILD_BUILDID} PLUGINS=nri-resource-policy-template build-plugins-static
 
 FROM gcr.io/distroless/static
 

--- a/cmd/plugins/topology-aware/Dockerfile
+++ b/cmd/plugins/topology-aware/Dockerfile
@@ -2,6 +2,9 @@ ARG GO_VERSION=1.22
 
 FROM golang:${GO_VERSION}-bullseye as builder
 
+ARG IMAGE_VERSION
+ARG BUILD_VERSION
+ARG BUILD_BUILDID
 WORKDIR /go/builder
 
 # Fetch go dependencies in a separate layer for caching
@@ -13,7 +16,7 @@ RUN go mod download
 COPY . .
 
 RUN make clean
-RUN make PLUGINS=nri-resource-policy-topology-aware build-plugins-static
+RUN make IMAGE_VERSION=${IMAGE_VERSION} BUILD_VERSION=${BUILD_VERSION} BUILD_BUILDID=${BUILD_BUILDID} PLUGINS=nri-resource-policy-topology-aware build-plugins-static
 
 FROM gcr.io/distroless/static
 


### PR DESCRIPTION
When we're docker-building images in a git worktree, version detection (which uses git-describe in the end) does not work correctly, since inside the docker build context .git refers to a non-existent git repo directory. Therefore pass version info to docker-build as build args.