### PR TITLE
resmgr: exit when ttrpc connection goes down.

### DIFF
--- a/pkg/resmgr/nri.go
+++ b/pkg/resmgr/nri.go
@@ -17,6 +17,7 @@ package resmgr
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/containers/nri-plugins/pkg/instrumentation/tracing"
 	logger "github.com/containers/nri-plugins/pkg/log"
@@ -106,13 +107,9 @@ func (p *nriPlugin) stop() {
 	p.stub.Stop()
 }
 
-func (p *nriPlugin) restart() error {
-	return p.start()
-}
-
 func (p *nriPlugin) onClose() {
-	p.resmgr.Warn("connection to NRI/runtime lost, trying to reconnect...")
-	p.restart()
+	p.Error("connection to NRI/runtime lost, exiting...")
+	os.Exit(1)
 }
 
 func (p *nriPlugin) Configure(ctx context.Context, cfg, runtime, version string) (stub.EventMask, error) {


### PR DESCRIPTION
We do not have proper connection re-establishment and the policy- agnostic resource management layer will require changes for this to be possible. Until we get that done, exit the plugin when the ttrpc connection goes down instead of just sitting there pretending everything is fine.