### PR TITLE
.github: fix release check for Helm Chart packaging.

### DIFF
--- a/.github/workflows/package-helm.yaml
+++ b/.github/workflows/package-helm.yaml
@@ -10,7 +10,6 @@ on:
 
 env:
   CHARTS_DIR: deployment/helm/
-  IS_RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') && 'true' || 'false' }}
   UNSTABLE_CHARTS: unstable-helm-charts
   REGISTRY: ghcr.io
   REGISTRY_USER: ${{ github.repository_owner }}
@@ -18,7 +17,7 @@ env:
 
 jobs:
   release:
-    if: ${{ github.env.IS_RELEASE == 'true' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -48,10 +47,10 @@ jobs:
           files: nri-*helm-chart*.tgz
 
   unstable:
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     concurrency:
       group: unstable-helm-charts
       cancel-in-progress: false
-    if: ${{ github.env.IS_RELEASE != 'true' }}
     permissions:
       packages: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
Setting an evironment variable and using that same variable to trigger conditional jobs with 'if:' does not work as expected. Use a dedicated job to decide if we are dealing with a release tag and propagate that decision to the output of the job. Then use the output to trigger either one of a dependent release or unstable job.