### PR TITLE
[release-0.4]: enable devel (unstable) Helm charts

### DIFF
--- a/.github/workflows/package-helm.yaml
+++ b/.github/workflows/package-helm.yaml
@@ -6,6 +6,7 @@ on:
       - "v*.*.*"
     branches:
       - main
+      - release-*
 
 env:
   CHARTS_DIR: deployment/helm/
@@ -71,7 +72,11 @@ jobs:
           #   - image version: 'unstable'.
           majmin="$(git describe --tags | sed -E 's/(v[0-9]*\.[0-9]*).*$/\1/')"
           CHART_VERSION="${majmin}-unstable"
-          APP_VERSION=unstable
+          if [  $GITHUB_REF_NAME = "main" ]; then
+              APP_VERSION=unstable
+          else
+              APP_VERSION="${majmin}-unstable"
+          fi
           # Package charts
           find "$CHARTS_DIR" -name values.yaml | xargs -I '{}' \
               sed -e s"/pullPolicy:.*/pullPolicy: Always/" -i '{}'

--- a/.github/workflows/package-helm.yaml
+++ b/.github/workflows/package-helm.yaml
@@ -69,7 +69,7 @@ jobs:
           # For unstable chart verison we use:
           #   - chart version: x.y-unstable derived from the latest tag x.y.z
           #   - image version: 'unstable'.
-          majmin="$(git describe | sed -E 's/v([0-9]*\.[0-9]*).*$/\1/')"
+          majmin="$(git describe | sed -E 's/(v[0-9]*\.[0-9]*).*$/\1/')"
           CHART_VERSION="${majmin}-unstable"
           APP_VERSION=unstable
           # Package charts
@@ -98,6 +98,6 @@ jobs:
           #   between new tags unstable chart have the same version, though.
           pushd ../$UNSTABLE_CHARTS
           for i in ./*.tgz; do
-              helm push $i oci://${{ env.REGISTRY }}/${{ env.REGISTRY_PATH }}
+              helm push $i oci://${{ env.REGISTRY }}/${{ env.REGISTRY_PATH }}/helm-charts
           done
           popd

--- a/.github/workflows/package-helm.yaml
+++ b/.github/workflows/package-helm.yaml
@@ -69,7 +69,7 @@ jobs:
           # For unstable chart verison we use:
           #   - chart version: x.y-unstable derived from the latest tag x.y.z
           #   - image version: 'unstable'.
-          majmin="$(git describe | sed -E 's/(v[0-9]*\.[0-9]*).*$/\1/')"
+          majmin="$(git describe --tags | sed -E 's/(v[0-9]*\.[0-9]*).*$/\1/')"
           CHART_VERSION="${majmin}-unstable"
           APP_VERSION=unstable
           # Package charts

--- a/.github/workflows/package-helm.yaml
+++ b/.github/workflows/package-helm.yaml
@@ -4,12 +4,20 @@ on:
   push:
     tags:
       - "v*.*.*"
+    branches:
+      - main
 
 env:
   CHARTS_DIR: deployment/helm/
+  IS_RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') && 'true' || 'false' }}
+  UNSTABLE_CHARTS: unstable-helm-charts
+  REGISTRY: ghcr.io
+  REGISTRY_USER: ${{ github.repository_owner }}
+  REGISTRY_PATH: ${{ github.repository }}
 
 jobs:
   release:
+    if: ${{ github.env.IS_RELEASE == 'true' }}
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -20,7 +28,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4.0.0
 
-      - name: Package Helm charts
+      - name: Package Stable Helm Charts
         run: |
           find "$CHARTS_DIR" -name values.yaml | xargs -I '{}' \
               sed -e s"/pullPolicy:.*/pullPolicy: IfNotPresent/" -i '{}'
@@ -30,10 +38,66 @@ jobs:
             mv $SRC_FILE $DEST_FILE
           done
 
-      - name: Upload Helm packages to GitHub releases
+      - name: Upload Stable Helm Charts to GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           name: ${{ github.ref_name }}
           draft: true
           append_body: true
           files: nri-*helm-chart*.tgz
