### PR TITLE
.github: fix unstable chart version and registry path.

### DIFF
--- a/.github/workflows/package-helm.yaml
+++ b/.github/workflows/package-helm.yaml
@@ -69,7 +69,7 @@ jobs:
           # For unstable chart verison we use:
           #   - chart version: x.y-unstable derived from the latest tag x.y.z
           #   - image version: 'unstable'.
-          majmin="$(git describe | sed -E 's/v([0-9]*\.[0-9]*).*$/\1/')"
+          majmin="$(git describe | sed -E 's/(v[0-9]*\.[0-9]*).*$/\1/')"
           CHART_VERSION="${majmin}-unstable"
           APP_VERSION=unstable
           # Package charts
@@ -98,6 +98,6 @@ jobs:
           #   between new tags unstable chart have the same version, though.
           pushd ../$UNSTABLE_CHARTS
           for i in ./*.tgz; do
-              helm push $i oci://${{ env.REGISTRY }}/${{ env.REGISTRY_PATH }}
+              helm push $i oci://${{ env.REGISTRY }}/${{ env.REGISTRY_PATH }}/helm-charts
           done
           popd

--- a/docs/deployment/helm/index.md
+++ b/docs/deployment/helm/index.md
@@ -32,14 +32,14 @@ are stored alongside plugin images in the OCI image registry.
 Unstable charts can be discovered using [skopeo](https://github.com/containers/skopeo).
 For instance, one can list the available charts for the balloons plugin using this
 skopeo command:
-`skopeo list-tags docker://ghcr.io/containers/nri-plugins/nri-resource-policy-balloons`
+`skopeo list-tags docker://ghcr.io/containers/nri-plugins/helm-charts/nri-resource-policy-balloons`
 
 ### Using Unstable Helm Charts
 
 Once discovered, unstable Helm charts can be used like any other. For instance, to use
-the `$X.$Y-unstable` version of the chart to install the development version of the
+the `v$X.$Y-unstable` version of the chart to install the development version of the
 balloons plugin one can use this command:
-`helm install --devel -n kube-system test oci://ghcr.io/containers/nri-plugins/nri-resource-policy-balloons --version $X.$Y-unstable --set image.tag=unstable --set image.pullPolicy=Always`
+`helm install --devel -n kube-system test oci://ghcr.io/containers/nri-plugins/helm-charts/nri-resource-policy-balloons --version v$X.$Y-unstable --set image.tag=unstable --set image.pullPolicy=Always`
 
 ```{toctree}
 ---


### PR DESCRIPTION
Add latest fixes which I managed to mis-push and thus omit from the merged version. These fix the Helm chart version to have a leading 'v', add a trailing '/helm-charts' to the registry push path and update the documentation accordingly.