### PR TITLE
topology-aware: log memory type preference as such.

### DIFF
--- a/cmd/plugins/topology-aware/policy/pod-preferences.go
+++ b/cmd/plugins/topology-aware/policy/pod-preferences.go
@@ -207,7 +207,7 @@ func memoryTypePreference(pod cache.Pod, container cache.Container) memoryType {
 		return memoryUnspec
 	}
 
-	log.Debug("%s: effective cold start preference %v", container.PrettyName(), mtype)
+	log.Debug("%s: effective memory type preference %v", container.PrettyName(), mtype)
 
 	return mtype
 }


### PR DESCRIPTION
Don't log effective memory type preference as cold start preference.