### PR TITLE
[release-0.5] fix release check for Helm Chart packaging.

### DIFF
--- a/.github/workflows/package-helm.yaml
+++ b/.github/workflows/package-helm.yaml
@@ -3,7 +3,7 @@ name: Package Helm charts
 on:
   push:
     tags:
-      - "v*.*.*"
+      - v[0-9]+.[0-9]+.[0-9]+
     branches:
       - main
       - release-*

--- a/.github/workflows/package-helm.yaml
+++ b/.github/workflows/package-helm.yaml
@@ -16,30 +16,11 @@ env:
   REGISTRY_PATH: ${{ github.repository }}
 
 jobs:
-  check_release:
-    runs-on: ubuntu-latest
-    outputs:
-      is_release: ${{ steps.check.outputs.is_release }}
-    steps:
-      - name: Check if this push was a release tag.
-        id: check
-        run: |
-          version="${{ github.ref }}"
-          release=false
-          if [[ "$version" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "$version is a release tag"
-              release=true
-          else
-              echo "$version is NOT a release tag"
-          fi
-          echo "is_release=$release" >> $GITHUB_OUTPUT
-
   release:
-    runs-on: ubuntu-latest
-    needs: check_release
-    if: ${{ needs.check_release.outputs.is_release == 'true' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     permissions:
       contents: write
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -66,14 +47,13 @@ jobs:
           files: nri-*helm-chart*.tgz
 
   unstable:
-    runs-on: ubuntu-latest
-    needs: check_release
-    if: ${{ needs.check_release.outputs.is_release != 'true' }}
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     concurrency:
       group: unstable-helm-charts
       cancel-in-progress: false
     permissions:
       packages: write
+    runs-on: ubuntu-latest
     steps:
       - name: Deep Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -6,7 +6,7 @@ on:
       - main
       - release-*
     tags:
-      - v*
+      - v[0-9]+.[0-9]+.[0-9]+
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
This PR is a backport of #308 to the `release-0.5` branch.

Be more selective with our triggering tags, to allow a simple 'a tag is always a release' logic when deciding whether to build release or development versions of Helm charts. Also, evaluating a condition once then passing the result on in the environment to alternative jobs within the workflow does not work as expected. Therefore, evaluate the condition directly whenever we need the result.
