### PR TITLE
resmgr: don't log about NRT CR updates when object isn't created

### DIFF
--- a/pkg/agent/node-resource-topology.go
+++ b/pkg/agent/node-resource-topology.go
@@ -67,24 +67,13 @@ func (a *Agent) updateNrtCR(policy string, zones []*policyapi.TopologyZone) erro
 		}
 	}
 
-	// delete existing CR if we got no data from policy
 	// XXX TODO Deletion should be handled differently:
 	//   1. add expiration timestamp to nrt.NodeResourceTopology
 	//   2. GC CRs that are past their expiration time (for instance by NFD)
 	//   3. make sure we refresh our CR (either here or preferably/easier
 	//      by triggering in resmgr an updateTopologyZones() during longer
 	//      periods of inactivity)
-	if len(zones) == 0 {
-		if cr != nil {
-			err := cli.Delete(ctx, a.nodeName, metav1.DeleteOptions{})
-			if err != nil && !errors.IsNotFound(err) {
-				return fmt.Errorf("failed to delete node resource topology CR: %w", err)
-			}
-		}
-		return nil
-	}
-
-	// otherwise update CR if one exists
+	// update CR if one exists
 	if cr != nil {
 		cr.Attributes = nrt.AttributeList{
 			nrt.AttributeInfo{

--- a/pkg/resmgr/resource-manager.go
+++ b/pkg/resmgr/resource-manager.go
@@ -271,10 +271,11 @@ func (m *resmgr) startControllers() error {
 
 // updateTopologyZones updates the 'topology zone' CRDs.
 func (m *resmgr) updateTopologyZones() {
-	m.Info("updating topology zones...")
-	err := m.agent.UpdateNrtCR(m.policy.ActivePolicy(), m.policy.GetTopologyZones())
-	if err != nil {
-		m.Error("failed to update topology zones: %v", err)
+	if zones := m.policy.GetTopologyZones(); len(zones) != 0 {
+		m.Info("updating topology zones...")
+		if err := m.agent.UpdateNrtCR(m.policy.ActivePolicy(), zones); err != nil {
+			m.Error("failed to update topology zones: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
You can see the following lines of logging in the balloons plugin for example:
```
I: [         resource-manager         ] updating topology zones...
I: [               agent              ] updating node resource topology CR
```
Currently it is only [TA plugin](https://github.com/containers/nri-plugins/blob/82131f985fbe5d496215c23cd0a198acfed75bcd/cmd/plugins/topology-aware/policy/topology-aware-policy.go#L260) that actually fetches the zone data, while other plugins like balloons doesn't fetch the data even though it has a [method](https://github.com/containers/nri-plugins/blob/82131f985fbe5d496215c23cd0a198acfed75bcd/cmd/plugins/balloons/policy/balloons-policy.go#L291) for that. As such, with this change, we now check if there is a zone data and only if yes, we allow calling methods & functions for updating the NRT CR.