+
+  unstable:
+    concurrency:
+      group: unstable-helm-charts
+      cancel-in-progress: false
+    if: ${{ github.env.IS_RELEASE != 'true' }}
+    permissions:
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deep Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4.0.0
+
+      - name: Package Unstable Helm Charts
+        id: package-charts
+        run: |
+          # For unstable chart verison we use:
+          #   - chart version: x.y-unstable derived from the latest tag x.y.z
+          #   - image version: 'unstable'.
+          majmin="$(git describe | sed -E 's/v([0-9]*\.[0-9]*).*$/\1/')"
+          CHART_VERSION="${majmin}-unstable"
+          APP_VERSION=unstable
+          # Package charts
+          find "$CHARTS_DIR" -name values.yaml | xargs -I '{}' \
+              sed -e s"/pullPolicy:.*/pullPolicy: Always/" -i '{}'
+          helm package --version "$CHART_VERSION" --app-version $APP_VERSION "$CHARTS_DIR"/*
+          find "$CHARTS_DIR" -name values.yaml | xargs -I '{}' \
+              git checkout '{}'
+          mkdir ../$UNSTABLE_CHARTS
+          find . -name '*.tgz' -print | while read SRC_FILE; do
+            DEST_FILE=$(echo $SRC_FILE | sed 's/v/helm-chart-v/g')
+            mv -v $SRC_FILE ../$UNSTABLE_CHARTS/$DEST_FILE
+          done
+
+      - name: Log In To Registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+              helm registry login ${{ env.REGISTRY }}/${{ env.REGISTRY_PATH }} -u ${{ env.REGISTRY_USER }} --password-stdin
+
+      - name: Push Unstable Helm Charts To Registry
+        shell: bash
+        run: |
+          # Notes:
+          #   Currently we only publish unstable Helm charts from main/HEAD.
+          #   We have no active cleanup of old unstable charts in place. In
+          #   between new tags unstable chart have the same version, though.
+          pushd ../$UNSTABLE_CHARTS
+          for i in ./*.tgz; do
+              helm push $i oci://${{ env.REGISTRY }}/${{ env.REGISTRY_PATH }}
+          done
+          popd

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -6,7 +6,7 @@ on:
         - main
         - release-*
     tags:
-        - v*
+        - v[0-9]+.[0-9]+.[0-9]+
 
 env:
   GO_VERSION: "1.22.1"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ SHELL := /bin/bash
 # Kubernetes version we pull in as modules and our external API versions.
 KUBERNETES_VERSION := $(shell grep 'k8s.io/kubernetes ' go.mod | sed 's/^.* //')
 
-IMAGE_VERSION  ?= $(shell git describe --dirty 2> /dev/null || echo v0.0.0-unknown)
+IMAGE_VERSION  ?= $(shell git describe --tags --dirty 2> /dev/null || echo v0.0.0-unknown)
 ifdef IMAGE_REPO
     override IMAGE_REPO := $(IMAGE_REPO)/
 endif

--- a/cmd/plugins/balloons/Dockerfile
+++ b/cmd/plugins/balloons/Dockerfile
@@ -2,6 +2,9 @@ ARG GO_VERSION=1.22
 
 FROM golang:${GO_VERSION}-bullseye as builder
 
+ARG IMAGE_VERSION
+ARG BUILD_VERSION
+ARG BUILD_BUILDID
 WORKDIR /go/builder
 
 # Fetch go dependencies in a separate layer for caching
@@ -13,7 +16,7 @@ RUN go mod download
 COPY . .
 
 RUN make clean
-RUN make PLUGINS=nri-resource-policy-balloons build-plugins-static
+RUN make IMAGE_VERSION=${IMAGE_VERSION} BUILD_VERSION=${BUILD_VERSION} BUILD_BUILDID=${BUILD_BUILDID} PLUGINS=nri-resource-policy-balloons build-plugins-static
 
 FROM gcr.io/distroless/static
 

--- a/cmd/plugins/memory-qos/Dockerfile
+++ b/cmd/plugins/memory-qos/Dockerfile
@@ -2,6 +2,9 @@ ARG GO_VERSION=1.22
 
 FROM golang:${GO_VERSION}-bullseye as builder
 
+ARG IMAGE_VERSION
+ARG BUILD_VERSION
+ARG BUILD_BUILDID
 WORKDIR /go/builder
 
 # Fetch go dependencies in a separate layer for caching
@@ -13,7 +16,7 @@ RUN go mod download
 COPY . .
 
 RUN make clean
-RUN make PLUGINS=nri-memory-qos build-plugins-static
+RUN make IMAGE_VERSION=${IMAGE_VERSION} BUILD_VERSION=${BUILD_VERSION} BUILD_BUILDID=${BUILD_BUILDID} PLUGINS=nri-memory-qos build-plugins-static
 
 FROM gcr.io/distroless/static
 

--- a/cmd/plugins/memtierd/Dockerfile
+++ b/cmd/plugins/memtierd/Dockerfile
@@ -1,5 +1,8 @@
 FROM golang:1.22-bullseye as builder
 
+ARG IMAGE_VERSION
+ARG BUILD_VERSION
+ARG BUILD_BUILDID
 WORKDIR /go/builder
 
 RUN GOBIN=/bin go install -tags osusergo,netgo -ldflags "-extldflags=-static" github.com/intel/memtierd/cmd/memtierd@v0.1.1
@@ -13,7 +16,7 @@ RUN go mod download
 COPY . .
 
 RUN make clean
-RUN make PLUGINS=nri-memtierd build-plugins-static
+RUN make IMAGE_VERSION=${IMAGE_VERSION} BUILD_VERSION=${BUILD_VERSION} BUILD_BUILDID=${BUILD_BUILDID} PLUGINS=nri-memtierd build-plugins-static
 
 FROM gcr.io/distroless/static
 ENV PATH=/bin

--- a/cmd/plugins/sgx-epc/Dockerfile
+++ b/cmd/plugins/sgx-epc/Dockerfile
@@ -2,6 +2,9 @@ ARG GO_VERSION=1.22
 
 FROM golang:${GO_VERSION}-bullseye as builder
 
+ARG IMAGE_VERSION
+ARG BUILD_VERSION
+ARG BUILD_BUILDID
 WORKDIR /go/builder
 
 # Fetch go dependencies in a separate layer for caching
@@ -13,7 +16,7 @@ RUN go mod download
 COPY . .
 
 RUN make clean
-RUN make PLUGINS=nri-sgx-epc build-plugins-static
+RUN make IMAGE_VERSION=${IMAGE_VERSION} BUILD_VERSION=${BUILD_VERSION} BUILD_BUILDID=${BUILD_BUILDID} PLUGINS=nri-sgx-epc build-plugins-static
 
 FROM gcr.io/distroless/static
 

--- a/cmd/plugins/template/Dockerfile
+++ b/cmd/plugins/template/Dockerfile
@@ -2,6 +2,9 @@ ARG GO_VERSION=1.22
 
 FROM golang:${GO_VERSION}-bullseye as builder
 
+ARG IMAGE_VERSION
+ARG BUILD_VERSION
+ARG BUILD_BUILDID
 WORKDIR /go/builder
 
 # Fetch go dependencies in a separate layer for caching
@@ -13,7 +16,7 @@ RUN go mod download
 COPY . .
 
 RUN make clean
-RUN make PLUGINS=nri-resource-policy-template build-plugins-static
+RUN make IMAGE_VERSION=${IMAGE_VERSION} BUILD_VERSION=${BUILD_VERSION} BUILD_BUILDID=${BUILD_BUILDID} PLUGINS=nri-resource-policy-template build-plugins-static
 
 FROM gcr.io/distroless/static
 

--- a/cmd/plugins/topology-aware/Dockerfile
+++ b/cmd/plugins/topology-aware/Dockerfile
@@ -2,6 +2,9 @@ ARG GO_VERSION=1.22
 
 FROM golang:${GO_VERSION}-bullseye as builder
 
+ARG IMAGE_VERSION
+ARG BUILD_VERSION
+ARG BUILD_BUILDID
 WORKDIR /go/builder
 
 # Fetch go dependencies in a separate layer for caching
@@ -13,7 +16,7 @@ RUN go mod download
 COPY . .
 
 RUN make clean
-RUN make PLUGINS=nri-resource-policy-topology-aware build-plugins-static
+RUN make IMAGE_VERSION=${IMAGE_VERSION} BUILD_VERSION=${BUILD_VERSION} BUILD_BUILDID=${BUILD_BUILDID} PLUGINS=nri-resource-policy-topology-aware build-plugins-static
 
 FROM gcr.io/distroless/static
 

--- a/deployment/operator/Makefile
+++ b/deployment/operator/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
 # Default image version (tag) and image save path.
-IMAGE_VERSION ?= $(shell git describe --dirty 2> /dev/null)
+IMAGE_VERSION ?= $(shell git describe --tags --dirty 2> /dev/null)
 IMAGE_PATH ?= .
 
 # CHANNELS define the bundle channels used in the bundle.

--- a/docs/deployment/helm/index.md
+++ b/docs/deployment/helm/index.md
@@ -1,5 +1,7 @@
 # Helm
 
+## Stable Helm Charts
+
 All the available charts can be found in [artifacthub.io](https://artifacthub.io/packages/search?ts_query_web=nri&verified_publisher=true&official=true&sort=relevance&page=1).
 
 **NOTE:** NRI-plugins Helm installation has been successfully verified in both local clusters and major Cloud Providers' managed clusters, including:
@@ -18,6 +20,26 @@ All the available charts can be found in [artifacthub.io](https://artifacthub.io
         - node image: Azure Linux Container Host, Ubuntu 20.04
 
 While Ubuntu 20.04/22.04 was used across all three CSP environments, it's worth noting that node images are not limited to Ubuntu 20.04/22.04 only. The majority of widely recognized Linux distributions should be suitable for use.
+
+## Unstable Helm Charts
+
+Helm charts are also published from the main/development branch after each merge.
+These charts reference the latest development images tagged as `unstable` and are
+are stored alongside plugin images in the OCI image registry.
+
+### Discovering Unstable Helm Charts
+
+Unstable charts can be discovered using [skopeo](https://github.com/containers/skopeo).
+For instance, one can list the available charts for the balloons plugin using this
+skopeo command:
+`skopeo list-tags docker://ghcr.io/containers/nri-plugins/nri-resource-policy-balloons`
+
+### Using Unstable Helm Charts
+
+Once discovered, unstable Helm charts can be used like any other. For instance, to use
+the `$X.$Y-unstable` version of the chart to install the development version of the
+balloons plugin one can use this command:
+`helm install --devel -n kube-system test oci://ghcr.io/containers/nri-plugins/nri-resource-policy-balloons --version $X.$Y-unstable --set image.tag=unstable --set image.pullPolicy=Always`
 
 ```{toctree}
 ---

--- a/docs/deployment/helm/index.md
+++ b/docs/deployment/helm/index.md
@@ -32,14 +32,14 @@ are stored alongside plugin images in the OCI image registry.
 Unstable charts can be discovered using [skopeo](https://github.com/containers/skopeo).
 For instance, one can list the available charts for the balloons plugin using this
 skopeo command:
-`skopeo list-tags docker://ghcr.io/containers/nri-plugins/nri-resource-policy-balloons`
+`skopeo list-tags docker://ghcr.io/containers/nri-plugins/helm-charts/nri-resource-policy-balloons`
 
 ### Using Unstable Helm Charts
 
 Once discovered, unstable Helm charts can be used like any other. For instance, to use
-the `$X.$Y-unstable` version of the chart to install the development version of the
+the `v$X.$Y-unstable` version of the chart to install the development version of the
 balloons plugin one can use this command:
-`helm install --devel -n kube-system test oci://ghcr.io/containers/nri-plugins/nri-resource-policy-balloons --version $X.$Y-unstable --set image.tag=unstable --set image.pullPolicy=Always`
+`helm install --devel -n kube-system test oci://ghcr.io/containers/nri-plugins/helm-charts/nri-resource-policy-balloons --version v$X.$Y-unstable --set image.tag=unstable --set image.pullPolicy=Always`
 
 ```{toctree}
 ---

--- a/scripts/build/update-gh-pages.sh
+++ b/scripts/build/update-gh-pages.sh
@@ -139,7 +139,7 @@ fi
 #
 # Update gh-pages branch
 #
-commit_hash=`git describe --dirty --always`
+commit_hash=`git describe --tags --dirty --always`
 
 # Switch to work in the gh-pages worktree
 pushd "$build_dir"


### PR DESCRIPTION
Backport patches needed for publishing unstable Helm charts from the v0.4-release branch.

- #271 
- #299 (not strictly needed but just for cleanly applying subsequent patches)
- #301 
- #302 
- #303 
- #304 