### PR TITLE
topology-aware: don't ignore HBM memory nodes without close CPUs.

### DIFF
--- a/cmd/plugins/topology-aware/policy/resources.go
+++ b/cmd/plugins/topology-aware/policy/resources.go
@@ -977,7 +977,7 @@ func newRequest(container cache.Container) Request {
 		container.PrettyName(), cpuType, full, fraction, isolate, prio)
 
 	if mtype == memoryUnspec {
-		mtype = defaultMemoryType
+		mtype = defaultMemoryType &^ memoryHBM
 	}
 
 	if mtype&memoryPMEM != 0 && mtype&memoryDRAM != 0 {

--- a/cmd/plugins/topology-aware/policy/resources.go
+++ b/cmd/plugins/topology-aware/policy/resources.go
@@ -1442,13 +1442,10 @@ func (cg *grant) String() string {
 			cg.node.FreeSupply().SharableCPUs(), cg.SharedPortion())
 	}
 
-	mem := cg.allocatedMem.String()
-	if mem != "" {
-		mem = ", MemLimit: " + mem
-	}
+	memset := ", MemPin: " + cg.memset.String()
 
 	return fmt.Sprintf("<grant for %s from %s: %s%s%s%s%s%s>",
-		cg.container.PrettyName(), cg.node.Name(), cpuType, isolated, exclusive, reserved, shared, mem)
+		cg.container.PrettyName(), cg.node.Name(), cpuType, isolated, exclusive, reserved, shared, memset)
 }
 
 func (cg *grant) AccountAllocateCPU() {

--- a/pkg/sysfs/system.go
+++ b/pkg/sysfs/system.go
@@ -78,6 +78,18 @@ const (
 	MemoryTypeHBM
 )
 
+func (t MemoryType) String() string {
+	switch t {
+	case MemoryTypeDRAM:
+		return "DRAM"
+	case MemoryTypePMEM:
+		return "PMEM"
+	case MemoryTypeHBM:
+		return "HBM"
+	}
+	return fmt.Sprintf("%%(BAD-MemoryType:%d)", t)
+}
+
 // System devices
 type System interface {
 	Discover(flags DiscoveryFlag) error


### PR DESCRIPTION
Treat HBM memory nodes without close CPUs similarly to PMEM nodes, IOW assign them to the closest DRAM node as extra capacity. Also, for now don't ever allocate HBM memory implicitly to containers.