### PR TITLE
[release-0.5] .github: fix release check for Helm Chart packaging.

### DIFF
--- a/.github/workflows/package-helm.yaml
+++ b/.github/workflows/package-helm.yaml
@@ -10,18 +10,36 @@ on:
 
 env:
   CHARTS_DIR: deployment/helm/
-  IS_RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') && 'true' || 'false' }}
   UNSTABLE_CHARTS: unstable-helm-charts
   REGISTRY: ghcr.io
   REGISTRY_USER: ${{ github.repository_owner }}
   REGISTRY_PATH: ${{ github.repository }}
 
 jobs:
+  check_release:
+    runs-on: ubuntu-latest
+    outputs:
+      is_release: ${{ steps.check.outputs.is_release }}
+    steps:
+      - name: Check if this push was a release tag.
+        id: check
+        run: |
+          version="${{ github.ref }}"
+          release=false
+          if [[ "$version" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "$version is a release tag"
+              release=true
+          else
+              echo "$version is NOT a release tag"
+          fi
+          echo "is_release=$release" >> $GITHUB_OUTPUT
+
   release:
-    if: ${{ github.env.IS_RELEASE == 'true' }}
+    runs-on: ubuntu-latest
+    needs: check_release
+    if: ${{ needs.check_release.outputs.is_release == 'true' }}
     permissions:
       contents: write
-    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,13 +66,14 @@ jobs:
           files: nri-*helm-chart*.tgz
 
   unstable:
+    runs-on: ubuntu-latest
+    needs: check_release
+    if: ${{ needs.check_release.outputs.is_release != 'true' }}
     concurrency:
       group: unstable-helm-charts
       cancel-in-progress: false
-    if: ${{ github.env.IS_RELEASE != 'true' }}
     permissions:
       packages: write
-    runs-on: ubuntu-latest
     steps:
       - name: Deep Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Setting an evironment variable and using that same variable to trigger conditional jobs with 'if:' does not work as expected. Use a dedicated job to decide if we are dealing with a release tag and propagate that decision to the output of the job. Then use the output to trigger either one of a dependent release or unstable job.