### PR TITLE
config-manager: allow configuring NRI timeouts.

### DIFF
--- a/config/crd/bases/config.nri_nriplugindeployments.yaml
+++ b/config/crd/bases/config.nri_nriplugindeployments.yaml
@@ -69,8 +69,23 @@ spec:
                     nri:
                       type: object
                       properties:
-                        patchRuntimeConfig:
-                          type: boolean
+                        runtime:
+                          type: object
+                          properties:
+                            patchConfig:
+                              type: boolean
+                            config:
+                              type: object
+                              required:
+                              - pluginRegistrationTimeout
+                              - pluginRequestTimeout
+                              properties:
+                                pluginRegistrationTimeout:
+                                  type: string
+                                  pattern: "^(([5-9])|([1-2][0-9])|(30))s$"
+                                pluginRequestTimeout:
+                                  type: string
+                                  pattern: "^(([2-9])|([1-2][0-9])|(30))s$"
                     image:
                       type: object
                       description: image defines Plugin DeamonSet image name and tag

--- a/deployment/helm/balloons/README.md
+++ b/deployment/helm/balloons/README.md
@@ -17,13 +17,13 @@ are disjoint CPU pools.
       [these](https://github.com/containerd/containerd/blob/main/docs/NRI.md#enabling-nri-support-in-containerd)
       detailed instructions. You can optionally enable the NRI in containerd
       using the Helm chart during the chart installation simply by setting the
-      `nri.patchRuntimeConfig` parameter. For instance,
+      `nri.runtime.patchConfig` parameter. For instance,
 
       ```sh
-      helm install my-balloons nri-plugins/nri-resource-policy-balloons --set nri.patchRuntimeConfig=true --namespace kube-system
+      helm install my-balloons nri-plugins/nri-resource-policy-balloons --set nri.runtime.patchConfig=true --namespace kube-system
       ```
 
-      Enabling `nri.patchRuntimeConfig` creates an init container to turn on
+      Enabling `nri.runtime.patchConfig` creates an init container to turn on
       NRI feature in containerd and only after that proceed the plugin
       installation.
 
@@ -34,10 +34,10 @@ are disjoint CPU pools.
       [these](https://github.com/cri-o/cri-o/blob/main/docs/crio.conf.5.md#crionri-table)
       detailed instructions.  You can optionally enable the NRI in CRI-O using
       the Helm chart during the chart installation simply by setting the
-      `nri.patchRuntimeConfig` parameter. For instance,
+      `nri.runtime.patchConfig` parameter. For instance,
 
       ```sh
-      helm install my-balloons nri-plugins/nri-resource-policy-balloons --namespace kube-system --set nri.patchRuntimeConfig=true
+      helm install my-balloons nri-plugins/nri-resource-policy-balloons --namespace kube-system --set nri.runtime.patchConfig=true
       ```
 
 ## Installing the Chart
@@ -57,14 +57,17 @@ values.yaml file and provide it using the `-f` flag. For example:
 
 ```sh
 # Install the balloons plugin with custom values provided using the --set option
-helm install my-balloons nri-plugins/nri-resource-policy-balloons --namespace kube-system --set nri.patchRuntimeConfig=true
+helm install my-balloons nri-plugins/nri-resource-policy-balloons --namespace kube-system --set nri.runtime.patchConfig=true
 ```
 
 ```sh
 # Install the balloons plugin with custom values specified in a custom values.yaml file
 cat <<EOF > myPath/values.yaml
 nri:
-  patchRuntimeConfig: true
+  runtime:
+    patchConfig: true
+  plugin:
+    index: 10
 
 tolerations:
 - key: "node-role.kubernetes.io/control-plane"
@@ -99,8 +102,10 @@ customize with their own values, along with the default values.
 | `hostPort`               | 8891                                                                                                                          | metrics port to expose on the host                   |
 | `config`                 | see [helm chart values](tree:/deployment/helm/balloons/values.yaml) for the default configuration                       | plugin configuration data                            |
 | `configGroupLabel`       | config.nri/group                                                                                                        | node label for grouping configuration                |
-| `nri.patchRuntimeConfig` | false                                                                                                                         | enable NRI in containerd or CRI-O                    |
-| `nri.pluginIndex`        | 90                                                                                                                            | NRI plugin index to register with                    |
+| `nri.runtime.config.pluginRegistrationTimeout` | ""                                                                                                      | set NRI plugin registration timeout in NRI config of containerd or CRI-O |
+| `nri.runtime.config.pluginRequestTimeout`      | ""                                                                                                      | set NRI plugin request timeout in NRI config of containerd or CRI-O |
+| `nri.runtime.patchConfig` | false                                                                                                                        | patch NRI configuration in containerd or CRI-O       |
+| `nri.plugin.index`        | 90                                                                                                                           | NRI plugin index to register with            
 | `initImage.name`         | [ghcr.io/containers/nri-plugins/config-manager](https://ghcr.io/containers/nri-plugins/config-manager)                        | init container image name                            |
 | `initImage.tag`          | unstable                                                                                                                      | init container image tag                             |
 | `initImage.pullPolicy`   | Always                                                                                                                        | init container image pull policy                     |

--- a/deployment/helm/balloons/templates/daemonset.yaml
+++ b/deployment/helm/balloons/templates/daemonset.yaml
@@ -28,9 +28,16 @@ spec:
     {{- with .Values.nodeSelector }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
-      {{- if .Values.nri.patchRuntimeConfig }}
+      {{- if .Values.nri.runtime.patchConfig }}
       initContainers:
       - name: patch-runtime
+        {{- if (not (or (eq .Values.nri.runtime.config nil) (eq .Values.nri.runtime.config.pluginRegistrationTimeout ""))) }}
+        args:
+          - -nri-plugin-registration-timeout
+          - {{ .Values.nri.runtime.config.pluginRegistrationTimeout }}
+          - -nri-plugin-request-timeout
+          - {{ .Values.nri.runtime.config.pluginRequestTimeout }}
+        {{- end }}
         image: {{ .Values.initContainerImage.name }}:{{ .Values.initContainerImage.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
         volumeMounts:
@@ -55,7 +62,7 @@ spec:
             - -metrics-interval
             - 5s
             - --nri-plugin-index
-            - "{{ .Values.nri.pluginIndex | int | printf "%02d"  }}"
+            - "{{ .Values.nri.plugin.index | int | printf "%02d"  }}"
             {{- if .Values.configGroupLabel }}
             - --config-group-label
             - {{ .Values.configGroupLabel }}
@@ -116,7 +123,7 @@ spec:
         hostPath:
           path: /var/run/nri
           type: DirectoryOrCreate
-      {{- if .Values.nri.patchRuntimeConfig }}
+      {{- if .Values.nri.runtime.patchConfig }}
       - name: containerd-config
         hostPath:
           path: /etc/containerd/

--- a/deployment/helm/balloons/values.schema.json
+++ b/deployment/helm/balloons/values.schema.json
@@ -65,17 +65,52 @@
         "nri": {
             "type": "object",
             "required": [
-                "patchRuntimeConfig",
-                "pluginIndex"
+                "plugin",
+                "runtime"
             ],
             "properties": {
-                "patchRuntimeConfig": {
-                    "type": "boolean"
+                "plugin": {
+                    "type": "object",
+                    "required": [
+                        "index"
+                    ],
+                    "properties": {
+                        "index": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 99
+                        }
+                    }
                 },
-                "pluginIndex": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 99
+                "runtime": {
+                    "type": "object",
+                    "required": [
+                        "patchConfig"
+                    ],
+                    "properties": {
+                        "patchConfig": {
+                            "type": "boolean"
+                        },
+                        "config": {
+                            "type": "object",
+                            "required": [
+                                "pluginRegistrationTimeout",
+                                "pluginRequestTimeout"
+                            ],
+                            "properties": {
+                                "pluginRegistrationTimeout": {
+                                    "type": "string",
+                                    "$comment": "allowed range is 5-30s",
+                                    "pattern": "^(([5-9])|([1-2][0-9])|(30))s$"
+                                },
+                                "pluginRequestTimeout": {
+                                    "type": "string",
+                                    "$comment": "allowed range is 2-30s",
+                                    "pattern": "^(([2-9])|([1-2][0-9])|(30))s$"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/deployment/helm/balloons/values.yaml
+++ b/deployment/helm/balloons/values.yaml
@@ -48,8 +48,13 @@ resources:
   memory: 512Mi
 
 nri:
-  patchRuntimeConfig: false
-  pluginIndex: 90
+  plugin:
+    index: 90
+  runtime:
+    patchConfig: false
+#   config:
+#     pluginRegistrationTimeout: 5s
+#     pluginRequestTimeout: 2s
 
 initContainerImage:
   name: ghcr.io/containers/nri-plugins/nri-config-manager

--- a/deployment/helm/memory-qos/README.md
+++ b/deployment/helm/memory-qos/README.md
@@ -17,13 +17,13 @@ parameters: QoS class and direct memory annotations.
       [these](https://github.com/containerd/containerd/blob/main/docs/NRI.md#enabling-nri-support-in-containerd)
       detailed instructions. You can optionally enable the NRI in containerd
       using the Helm chart during the chart installation simply by setting the
-      `nri.patchRuntimeConfig` parameter. For instance,
+      `nri.runtime.patchConfig` parameter. For instance,
 
       ```sh
-      helm install my-memory-qos nri-plugins/nri-memory-qos --set nri.patchRuntimeConfig=true --namespace kube-system
+      helm install my-memory-qos nri-plugins/nri-memory-qos --set nri.runtime.patchConfig=true --namespace kube-system
       ```
 
-      Enabling `nri.patchRuntimeConfig` creates an init container to turn on
+      Enabling `nri.runtime.patchConfig` creates an init container to turn on
       NRI feature in containerd and only after that proceed the plugin
       installation.
 
@@ -34,10 +34,10 @@ parameters: QoS class and direct memory annotations.
       [these](https://github.com/cri-o/cri-o/blob/main/docs/crio.conf.5.md#crionri-table)
       detailed instructions.  You can optionally enable the NRI in CRI-O using
       the Helm chart during the chart installation simply by setting the
-      `nri.patchRuntimeConfig` parameter. For instance,
+      `nri.runtime.patchConfig` parameter. For instance,
 
       ```sh
-      helm install my-memory-qos nri-plugins/nri-memory-qos --namespace kube-system --set nri.patchRuntimeConfig=true
+      helm install my-memory-qos nri-plugins/nri-memory-qos --namespace kube-system --set nri.runtime.patchConfig=true
       ```
 
 ## Installing the Chart
@@ -57,14 +57,17 @@ values.yaml file and provide it using the `-f` flag. For example:
 
 ```sh
 # Install the memory-qos plugin with custom values provided using the --set option
-helm install my-memory-qos nri-plugins/nri-memory-qos --namespace kube-system --set nri.patchRuntimeConfig=true
+helm install my-memory-qos nri-plugins/nri-memory-qos --namespace kube-system --set nri.runtime.patchConfig=true
 ```
 
 ```sh
 # Install the memory-qos plugin with custom values specified in a custom values.yaml file
 cat <<EOF > myPath/values.yaml
 nri:
-  patchRuntimeConfig: true
+  runtime:
+    patchConfig: true
+  plugin:
+    index: 10
 
 tolerations:
 - key: "node-role.kubernetes.io/control-plane"
@@ -95,8 +98,10 @@ customize with their own values, along with the default values.
 | `image.pullPolicy`       | Always                                                                                                                        | image pull policy                                    |
 | `resources.cpu`          | 10m                                                                                                                           | cpu resources for the Pod                            |
 | `resources.memory`       | 100Mi                                                                                                                         | memory qouta for the Pod                         |
-| `nri.patchRuntimeConfig` | false                                                                                                                         | enable NRI in containerd or CRI-O                    |
-| `nri.pluginIndex`        | 40                                                                                                                            | NRI plugin index to register with                    |
+| `nri.runtime.config.pluginRegistrationTimeout` | ""                                                                                                      | set NRI plugin registration timeout in NRI config of containerd or CRI-O |
+| `nri.runtime.config.pluginRequestTimeout`      | ""                                                                                                      | set NRI plugin request timeout in NRI config of containerd or CRI-O |
+| `nri.runtime.patchConfig` | false                                                                                                                        | patch NRI configuration in containerd or CRI-O       |
+| `nri.plugin.index`        | 90                                                                                                                           | NRI plugin index to register with            
 | `initImage.name`         | [ghcr.io/containers/nri-plugins/config-manager](https://ghcr.io/containers/nri-plugins/config-manager)                        | init container image name                            |
 | `initImage.tag`          | unstable                                                                                                                      | init container image tag                             |
 | `initImage.pullPolicy`   | Always                                                                                                                        | init container image pull policy                     |

--- a/deployment/helm/memory-qos/templates/daemonset.yaml
+++ b/deployment/helm/memory-qos/templates/daemonset.yaml
@@ -27,9 +27,16 @@ spec:
     {{- with .Values.nodeSelector }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
-      {{- if .Values.nri.patchRuntimeConfig }}
+      {{- if .Values.nri.runtime.patchConfig }}
       initContainers:
       - name: patch-runtime
+        {{- if (not (or (eq .Values.nri.runtime.config nil) (eq .Values.nri.runtime.config.pluginRegistrationTimeout ""))) }}
+        args:
+          - -nri-plugin-registration-timeout
+          - {{ .Values.nri.runtime.config.pluginRegistrationTimeout }}
+          - -nri-plugin-request-timeout
+          - {{ .Values.nri.runtime.config.pluginRequestTimeout }}
+        {{- end }}
         image: {{ .Values.initContainerImage.name }}:{{ .Values.initContainerImage.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
         volumeMounts:
@@ -47,7 +54,7 @@ spec:
           command:
             - nri-memory-qos
             - --idx
-            - "{{ .Values.nri.pluginIndex | int | printf "%02d"  }}"
+            - "{{ .Values.nri.plugin.index | int | printf "%02d"  }}"
             - --config
             - /etc/nri/memory-qos/config.yaml
             - -v
@@ -73,7 +80,7 @@ spec:
         hostPath:
           path: /var/run/nri
           type: DirectoryOrCreate
-      {{- if .Values.nri.patchRuntimeConfig }}
+      {{- if .Values.nri.runtime.patchConfig }}
       - name: containerd-config
         hostPath:
           path: /etc/containerd/

--- a/deployment/helm/memory-qos/values.schema.json
+++ b/deployment/helm/memory-qos/values.schema.json
@@ -61,17 +61,52 @@
         "nri": {
             "type": "object",
             "required": [
-                "patchRuntimeConfig",
-                "pluginIndex"
+                "plugin",
+                "runtime"
             ],
             "properties": {
-                "patchRuntimeConfig": {
-                    "type": "boolean"
+                "plugin": {
+                    "type": "object",
+                    "required": [
+                        "index"
+                    ],
+                    "properties": {
+                        "index": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 99
+                        }
+                    }
                 },
-                "pluginIndex": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 99
+                "runtime": {
+                    "type": "object",
+                    "required": [
+                        "patchConfig"
+                    ],
+                    "properties": {
+                        "patchConfig": {
+                            "type": "boolean"
+                        },
+                        "config": {
+                            "type": "object",
+                            "required": [
+                                "pluginRegistrationTimeout",
+                                "pluginRequestTimeout"
+                            ],
+                            "properties": {
+                                "pluginRegistrationTimeout": {
+                                    "type": "string",
+                                    "$comment": "allowed range is 5-30s",
+                                    "pattern": "^(([5-9])|([1-2][0-9])|(30))s$"
+                                },
+                                "pluginRequestTimeout": {
+                                    "type": "string",
+                                    "$comment": "allowed range is 2-30s",
+                                    "pattern": "^(([2-9])|([1-2][0-9])|(30))s$"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/deployment/helm/memory-qos/values.yaml
+++ b/deployment/helm/memory-qos/values.yaml
@@ -13,8 +13,13 @@ resources:
   memory: 100Mi
 
 nri:
-  patchRuntimeConfig: false
-  pluginIndex: 40
+  plugin:
+    index: 90
+  runtime:
+    patchConfig: false
+#   config:
+#     pluginRegistrationTimeout: 5s
+#     pluginRequestTimeout: 2s
 
 initContainerImage:
   name: ghcr.io/containers/nri-plugins/nri-config-manager

--- a/deployment/helm/memtierd/README.md
+++ b/deployment/helm/memtierd/README.md
@@ -16,13 +16,13 @@ NRI plugin enables managing workloads with Memtierd in Kubernetes.
       [these](https://github.com/containerd/containerd/blob/main/docs/NRI.md#enabling-nri-support-in-containerd)
       detailed instructions. You can optionally enable the NRI in containerd
       using the Helm chart during the chart installation simply by setting the
-      `nri.patchRuntimeConfig` parameter. For instance,
+      `nri.runtime.patchConfig` parameter. For instance,
 
       ```sh
-      helm install my-memtierd nri-plugins/nri-memtierd --set nri.patchRuntimeConfig=true --namespace kube-system
+      helm install my-memtierd nri-plugins/nri-memtierd --set nri.runtime.patchConfig=true --namespace kube-system
       ```
 
-      Enabling `nri.patchRuntimeConfig` creates an init container to turn on
+      Enabling `nri.runtime.patchConfig` creates an init container to turn on
       NRI feature in containerd and only after that proceed the plugin
       installation.
 
@@ -33,10 +33,10 @@ NRI plugin enables managing workloads with Memtierd in Kubernetes.
       [these](https://github.com/cri-o/cri-o/blob/main/docs/crio.conf.5.md#crionri-table)
       detailed instructions.  You can optionally enable the NRI in CRI-O using
       the Helm chart during the chart installation simply by setting the
-      `nri.patchRuntimeConfig` parameter. For instance,
+      `nri.runtime.patchConfig` parameter. For instance,
 
       ```sh
-      helm install my-memtierd nri-plugins/nri-memtierd --namespace kube-system --set nri.patchRuntimeConfig=true
+      helm install my-memtierd nri-plugins/nri-memtierd --namespace kube-system --set nri.runtime.patchConfig=true
       ```
 
 ## Installing the Chart
@@ -56,14 +56,17 @@ values.yaml file and provide it using the `-f` flag. For example:
 
 ```sh
 # Install the memtierd plugin with custom values provided using the --set option
-helm install my-memtierd nri-plugins/nri-memtierd --namespace kube-system --set nri.patchRuntimeConfig=true
+helm install my-memtierd nri-plugins/nri-memtierd --namespace kube-system --set nri.runtime.patchConfig=true
 ```
 
 ```sh
 # Install the nri-memtierd plugin with custom values specified in a custom values.yaml file
 cat <<EOF > myPath/values.yaml
 nri:
-  patchRuntimeConfig: true
+  runtime:
+    patchConfig: true
+  plugin:
+    index: 10
 
 tolerations:
 - key: "node-role.kubernetes.io/control-plane"
@@ -95,8 +98,10 @@ customize with their own values, along with the default values.
 | `resources.cpu`          | 250m                                                                                                                          | cpu resources for the Pod                            |
 | `resources.memory`       | 100Mi                                                                                                                         | memory qouta for the Pod                         |
 | `outputDir`              | empty string                                                                                                                  | host directory for memtierd.output files             |
-| `nri.patchRuntimeConfig` | false                                                                                                                         | enable NRI in containerd or CRI-O                    |
-| `nri.pluginIndex`        | 45                                                                                                                            | NRI plugin index to register with                    |
+| `nri.runtime.config.pluginRegistrationTimeout` | ""                                                                                                      | set NRI plugin registration timeout in NRI config of containerd or CRI-O |
+| `nri.runtime.config.pluginRequestTimeout`      | ""                                                                                                      | set NRI plugin request timeout in NRI config of containerd or CRI-O |
+| `nri.runtime.patchConfig` | false                                                                                                                        | patch NRI configuration in containerd or CRI-O       |
+| `nri.plugin.index`        | 90                                                                                                                           | NRI plugin index to register with            
 | `initImage.name`         | [ghcr.io/containers/nri-plugins/config-manager](https://ghcr.io/containers/nri-plugins/config-manager)                        | init container image name                            |
 | `initImage.tag`          | unstable                                                                                                                      | init container image tag                             |
 | `initImage.pullPolicy`   | Always                                                                                                                        | init container image pull policy                     |

--- a/deployment/helm/memtierd/templates/daemonset.yaml
+++ b/deployment/helm/memtierd/templates/daemonset.yaml
@@ -28,9 +28,16 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       hostPID: true
-      {{- if .Values.nri.patchRuntimeConfig }}
+      {{- if .Values.nri.runtime.patchConfig }}
       initContainers:
       - name: patch-runtime
+        {{- if (not (or (eq .Values.nri.runtime.config nil) (eq .Values.nri.runtime.config.pluginRegistrationTimeout ""))) }}
+        args:
+          - -nri-plugin-registration-timeout
+          - {{ .Values.nri.runtime.config.pluginRegistrationTimeout }}
+          - -nri-plugin-request-timeout
+          - {{ .Values.nri.runtime.config.pluginRequestTimeout }}
+        {{- end }}
         image: {{ .Values.initContainerImage.name }}:{{ .Values.initContainerImage.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
         volumeMounts:
@@ -48,7 +55,7 @@ spec:
           command:
             - nri-memtierd
             - --idx
-            - "{{ .Values.nri.pluginIndex | int | printf "%02d"  }}"
+            - "{{ .Values.nri.plugin.index | int | printf "%02d"  }}"
             - --config
             - /etc/nri/memtierd/config.yaml
             {{- if .Values.outputDir }}
@@ -104,7 +111,7 @@ spec:
           path: {{ .Values.outputDir }}
           type: DirectoryOrCreate
       {{- end }}
-      {{- if .Values.nri.patchRuntimeConfig }}
+      {{- if .Values.nri.runtime.patchConfig }}
       - name: containerd-config
         hostPath:
           path: /etc/containerd/

--- a/deployment/helm/memtierd/values.schema.json
+++ b/deployment/helm/memtierd/values.schema.json
@@ -61,17 +61,52 @@
         "nri": {
             "type": "object",
             "required": [
-                "patchRuntimeConfig",
-                "pluginIndex"
+                "plugin",
+                "runtime"
             ],
             "properties": {
-                "patchRuntimeConfig": {
-                    "type": "boolean"
+                "plugin": {
+                    "type": "object",
+                    "required": [
+                        "index"
+                    ],
+                    "properties": {
+                        "index": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 99
+                        }
+                    }
                 },
-                "pluginIndex": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 99
+                "runtime": {
+                    "type": "object",
+                    "required": [
+                        "patchConfig"
+                    ],
+                    "properties": {
+                        "patchConfig": {
+                            "type": "boolean"
+                        },
+                        "config": {
+                            "type": "object",
+                            "required": [
+                                "pluginRegistrationTimeout",
+                                "pluginRequestTimeout"
+                            ],
+                            "properties": {
+                                "pluginRegistrationTimeout": {
+                                    "type": "string",
+                                    "$comment": "allowed range is 5-30s",
+                                    "pattern": "^(([5-9])|([1-2][0-9])|(30))s$"
+                                },
+                                "pluginRequestTimeout": {
+                                    "type": "string",
+                                    "$comment": "allowed range is 2-30s",
+                                    "pattern": "^(([2-9])|([1-2][0-9])|(30))s$"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/deployment/helm/memtierd/values.yaml
+++ b/deployment/helm/memtierd/values.yaml
@@ -15,8 +15,13 @@ resources:
 outputDir: ""
 
 nri:
-  patchRuntimeConfig: false
-  pluginIndex: 45
+  plugin:
+    index: 90
+  runtime:
+    patchConfig: false
+#   config:
+#     pluginRegistrationTimeout: 5s
+#     pluginRequestTimeout: 2s
 
 initContainerImage:
   name: ghcr.io/containers/nri-plugins/nri-config-manager

--- a/deployment/helm/sgx-epc/README.md
+++ b/deployment/helm/sgx-epc/README.md
@@ -17,13 +17,13 @@ annotations and (a yet to be merged pull request to) the cgroup v2 misc controll
       [these](https://github.com/containerd/containerd/blob/main/docs/NRI.md#enabling-nri-support-in-containerd)
       detailed instructions. You can optionally enable the NRI in containerd
       using the Helm chart during the chart installation simply by setting the
-      `nri.patchRuntimeConfig` parameter. For instance,
+      `nri.runtime.patchConfig` parameter. For instance,
 
       ```sh
-      helm install my-sgx-epc nri-plugins/nri-sgx-epc --set nri.patchRuntimeConfig=true --namespace kube-system
+      helm install my-sgx-epc nri-plugins/nri-sgx-epc --set nri.runtime.patchConfig=true --namespace kube-system
       ```
 
-      Enabling `nri.patchRuntimeConfig` creates an init container to turn on
+      Enabling `nri.runtime.patchConfig` creates an init container to turn on
       NRI feature in containerd and only after that proceed the plugin
       installation.
 
@@ -34,10 +34,10 @@ annotations and (a yet to be merged pull request to) the cgroup v2 misc controll
       [these](https://github.com/cri-o/cri-o/blob/main/docs/crio.conf.5.md#crionri-table)
       detailed instructions.  You can optionally enable the NRI in CRI-O using
       the Helm chart during the chart installation simply by setting the
-      `nri.patchRuntimeConfig` parameter. For instance,
+      `nri.runtime.patchConfig` parameter. For instance,
 
       ```sh
-      helm install my-sgx-epc nri-plugins/nri-sgx-epc --namespace kube-system --set nri.patchRuntimeConfig=true
+      helm install my-sgx-epc nri-plugins/nri-sgx-epc --namespace kube-system --set nri.runtime.patchConfig=true
       ```
 
 ## Installing the Chart
@@ -57,14 +57,17 @@ values.yaml file and provide it using the `-f` flag. For example:
 
 ```sh
 # Install the sgx-epc plugin with custom values provided using the --set option
-helm install my-sgx-epc nri-plugins/nri-sgx-epc --namespace kube-system --set nri.patchRuntimeConfig=true
+helm install my-sgx-epc nri-plugins/nri-sgx-epc --namespace kube-system --set nri.runtime.patchConfig=true
 ```
 
 ```sh
 # Install the sgx-epc plugin with custom values specified in a custom values.yaml file
 cat <<EOF > myPath/values.yaml
 nri:
-  patchRuntimeConfig: true
+  runtime:
+    patchConfig: true
+  plugin:
+    index: 10
 
 tolerations:
 - key: "node-role.kubernetes.io/control-plane"
@@ -95,8 +98,10 @@ customize with their own values, along with the default values.
 | `image.pullPolicy`       | Always                                                                                                                        | image pull policy                                    |
 | `resources.cpu`          | 25m                                                                                                                           | cpu resources for the Pod                            |
 | `resources.memory`       | 100Mi                                                                                                                         | memory qouta for the Pod                         |
-| `nri.patchRuntimeConfig` | false                                                                                                                         | enable NRI in containerd or CRI-O                    |
-| `nri.pluginIndex`        | 40                                                                                                                            | NRI plugin index to register with                    |
+| `nri.runtime.config.pluginRegistrationTimeout` | ""                                                                                                      | set NRI plugin registration timeout in NRI config of containerd or CRI-O |
+| `nri.runtime.config.pluginRequestTimeout`      | ""                                                                                                      | set NRI plugin request timeout in NRI config of containerd or CRI-O |
+| `nri.runtime.patchConfig` | false                                                                                                                        | patch NRI configuration in containerd or CRI-O       |
+| `nri.plugin.index`        | 90                                                                                                                           | NRI plugin index to register with            
 | `initImage.name`         | [ghcr.io/containers/nri-plugins/config-manager](https://ghcr.io/containers/nri-plugins/config-manager)                        | init container image name                            |
 | `initImage.tag`          | unstable                                                                                                                      | init container image tag                             |
 | `initImage.pullPolicy`   | Always                                                                                                                        | init container image pull policy                     |

--- a/deployment/helm/sgx-epc/templates/daemonset.yaml
+++ b/deployment/helm/sgx-epc/templates/daemonset.yaml
@@ -28,9 +28,16 @@ spec:
     {{- with .Values.nodeSelector }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
-      {{- if .Values.nri.patchRuntimeConfig }}
+      {{- if .Values.nri.runtime.patchConfig }}
       initContainers:
       - name: patch-runtime
+        {{- if (not (or (eq .Values.nri.runtime.config nil) (eq .Values.nri.runtime.config.pluginRegistrationTimeout ""))) }}
+        args:
+          - -nri-plugin-registration-timeout
+          - {{ .Values.nri.runtime.config.pluginRegistrationTimeout }}
+          - -nri-plugin-request-timeout
+          - {{ .Values.nri.runtime.config.pluginRequestTimeout }}
+        {{- end }}
         image: {{ .Values.initContainerImage.name }}:{{ .Values.initContainerImage.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
         volumeMounts:
@@ -48,7 +55,7 @@ spec:
           command:
             - nri-sgx-epc
             - --idx
-            - "{{ .Values.nri.pluginIndex | int | printf "%02d"  }}"
+            - "{{ .Values.nri.plugin.index | int | printf "%02d"  }}"
           image: {{ .Values.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
@@ -66,7 +73,7 @@ spec:
         hostPath:
           path: /var/run/nri
           type: DirectoryOrCreate
-      {{- if .Values.nri.patchRuntimeConfig }}
+      {{- if .Values.nri.runtime.patchConfig }}
       - name: containerd-config
         hostPath:
           path: /etc/containerd/

--- a/deployment/helm/sgx-epc/values.schema.json
+++ b/deployment/helm/sgx-epc/values.schema.json
@@ -61,17 +61,52 @@
         "nri": {
             "type": "object",
             "required": [
-                "patchRuntimeConfig",
-                "pluginIndex"
+                "plugin",
+                "runtime"
             ],
             "properties": {
-                "patchRuntimeConfig": {
-                    "type": "boolean"
+                "plugin": {
+                    "type": "object",
+                    "required": [
+                        "index"
+                    ],
+                    "properties": {
+                        "index": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 99
+                        }
+                    }
                 },
-                "pluginIndex": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 99
+                "runtime": {
+                    "type": "object",
+                    "required": [
+                        "patchConfig"
+                    ],
+                    "properties": {
+                        "patchConfig": {
+                            "type": "boolean"
+                        },
+                        "config": {
+                            "type": "object",
+                            "required": [
+                                "pluginRegistrationTimeout",
+                                "pluginRequestTimeout"
+                            ],
+                            "properties": {
+                                "pluginRegistrationTimeout": {
+                                    "type": "string",
+                                    "$comment": "allowed range is 5-30s",
+                                    "pattern": "^(([5-9])|([1-2][0-9])|(30))s$"
+                                },
+                                "pluginRequestTimeout": {
+                                    "type": "string",
+                                    "$comment": "allowed range is 2-30s",
+                                    "pattern": "^(([2-9])|([1-2][0-9])|(30))s$"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/deployment/helm/sgx-epc/values.yaml
+++ b/deployment/helm/sgx-epc/values.yaml
@@ -13,8 +13,13 @@ resources:
   memory: 100Mi
 
 nri:
-  patchRuntimeConfig: false
-  pluginIndex: 40
+  plugin:
+    index: 90
+  runtime:
+    patchConfig: false
+#   config:
+#     pluginRegistrationTimeout: 5s
+#     pluginRequestTimeout: 2s
 
 initContainerImage:
   name: ghcr.io/containers/nri-plugins/nri-config-manager

--- a/deployment/helm/template/README.md
+++ b/deployment/helm/template/README.md
@@ -17,13 +17,13 @@ logic. It serves as a template for creating new policy implementations.
       [these](https://github.com/containerd/containerd/blob/main/docs/NRI.md#enabling-nri-support-in-containerd)
       detailed instructions. You can optionally enable the NRI in containerd
       using the Helm chart during the chart installation simply by setting the
-      `nri.patchRuntimeConfig` parameter. For instance,
+      `nri.runtime.patchConfig` parameter. For instance,
 
       ```sh
-      helm install my-template nri-plugins/nri-resource-policy-template --set nri.patchRuntimeConfig=true --namespace kube-system
+      helm install my-template nri-plugins/nri-resource-policy-template --set nri.runtime.patchConfig=true --namespace kube-system
       ```
 
-      Enabling `nri.patchRuntimeConfig` creates an init container to turn on
+      Enabling `nri.runtime.patchConfig` creates an init container to turn on
       NRI feature in containerd and only after that proceed the plugin
       installation.
 
@@ -34,10 +34,10 @@ logic. It serves as a template for creating new policy implementations.
       [these](https://github.com/cri-o/cri-o/blob/main/docs/crio.conf.5.md#crionri-table)
       detailed instructions.  You can optionally enable the NRI in CRI-O using
       the Helm chart during the chart installation simply by setting the
-      `nri.patchRuntimeConfig` parameter. For instance,
+      `nri.runtime.patchConfig` parameter. For instance,
 
       ```sh
-      helm install my-template nri-plugins/nri-resource-policy-template --namespace kube-system --set nri.patchRuntimeConfig=true
+      helm install my-template nri-plugins/nri-resource-policy-template --namespace kube-system --set nri.runtime.patchConfig=true
       ```
 
 ## Installing the Chart
@@ -57,14 +57,17 @@ values.yaml file and provide it using the `-f` flag. For example:
 
 ```sh
 # Install the template plugin with custom values provided using the --set option
-helm install my-template nri-plugins/nri-resource-policy-template --namespace kube-system --set nri.patchRuntimeConfig=true
+helm install my-template nri-plugins/nri-resource-policy-template --namespace kube-system --set nri.runtime.patchConfig=true
 ```
 
 ```sh
 # Install the template plugin with custom values specified in a custom values.yaml file
 cat <<EOF > myPath/values.yaml
 nri:
-  patchRuntimeConfig: true
+  runtime:
+    patchConfig: true
+  plugin:
+    index: 10
 
 tolerations:
 - key: "node-role.kubernetes.io/control-plane"
@@ -99,8 +102,10 @@ customize with their own values, along with the default values.
 | `hostPort`               | 8891                                                                                                                          | metrics port to expose on the host                   |
 | `config`                 | see [helm chart values](tree:/deployment/helm/template/values.yaml) for the default configuration                       | plugin configuration data                            |
 | `configGroupLabel`       | config.nri/group                                                                                                        | node label for grouping configuration                |
-| `nri.patchRuntimeConfig` | false                                                                                                                         | enable NRI in containerd or CRI-O                    |
-| `nri.pluginIndex`        | 90                                                                                                                            | NRI plugin index to register with                    |
+| `nri.runtime.config.pluginRegistrationTimeout` | ""                                                                                                      | set NRI plugin registration timeout in NRI config of containerd or CRI-O |
+| `nri.runtime.config.pluginRequestTimeout`      | ""                                                                                                      | set NRI plugin request timeout in NRI config of containerd or CRI-O |
+| `nri.runtime.patchConfig` | false                                                                                                                        | patch NRI configuration in containerd or CRI-O       |
+| `nri.plugin.index`        | 90                                                                                                                           | NRI plugin index to register with            
 | `initImage.name`         | [ghcr.io/containers/nri-plugins/config-manager](https://ghcr.io/containers/nri-plugins/config-manager)                                | init container image name                            |
 | `initImage.tag`          | unstable                                                                                                                      | init container image tag                             |
 | `initImage.pullPolicy`   | Always                                                                                                                        | init container image pull policy                     |

--- a/deployment/helm/template/templates/daemonset.yaml
+++ b/deployment/helm/template/templates/daemonset.yaml
@@ -21,9 +21,16 @@ spec:
       serviceAccount: nri-resource-policy-template
       nodeSelector:
         kubernetes.io/os: "linux"
-      {{- if .Values.nri.patchRuntimeConfig }}
+      {{- if .Values.nri.runtime.patchConfig }}
       initContainers:
       - name: patch-runtime
+        {{- if (not (or (eq .Values.nri.runtime.config nil) (eq .Values.nri.runtime.config.pluginRegistrationTimeout ""))) }}
+        args:
+          - -nri-plugin-registration-timeout
+          - {{ .Values.nri.runtime.config.pluginRegistrationTimeout }}
+          - -nri-plugin-request-timeout
+          - {{ .Values.nri.runtime.config.pluginRequestTimeout }}
+        {{- end }}
         image: {{ .Values.initContainerImage.name }}:{{ .Values.initContainerImage.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
         volumeMounts:
@@ -48,7 +55,7 @@ spec:
             - -metrics-interval
             - 5s
             - --nri-plugin-index
-            - "{{ .Values.nri.pluginIndex | int | printf "%02d"  }}"
+            - "{{ .Values.nri.plugin.index | int | printf "%02d"  }}"
             {{- if .Values.configGroupLabel }}
             - --config-group-label
             - {{ .Values.configGroupLabel }}
@@ -109,7 +116,7 @@ spec:
         hostPath:
           path: /var/run/nri
           type: DirectoryOrCreate
-      {{- if .Values.nri.patchRuntimeConfig }}
+      {{- if .Values.nri.runtime.patchConfig }}
       - name: containerd-config
         hostPath:
           path: /etc/containerd/

--- a/deployment/helm/template/values.schema.json
+++ b/deployment/helm/template/values.schema.json
@@ -65,17 +65,52 @@
         "nri": {
             "type": "object",
             "required": [
-                "patchRuntimeConfig",
-                "pluginIndex"
+                "plugin",
+                "runtime"
             ],
             "properties": {
-                "patchRuntimeConfig": {
-                    "type": "boolean"
+                "plugin": {
+                    "type": "object",
+                    "required": [
+                        "index"
+                    ],
+                    "properties": {
+                        "index": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 99
+                        }
+                    }
                 },
-                "pluginIndex": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 99
+                "runtime": {
+                    "type": "object",
+                    "required": [
+                        "patchConfig"
+                    ],
+                    "properties": {
+                        "patchConfig": {
+                            "type": "boolean"
+                        },
+                        "config": {
+                            "type": "object",
+                            "required": [
+                                "pluginRegistrationTimeout",
+                                "pluginRequestTimeout"
+                            ],
+                            "properties": {
+                                "pluginRegistrationTimeout": {
+                                    "type": "string",
+                                    "$comment": "allowed range is 5-30s",
+                                    "pattern": "^(([5-9])|([1-2][0-9])|(30))s$"
+                                },
+                                "pluginRequestTimeout": {
+                                    "type": "string",
+                                    "$comment": "allowed range is 2-30s",
+                                    "pattern": "^(([2-9])|([1-2][0-9])|(30))s$"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/deployment/helm/template/values.yaml
+++ b/deployment/helm/template/values.yaml
@@ -36,8 +36,13 @@ resources:
   memory: 512Mi
 
 nri:
-  patchRuntimeConfig: false
-  pluginIndex: 90
+  plugin:
+    index: 90
+  runtime:
+    patchConfig: false
+#   config:
+#     pluginRegistrationTimeout: 5s
+#     pluginRequestTimeout: 2s
 
 initContainerImage:
   name: ghcr.io/containers/nri-plugins/nri-config-manager

--- a/deployment/helm/topology-aware/README.md
+++ b/deployment/helm/topology-aware/README.md
@@ -18,13 +18,13 @@ system.
       [these](https://github.com/containerd/containerd/blob/main/docs/NRI.md#enabling-nri-support-in-containerd)
       detailed instructions. You can optionally enable the NRI in containerd
       using the Helm chart during the chart installation simply by setting the
-      `nri.patchRuntimeConfig` parameter. For instance,
+      `nri.runtime.patchConfig` parameter. For instance,
 
       ```sh
-      helm install my-topology-aware nri-plugins/nri-resource-policy-topology-aware --set nri.patchRuntimeConfig=true --namespace kube-system
+      helm install my-topology-aware nri-plugins/nri-resource-policy-topology-aware --set nri.runtime.patchConfig=true --namespace kube-system
       ```
 
-      Enabling `nri.patchRuntimeConfig` creates an init container to turn on
+      Enabling `nri.runtime.patchConfig` creates an init container to turn on
       NRI feature in containerd and only after that proceed the plugin
       installation.
 
@@ -35,10 +35,10 @@ system.
       [these](https://github.com/cri-o/cri-o/blob/main/docs/crio.conf.5.md#crionri-table)
       detailed instructions.  You can optionally enable the NRI in CRI-O using
       the Helm chart during the chart installation simply by setting the
-      `nri.patchRuntimeConfig` parameter. For instance,
+      `nri.runtime.patchConfig` parameter. For instance,
 
       ```sh
-      helm install my-topology-aware nri-plugins/nri-resource-policy-topology-aware --namespace kube-system --set nri.patchRuntimeConfig=true
+      helm install my-topology-aware nri-plugins/nri-resource-policy-topology-aware --namespace kube-system --set nri.runtime.patchConfig=true
       ```
 
 ## Installing the Chart
@@ -58,14 +58,17 @@ values.yaml file and provide it using the `-f` flag. For example:
 
 ```sh
 # Install the topology-aware plugin with custom values provided using the --set option
-helm install my-topology-aware nri-plugins/nri-resource-policy-topology-aware --namespace kube-system --set nri.patchRuntimeConfig=true
+helm install my-topology-aware nri-plugins/nri-resource-policy-topology-aware --namespace kube-system --set nri.runtime.patchConfig=true
 ```
 
 ```sh
 # Install the topology-aware plugin with custom values specified in a custom values.yaml file
 cat <<EOF > myPath/values.yaml
 nri:
-  patchRuntimeConfig: true
+  runtime:
+    patchConfig: true
+  plugin:
+    index: 10
 
 tolerations:
 - key: "node-role.kubernetes.io/control-plane"
@@ -100,8 +103,10 @@ customize with their own values, along with the default values.
 | `hostPort`               | 8891                                                                                                                          | metrics port to expose on the host                   |
 | `config`                 | see [helm chart values](tree:/deployment/helm/topology-aware/values.yaml) for the default configuration                       | plugin configuration data                            |
 | `configGroupLabel`       | config.nri/group                                                                                                        | node label for grouping configuration                |
-| `nri.patchRuntimeConfig` | false                                                                                                                         | enable NRI in containerd or CRI-O                    |
-| `nri.pluginIndex`        | 90                                                                                                                            | NRI plugin index to register with                    |
+| `nri.runtime.config.pluginRegistrationTimeout` | ""                                                                                                      | set NRI plugin registration timeout in NRI config of containerd or CRI-O |
+| `nri.runtime.config.pluginRequestTimeout`      | ""                                                                                                      | set NRI plugin request timeout in NRI config of containerd or CRI-O |
+| `nri.runtime.patchConfig` | false                                                                                                                        | patch NRI configuration in containerd or CRI-O       |
+| `nri.plugin.index`        | 90                                                                                                                           | NRI plugin index to register with                    |
 | `initImage.name`         | [ghcr.io/containers/nri-plugins/config-manager](https://ghcr.io/containers/nri-plugins/config-manager)                        | init container image name                            |
 | `initImage.tag`          | unstable                                                                                                                      | init container image tag                             |
 | `initImage.pullPolicy`   | Always                                                                                                                        | init container image pull policy                     |

--- a/deployment/helm/topology-aware/templates/daemonset.yaml
+++ b/deployment/helm/topology-aware/templates/daemonset.yaml
@@ -28,9 +28,16 @@ spec:
     {{- with .Values.nodeSelector }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
-      {{- if .Values.nri.patchRuntimeConfig }}
+      {{- if .Values.nri.runtime.patchConfig }}
       initContainers:
       - name: patch-runtime
+        {{- if (not (or (eq .Values.nri.runtime.config nil) (eq .Values.nri.runtime.config.pluginRegistrationTimeout ""))) }}
+        args:
+          - -nri-plugin-registration-timeout
+          - {{ .Values.nri.runtime.config.pluginRegistrationTimeout }}
+          - -nri-plugin-request-timeout
+          - {{ .Values.nri.runtime.config.pluginRequestTimeout }}
+        {{- end }}
         image: {{ .Values.initContainerImage.name }}:{{ .Values.initContainerImage.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
         volumeMounts:
@@ -55,7 +62,7 @@ spec:
             - -metrics-interval
             - 5s
             - --nri-plugin-index
-            - "{{ .Values.nri.pluginIndex | int | printf "%02d"  }}"
+            - "{{ .Values.nri.plugin.index | int | printf "%02d"  }}"
             {{- if .Values.configGroupLabel }}
             - --config-group-label
             - {{ .Values.configGroupLabel }}
@@ -116,7 +123,7 @@ spec:
         hostPath:
           path: /var/run/nri
           type: DirectoryOrCreate
-      {{- if .Values.nri.patchRuntimeConfig }}
+      {{- if .Values.nri.runtime.patchConfig }}
       - name: containerd-config
         hostPath:
           path: /etc/containerd/

--- a/deployment/helm/topology-aware/values.schema.json
+++ b/deployment/helm/topology-aware/values.schema.json
@@ -65,17 +65,52 @@
         "nri": {
             "type": "object",
             "required": [
-                "patchRuntimeConfig",
-                "pluginIndex"
+                "plugin",
+                "runtime"
             ],
             "properties": {
-                "patchRuntimeConfig": {
-                    "type": "boolean"
+                "plugin": {
+                    "type": "object",
+                    "required": [
+                        "index"
+                    ],
+                    "properties": {
+                        "index": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 99
+                        }
+                    }
                 },
-                "pluginIndex": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 99
+                "runtime": {
+                    "type": "object",
+                    "required": [
+                        "patchConfig"
+                    ],
+                    "properties": {
+                        "patchConfig": {
+                            "type": "boolean"
+                        },
+                        "config": {
+                            "type": "object",
+                            "required": [
+                                "pluginRegistrationTimeout",
+                                "pluginRequestTimeout"
+                            ],
+                            "properties": {
+                                "pluginRegistrationTimeout": {
+                                    "type": "string",
+                                    "$comment": "allowed range is 5-30s",
+                                    "pattern": "^(([5-9])|([1-2][0-9])|(30))s$"
+                                },
+                                "pluginRequestTimeout": {
+                                    "type": "string",
+                                    "$comment": "allowed range is 2-30s",
+                                    "pattern": "^(([2-9])|([1-2][0-9])|(30))s$"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/deployment/helm/topology-aware/values.yaml
+++ b/deployment/helm/topology-aware/values.yaml
@@ -36,8 +36,13 @@ resources:
   memory: 512Mi
 
 nri:
-  patchRuntimeConfig: false
-  pluginIndex: 90
+  plugin:
+    index: 90
+  runtime:
+    patchConfig: false
+#   config:
+#     pluginRegistrationTimeout: 5s
+#     pluginRequestTimeout: 2s
 
 initContainerImage:
   name: ghcr.io/containers/nri-plugins/nri-config-manager

--- a/deployment/operator/README.md
+++ b/deployment/operator/README.md
@@ -39,7 +39,13 @@ spec:
   state: present
   values:
     nri:
-      patchRuntimeConfig: true
+      plugin:
+        index: 90
+      runtime:
+        patchConfig: true
+#       config:
+#         pluginRegistrationTimeout: 5s
+#         pluginRequestTimeout: 2s
     tolerations:
       - key: "node-role.kubernetes.io/control-plane"
         operator: "Exists"

--- a/deployment/operator/config/samples/config.nri_v1alpha1_nriplugindeployment.yaml
+++ b/deployment/operator/config/samples/config.nri_v1alpha1_nriplugindeployment.yaml
@@ -15,5 +15,5 @@ spec:
   state: present
   values:
     nri:
-      patchRuntimeConfig: true
-
+      runtime:
+        patchConfig: true


### PR DESCRIPTION
Allow setting NRI plugin registration and request timeouts in the CRI-O or containerd configuration files. Require neither or both timeouts to be given. If both are given, verify that registration timeout is larger than the request timeout.
