### PR TITLE
sysfs,cpuallocator: fix CPU cluster discovery. 

### DIFF
--- a/pkg/cpuallocator/allocator.go
+++ b/pkg/cpuallocator/allocator.go
@@ -947,14 +947,15 @@ func (c *topologyCache) discoverCPUClusters(sys sysfs.System) {
 		clusters := []*cpuCluster{}
 		for _, die := range pkg.DieIDs() {
 			for _, cl := range pkg.LogicalDieClusterIDs(id) {
-				cpus := pkg.LogicalDieClusterCPUSet(die, cl)
-				clusters = append(clusters, &cpuCluster{
-					pkg:     id,
-					die:     die,
-					cluster: cl,
-					cpus:    cpus,
-					kind:    sys.CPU(cpus.List()[0]).CoreKind(),
-				})
+				if cpus := pkg.LogicalDieClusterCPUSet(die, cl); cpus.Size() > 0 {
+					clusters = append(clusters, &cpuCluster{
+						pkg:     id,
+						die:     die,
+						cluster: cl,
+						cpus:    cpus,
+						kind:    sys.CPU(cpus.List()[0]).CoreKind(),
+					})
+				}
 			}
 		}
 		if len(clusters) > 1 {

--- a/pkg/cpuallocator/allocator.go
+++ b/pkg/cpuallocator/allocator.go
@@ -946,7 +946,7 @@ func (c *topologyCache) discoverCPUClusters(sys sysfs.System) {
 		pkg := sys.Package(id)
 		clusters := []*cpuCluster{}
 		for _, die := range pkg.DieIDs() {
-			for _, cl := range pkg.LogicalDieClusterIDs(id) {
+			for _, cl := range pkg.LogicalDieClusterIDs(die) {
 				if cpus := pkg.LogicalDieClusterCPUSet(die, cl); cpus.Size() > 0 {
 					clusters = append(clusters, &cpuCluster{
 						pkg:     id,

--- a/pkg/sysfs/system.go
+++ b/pkg/sysfs/system.go
@@ -1413,6 +1413,9 @@ func (sys *system) discoverPackages() error {
 				pkg.logicalClusters[die][first.cluster] = idset.NewIDSet(allHTCPUs.Members()...)
 			}
 		}
+		if len(pkg.logicalClusters) == 0 {
+			pkg.logicalClusters = pkg.clusterCPUs
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This patch series fixes a few problems related to CPU cluster discovery. In particular
- on systems without SMT/hyperthreading use physical clusters as the logical ones, ensuring that we always have logical clusters if we have any
- during CPU cluster discovery, use the correct die ID instead of the incorrect package ID when querying per package CPU clusters

