### PR TITLE
e2e: cache and restore latest github versions

### DIFF
--- a/test/e2e/lib/vm.bash
+++ b/test/e2e/lib/vm.bash
@@ -36,6 +36,58 @@ vm-create-name() {
     echo "${topology}-${distro}-${runtime}"
 }
 
+vm-save-cached-var() {
+    local output_dir="$1"
+    local var="$2"
+    local val="${3:-}"
+    local cache_dir="$output_dir/cache"
+
+    if [ $# = 3 ]; then
+        val="$3"
+    else
+        val="${!var}"
+    fi
+
+    if [ -z "$val" ]; then
+        echo "WARNING: not saving cached empty value for variable $var..." 1>&2
+        return 0
+    fi
+
+    if [ ! -d "$cache_dir" ]; then
+        mkdir -p "$cache_dir" || \
+            error "failed to create cache dir $cache_dir"
+    fi
+
+    echo "$val" > "$cache_dir/$var"
+    if [ $? = 0 ]; then
+        echo "saved cached variable $var=$val..." 1>&2
+        return 0
+    fi
+
+    return 1
+}
+
+vm-load-cached-var() {
+    local output_dir="$1"
+    local var="$2"
+    local cache_dir="$output_dir/cache"
+    local val
+
+    if [ ! -d "$cache_dir" -o ! -f "$cache_dir/$var" ]; then
+        return 1
+    fi
+
+    val="$(cat $cache_dir/$var)"
+    if [ $? = 0 ]; then
+        echo "loaded cached variable $var=$val..." 1>&2
+        echo $val
+        return 0
+    fi
+
+    error "failed to load cached variable $var" 1>&2
+    return 1
+}
+
 vm-setup() {
     local output_dir="$1"
     local vmname="$2"

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -60,8 +60,14 @@ latest-github-release () {
 }
 
 if [ "$k8s_release" = "latest" ]; then
-    if ! k8s_release=$(latest-github-release $GH_K8S_REPO); then
-        error "$k8s_release"
+    if latest_k8s_release=$(vm-load-cached-var "$OUTPUT_DIR" latest_k8s_release); then
+        echo "Loaded cached latest_k8s_release=$latest_k8s_release..."
+        k8s_release="$latest_k8s_release"
+    else
+        if ! k8s_release=$(latest-github-release $GH_K8S_REPO); then
+            error "$k8s_release"
+        fi
+        vm-save-cached-var "$OUTPUT_DIR" latest_k8s_release $k8s_release
     fi
     k8s_release="${k8s_release#v}"
     echo "Latest Kubernetes release: $k8s_release"
@@ -104,12 +110,19 @@ GH_CONTAINERD_REPO="containerd/containerd"
 export containerd_release=${containerd_release:-latest}
 
 if [ "$k8scri" = "containerd" -a "$containerd_release" = "latest" ]; then
-    if ! containerd_release=$(latest-github-release $GH_CONTAINERD_REPO); then
-        error "$containerd_release"
+    if latest_containerd_release=$(vm-load-cached-var "$OUTPUT_DIR" latest_containerd_release); then
+        echo "Loaded cached latest_containerd_release=$latest_containerd_release..."
+        containerd_release="$latest_containerd_release"
+    else
+        if ! containerd_release=$(latest-github-release $GH_CONTAINERD_REPO); then
+            error "$containerd_release"
+        fi
+        vm-save-cached-var "$OUTPUT_DIR" latest_containerd_release $containerd_release
     fi
     containerd_release="${containerd_release#v}"
     echo "Latest containerd release: $containerd_release"
 fi
+
 
 export containerd_src=${containerd_src:-}
 
@@ -123,9 +136,16 @@ export crio_release=${crio_release:-latest}
 export crio_src=${crio_src:-}
 
 if [ "$k8scri" = "crio" -a "$crio_release" = "latest" ]; then
-    if ! crio_release=$(latest-github-release $GH_CRIO_REPO); then
-        error "$crio_release"
+    if latest_crio_release=$(vm-load-cached-var "$OUTPUT_DIR" latest_crio_release); then
+        echo "Loaded cached latest_crio_release=$latest_crio_release..."
+        crio_release="$latest_crio_release"
+    else
+        if ! crio_release=$(latest-github-release $GH_CRIO_REPO); then
+            error "$crio_release"
+        fi
+        vm-save-cached-var "$OUTPUT_DIR" latest_crio_release $crio_release
     fi
+    crio_release="${crio_release#v}"
     echo "Latest CRI-O release: $crio_release"
 fi
 


### PR DESCRIPTION
Note: this PR is stacked on top of #323.

Add support for caching and restoring variables per test VM. Once the `latest` github version of CRI-O, containerd or kubernetes has been resolved to a real version tag, save it in the new vm-specific variable cache. Always try restoring these versions from cache before turning to discover them from github. This should significantly reduce how much we punish/bang on github for the full set of our e2e tests. 