### PR TITLE
github: don't trigger docs update on non-release tags

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -6,7 +6,7 @@ on:
         - main
         - release-*
     tags:
-        - v*
+        - v[0-9]+.[0-9]+.[0-9]+
 
 env:
   GO_VERSION: "1.22.1"


### PR DESCRIPTION
When triggered from a tag, our gh-pages update script considers this as a new release. This means potentially (if it's the first tag in the vX.Y series) creating a new vX.Y/ subdir in the docs, linking that as the latest stable release etc. We definitely don't want this to happen for devel or rc or such tags. Modifying the workflow file to only act on well-formed release tags (like v1.2.3) is the most straightforward way to fix this.