### PR TITLE
.github: fetch tags for image build.

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Build images
         run: make images


### PR DESCRIPTION
If we build images from a shallow clone, `git describe` isn't able to determine a descriptive version derived from the latest tag. Therefore fetch full history with all tags for image builds.