### PR TITLE
cpuallocator: implement clustered allocation based on cache groups.

### DIFF
--- a/pkg/cpuallocator/allocator.go
+++ b/pkg/cpuallocator/allocator.go
@@ -1072,11 +1072,17 @@ func (a *allocatorHelper) allocate() cpuset.CPUSet {
 		if (a.flags & AllocIdlePackages) != 0 {
 			a.takeIdlePackages()
 		}
-		if a.cnt > 0 && (a.flags&AllocIdleClusters) != 0 {
-			a.takeIdleClusters()
-		}
-		if a.cnt > 0 && (a.flags&AllocCacheGroups) != 0 {
-			a.takeCacheGroups()
+		if len(a.topology.kind) > 1 {
+			if a.cnt > 0 && (a.flags&AllocIdleClusters) != 0 {
+				a.takeIdleClusters()
+			}
+			if a.cnt > 0 && (a.flags&AllocCacheGroups) != 0 {
+				a.takeCacheGroups()
+			}
+		} else {
+			if a.cnt > 0 && (a.flags&AllocCacheGroups) != 0 {
+				a.takeCacheGroups()
+			}
 		}
 		if a.cnt > 0 && (a.flags&AllocIdleCores) != 0 {
 			a.takeIdleCores()

--- a/pkg/sysfs/system.go
+++ b/pkg/sysfs/system.go
@@ -212,6 +212,7 @@ type CPU interface {
 	GetCaches() []*Cache
 	GetCachesByLevel(int) []*Cache
 	GetCacheByIndex(int) *Cache
+	GetNthLevelCacheCPUSet(n int) cpuset.CPUSet
 	GetLastLevelCaches() []*Cache
 	GetLastLevelCacheCPUSet() cpuset.CPUSet
 	CoreKind() CoreKind
@@ -1094,6 +1095,25 @@ func (c *cpu) GetLastLevelCaches() []*Cache {
 	}
 
 	return caches
+}
+
+// GetNthLevelCacheCPUSet returns the cpuset for the nth level caches of this CPU.
+func (c *cpu) GetNthLevelCacheCPUSet(n int) cpuset.CPUSet {
+	if len(c.caches) < 1 {
+		return c.ThreadCPUSet()
+	}
+
+	cpus := cpuset.New()
+
+	for _, cch := range c.caches {
+		if cch.level == n {
+			cpus = cpus.Union(CPUSetFromIDSet(cch.cpus))
+		} else if cch.level > n {
+			break
+		}
+	}
+
+	return cpus
 }
 
 // GetLastLevelCacheCPUSet returns the cpuset for the last level caches of this CPU.

--- a/pkg/sysfs/system.go
+++ b/pkg/sysfs/system.go
@@ -20,6 +20,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -934,6 +935,13 @@ func (sys *system) discoverCPU(path string) error {
 
 	if (sys.flags & DiscoverCache) != 0 {
 		entries, _ := filepath.Glob(filepath.Join(path, "cache/index[0-9]*"))
+		slices.SortFunc(entries, func(a, b string) int {
+			a = strings.TrimPrefix(filepath.Base(a), "index")
+			b = strings.TrimPrefix(filepath.Base(b), "index")
+			idxA, _ := strconv.Atoi(a)
+			idxB, _ := strconv.Atoi(b)
+			return idxA - idxB
+		})
 		for _, entry := range entries {
 			if err := sys.discoverCache(cpu, entry); err != nil {
 				return err
@@ -1060,6 +1068,8 @@ func (c *cpu) GetCachesByLevel(level int) []*Cache {
 	for _, cch := range c.caches {
 		if cch.level == level {
 			caches = append(caches, cch)
+		} else if cch.level > level {
+			break
 		}
 	}
 


### PR DESCRIPTION
This patch series adds support for clustered CPU allocation based on cache groups to the cpuallocator package. In particular with these patches in place, the cpuallocator now
- discovers cache groups on instantiation
- tries to satisfy allocation requests using one or more cache groups
- uses explicit cluster info based allocation only on hybrid core architectures

Allocation always prefers using fully idle cache groups first, fragmenting idle cache groups by partial allocation second, and only resort to using fragmented groups when the allocation cannot be satisfied in any other way. Partial cache group allocations are done in a hyperthread aware fashion, taking full physical cores whenever possible.

The allocator uses the last useful level of cache for clustering. IOW it tries to find the last cache which provides non-trivial clustering, one that provides different grouping than packages, dies, or hyperthreading, and uses that for grouping CPUs. The current implementation is currently somewhat simplistic as it expects all CPUs to provide identical cache grouping and therefore picks a single cache level for grouping. This is fine on most architectures, but it might result in suboptimal clustering with hybrid cores. If necessary this limitation can be addressed in the future.