### PR TITLE
.github: update issue template for new release.

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -38,4 +38,5 @@ future releases.
   - [ ] Verify that the Helm repo was updated
   - [ ] Add a link to the tagged release in this issue.
   - [ ] Generate the operator bundle by running make bundle within `deployment/operator` directory and submit the generated content to the [community-operators](https://github.com/k8s-operatorhub/community-operators).
+- [ ] Create and push unannotated development tag `X.Y.0-devel` for next release cycle.
 - [ ] Close this issue.


### PR DESCRIPTION
Add the creation of a new unnanotated devel-tag for the next release cycle to the release process issue template.