### PR TITLE
pkg/{cgroups,topology}: move linux-specific functions

### DIFF
--- a/pkg/cgroups/cgroupid.go
+++ b/pkg/cgroups/cgroupid.go
@@ -1,13 +1,10 @@
 package cgroups
 
 import (
-	"encoding/binary"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
-
-	"golang.org/x/sys/unix"
 )
 
 // CgroupID implements mapping kernel cgroup IDs to cgroupfs paths with transparent caching.
@@ -23,15 +20,6 @@ func NewCgroupID(root string) *CgroupID {
 		root:  root,
 		cache: make(map[uint64]string),
 	}
-}
-
-func getID(path string) uint64 {
-	h, _, err := unix.NameToHandleAt(unix.AT_FDCWD, path, 0)
-	if err != nil {
-		return 0
-	}
-
-	return binary.LittleEndian.Uint64(h.Bytes())
 }
 
 // Find finds the path for the given cgroup id.

--- a/pkg/cgroups/cgroupid_linux.go
+++ b/pkg/cgroups/cgroupid_linux.go
@@ -1,0 +1,16 @@
+package cgroups
+
+import (
+	"encoding/binary"
+
+	"golang.org/x/sys/unix"
+)
+
+func getID(path string) uint64 {
+	h, _, err := unix.NameToHandleAt(unix.AT_FDCWD, path, 0)
+	if err != nil {
+		return 0
+	}
+
+	return binary.LittleEndian.Uint64(h.Bytes())
+}

--- a/pkg/cgroups/cgroupid_other.go
+++ b/pkg/cgroups/cgroupid_other.go
@@ -1,0 +1,8 @@
+//go:build !linux
+// +build !linux
+
+package cgroups
+
+func getID(path string) uint64 {
+	panic("not implemented")
+}

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -19,9 +19,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
-
-	"golang.org/x/sys/unix"
 )
 
 // to mock in tests
@@ -233,43 +230,6 @@ func (h *Hint) String() string {
 	}
 
 	return "<hints " + cpus + nodes + sockets + " (from " + h.Provider + ")>"
-}
-
-// FindSysFsDevice for given argument returns physical device where it is linked to.
-// For device nodes it will return path for device itself. For regular files or directories
-// this function returns physical device where this inode resides (storage device).
-// If result device is a virtual one (e.g. tmpfs), error will be returned.
-// For non-existing path, no error returned and path is empty.
-func FindSysFsDevice(dev string) (string, error) {
-	fi, err := os.Stat(dev)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return "", nil
-		}
-		return "", fmt.Errorf("unable to get stat for %s: %w", dev, err)
-	}
-
-	devType := "block"
-	rdev := fi.Sys().(*syscall.Stat_t).Dev
-	if mode := fi.Mode(); mode&os.ModeDevice != 0 {
-		rdev = fi.Sys().(*syscall.Stat_t).Rdev
-		if mode&os.ModeCharDevice != 0 {
-			devType = "char"
-		}
-	}
-
-	major := int64(unix.Major(rdev))
-	minor := int64(unix.Minor(rdev))
-	if major == 0 {
-		return "", fmt.Errorf("%s is a virtual device node: %w", dev, err)
-	}
-
-	realDevPath, err := findSysFsDevice(devType, major, minor)
-	if err != nil {
-		return "", fmt.Errorf("failed to find sysfs device for %s: %w", dev, err)
-	}
-
-	return realDevPath, nil
 }
 
 // FindGivenSysFsDevice returns the physical device with the given device type,

--- a/pkg/topology/topology_linux.go
+++ b/pkg/topology/topology_linux.go
@@ -1,0 +1,46 @@
+package topology
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// FindSysFsDevice for given argument returns physical device where it is linked to.
+// For device nodes it will return path for device itself. For regular files or directories
+// this function returns physical device where this inode resides (storage device).
+// If result device is a virtual one (e.g. tmpfs), error will be returned.
+// For non-existing path, no error returned and path is empty.
+func FindSysFsDevice(dev string) (string, error) {
+	fi, err := os.Stat(dev)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("unable to get stat for %s: %w", dev, err)
+	}
+
+	devType := "block"
+	rdev := fi.Sys().(*syscall.Stat_t).Dev
+	if mode := fi.Mode(); mode&os.ModeDevice != 0 {
+		rdev = fi.Sys().(*syscall.Stat_t).Rdev
+		if mode&os.ModeCharDevice != 0 {
+			devType = "char"
+		}
+	}
+
+	major := int64(unix.Major(rdev))
+	minor := int64(unix.Minor(rdev))
+	if major == 0 {
+		return "", fmt.Errorf("%s is a virtual device node: %w", dev, err)
+	}
+
+	realDevPath, err := findSysFsDevice(devType, major, minor)
+	if err != nil {
+		return "", fmt.Errorf("failed to find sysfs device for %s: %w", dev, err)
+	}
+
+	return realDevPath, nil
+}

--- a/pkg/topology/topology_other.go
+++ b/pkg/topology/topology_other.go
@@ -1,0 +1,15 @@
+//go:build !linux
+// +build !linux
+
+package topology
+
+import "errors"
+
+// FindSysFsDevice for given argument returns physical device where it is linked to.
+// For device nodes it will return path for device itself. For regular files or directories
+// this function returns physical device where this inode resides (storage device).
+// If result device is a virtual one (e.g. tmpfs), error will be returned.
+// For non-existing path, no error returned and path is empty.
+func FindSysFsDevice(dev string) (string, error) {
+	return "", errors.New("not implemented")
+}


### PR DESCRIPTION
This change moves linux-specific functions to `_linux.go` source files and adds stub implementations for other platforms.