### PR TITLE
go.mod: align go version in go.mod with project's semantic version

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -3,8 +3,8 @@ FROM sphinxdoc/sphinx:5.3.0
 RUN apt-get update && apt-get install -y wget git
 
 # Note: Any golang version that can 'go list -m -f {{.Variable}}' is fine...
-RUN wget https://go.dev/dl/go1.20.4.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go1.20.4.linux-amd64.tar.gz
+RUN wget https://go.dev/dl/go1.22.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go1.22.1.linux-amd64.tar.gz
 
 ENV PATH=$PATH:/usr/local/go/bin
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containers/nri-plugins
 
-go 1.22
+go 1.22.1
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2


### PR DESCRIPTION
In the Go 1.21 release, support was introduced to enforce stricter version control within go.mod files, enabling the specification of patch versions. This commit synchronizes the Go version specified in go.mod with the semantic version used across other files (dockefile, etc) for the sake of consistency.