### PR TITLE
topology-aware: add support for hide-hyperthreads annotation.

### DIFF
--- a/cmd/plugins/topology-aware/policy/pod-preferences.go
+++ b/cmd/plugins/topology-aware/policy/pod-preferences.go
@@ -44,6 +44,8 @@ const (
 	keyReservedCPUsPreference = "prefer-reserved-cpus"
 	// annotation key for CPU Priority preference
 	keyCpuPriorityPreference = "prefer-cpu-priority"
+	// annotation key for hiding hyperthreads from allocated CPU sets
+	keyHideHyperthreads = "hide-hyperthreads"
 
 	// effective annotation key for isolated CPU preference
 	preferIsolatedCPUsKey = keyIsolationPreference + "." + kubernetes.ResmgrKeyNamespace
@@ -57,6 +59,8 @@ const (
 	preferReservedCPUsKey = keyReservedCPUsPreference + "." + kubernetes.ResmgrKeyNamespace
 	// effective annotation key for CPU priority preference
 	preferCpuPriorityKey = keyCpuPriorityPreference + "." + kubernetes.ResmgrKeyNamespace
+	// effective annotation key for hiding hyperthreads
+	hideHyperthreadsKey = keyHideHyperthreads + "." + kubernetes.ResmgrKeyNamespace
 )
 
 // cpuClass is a type of CPU to allocate
@@ -185,6 +189,20 @@ func cpuPrioPreference(pod cache.Pod, container cache.Container, fallback cpuPri
 
 	log.Debug("%s: explicit CPU priority preference %q", container.PrettyName(), prio)
 	return prio
+}
+
+// hideHyperthreadsPreference returns if a container should run using
+// only single hyperthread from each physical core.
+func hideHyperthreadsPreference(pod cache.Pod, container cache.Container) bool {
+	value, ok := container.GetEffectiveAnnotation(hideHyperthreadsKey)
+	if !ok {
+		return false
+	}
+	hide, err := strconv.ParseBool(value)
+	if err != nil {
+		return false
+	}
+	return hide
 }
 
 // memoryTypePreference returns what type of memory should be allocated for the container.

--- a/docs/resource-policy/policy/topology-aware.md
+++ b/docs/resource-policy/policy/topology-aware.md
@@ -271,6 +271,24 @@ metadata:
 These Pod annotations have no effect on containers which are not eligible for
 exclusive allocation.
 
+### Selectively Disabling Hyperthreading
+
+If a container opts to hide hyperthreads, it is allowed to use only
+one hyperthread from every physical CPU core allocated to it. Note
+that as a result the container may be allowed to run on only half of
+the CPUs it has requested. In case of workloads that do not benefit
+from hyperthreading this nevertheless results in better performance
+compared to running on all hyperthreads of the same CPU cores. If
+container's CPU allocation is exclusive, no other container can run on
+hidden hyperthreads either.
+
+```yaml
+metadata:
+  annotations:
+    # allow the "LLM" container to use only single thread per physical CPU core
+    hide-hyperthreads.resource-policy.nri.io/container.LLM: "true"
+```
+
 ### Implicit Hardware Topology Hints
 
 `NRI Resource Policy` automatically generates HW `Topology Hints` for devices

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test00-basic-placement/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test00-basic-placement/code.var.sh
@@ -38,12 +38,13 @@ vm-command "kubectl delete pods --all --now"
 
 # pod1: Test that 4 guaranteed containers not eligible for isolated CPU allocation
 # gets evenly spread over NUMA nodes.
-CONTCOUNT=4 CPU=3 create guaranteed
+CONTCOUNT=4 CPU=3 ANN0='hide-hyperthreads.resource-policy.nri.io/container.pod1c2: "true"' create guaranteed
 report allowed
 verify \
     'len(cpus["pod1c0"]) == 3' \
     'len(cpus["pod1c1"]) == 3' \
-    'len(cpus["pod1c2"]) == 3' \
+    'len(cpus["pod1c2"]) == 2' \
+    'len(cores["pod1c2"]) == 2' \
     'len(cpus["pod1c3"]) == 3' \
     'disjoint_sets(cpus["pod1c0"], cpus["pod1c1"], cpus["pod1c2"], cpus["pod1c3"])' \
     'disjoint_sets(nodes["pod1c0"], nodes["pod1c1"], nodes["pod1c2"], nodes["pod1c3"])'

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test11-reserved-cpu-annotations/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test11-reserved-cpu-annotations/code.var.sh
@@ -7,6 +7,7 @@ cleanup-test-pods() {
     ( vm-command "kubectl delete pods pod0 --now" ) || true
     ( vm-command "kubectl delete pods pod1 --now" ) || true
     ( vm-command "kubectl delete pods pod2 --now" ) || true
+    ( vm-command "kubectl delete pods pod3 --now" ) || true
 }
 cleanup-test-pods
 
@@ -19,33 +20,41 @@ helm_config=$(instantiate helm-config.yaml) helm-launch topology-aware
 ANNOTATIONS='prefer-reserved-cpus.resource-policy.nri.io/pod: "true"'
 CONTCOUNT=1 create reserved-annotated
 report allowed
+verify 'cpus["pod0c0"] == {"cpu10", "cpu11"}'
 
 ANNOTATIONS='prefer-reserved-cpus.resource-policy.nri.io/container.special: "false"'
 CONTCOUNT=1 create reserved-annotated
 report allowed
-
-verify 'cpus["pod0c0"] == {"cpu10", "cpu11"}'
 verify 'cpus["pod1c0"] == {"cpu08"}'
+
+vm-command "kubectl delete pods pod0 --now"
+ANNOTATIONS=(
+    'prefer-reserved-cpus.resource-policy.nri.io/pod: "true"'
+    'hide-hyperthreads.resource-policy.nri.io/pod: "true"'
+)
+CONTCOUNT=1 create reserved-annotated
+report allowed
+verify 'cpus["pod2c0"] == {"cpu10"}'
 
 ANNOTATIONS=(
     'cpu.preserve.resource-policy.nri.io: "true"'
-    'memory.preserve.resource-policy.nri.io/container.pod2c1: "true"'
-    'memory.preserve.resource-policy.nri.io/container.pod2c2: "true"'
-    'cpu.preserve.resource-policy.nri.io/container.pod2c2: "false"'
-    'cpu.preserve.resource-policy.nri.io/container.pod2c3: "false"'
-    'memory.preserve.resource-policy.nri.io/container.pod2c3: "false"'
+    'memory.preserve.resource-policy.nri.io/container.pod3c1: "true"'
+    'memory.preserve.resource-policy.nri.io/container.pod3c2: "true"'
+    'cpu.preserve.resource-policy.nri.io/container.pod3c2: "false"'
+    'cpu.preserve.resource-policy.nri.io/container.pod3c3: "false"'
+    'memory.preserve.resource-policy.nri.io/container.pod3c3: "false"'
 )
 CONTCOUNT=4 CPU=100m MEM=100M create reserved-annotated
 report allowed
 
-verify 'len(cpus["pod2c0"]) == 16' \
-       'len(mems["pod2c0"]) == 4' \
-       'len(cpus["pod2c1"]) == 16' \
-       'len(mems["pod2c1"]) == 4' \
-       'len(cpus["pod2c2"]) == 1' \
-       'len(mems["pod2c2"]) == 4' \
-       'len(cpus["pod2c3"]) == 1' \
-       'len(mems["pod2c3"]) == 1'
+verify 'len(cpus["pod3c0"]) == 16' \
+       'len(mems["pod3c0"]) == 4' \
+       'len(cpus["pod3c1"]) == 16' \
+       'len(mems["pod3c1"]) == 4' \
+       'len(cpus["pod3c2"]) == 1' \
+       'len(mems["pod3c2"]) == 4' \
+       'len(cpus["pod3c3"]) == 1' \
+       'len(mems["pod3c3"]) == 1'
 
 cleanup-test-pods
 


### PR DESCRIPTION
Containers with effective hide-hyperthreads annotation are allowed to run only on the first CPU hyperthread of all physical CPU cores allocated to its pool.