### PR TITLE
 balloons: add support for isolated cpus.

### DIFF
--- a/config/crd/bases/config.nri_balloonspolicies.yaml
+++ b/config/crd/bases/config.nri_balloonspolicies.yaml
@@ -195,6 +195,10 @@ spec:
                       items:
                         type: string
                       type: array
+                    preferIsolCpus:
+                      default: false
+                      description: 'preferIsolCpus: prefer kernel isolated cpus'
+                      type: boolean
                     preferNewBalloons:
                       description: |-
                         PreferNewBalloons: prefer creating new balloons over adding

--- a/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
+++ b/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
@@ -195,6 +195,10 @@ spec:
                       items:
                         type: string
                       type: array
+                    preferIsolCpus:
+                      default: false
+                      description: 'preferIsolCpus: prefer kernel isolated cpus'
+                      type: boolean
                     preferNewBalloons:
                       description: |-
                         PreferNewBalloons: prefer creating new balloons over adding

--- a/docs/resource-policy/policy/balloons.md
+++ b/docs/resource-policy/policy/balloons.md
@@ -168,6 +168,14 @@ Balloons policy parameters:
     preferring exclusive CPUs, as long as there are enough free
     CPUs. The default is `false`: prefer filling and inflating
     existing balloons over creating new ones.
+  - `preferIsolCpus`: if `true`,prefer system isolated CPUs (refer to
+    kernel command line parameter "isolcpus") for this balloon. Warning:
+    if there are not enough isolated CPUs in the system for balloons that
+    prefer them, balloons may include normal CPUs, too. This kind of
+    mixed-CPU balloons require special attention when implementing
+    programs that run on them. Therefore it is recommended to limit the
+    number of balloon CPUs (see maxCPUs) and allocate CPUs upfront (see
+    minBalloons, minCPUs) when using preferIsolCpus. The default is `false`.
   - `shareIdleCPUsInSame`: Whenever the number of or sizes of balloons
     change, idle CPUs (that do not belong to any balloon) are reshared
     as extra CPUs to containers in balloons with this option. The value

--- a/pkg/apis/config/v1alpha1/resmgr/policy/balloons/config.go
+++ b/pkg/apis/config/v1alpha1/resmgr/policy/balloons/config.go
@@ -216,6 +216,9 @@ type BalloonDef struct {
 	// TODO: PreferFarFromDevices is considered too untested for usage. Hence,
 	// for the time being we prevent its usage through CRDs.
 	PreferFarFromDevices []string `json:"-"`
+	// preferIsolCpus: prefer kernel isolated cpus
+	// +kubebuilder:default:=false
+	PreferIsolCpus bool `json:"preferIsolCpus,omitempty"`
 }
 
 // String stringifies a BalloonDef

--- a/test/e2e/policies.test-suite/balloons/n4c16/test22-isolcpus/balloons-isolcpus.cfg
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test22-isolcpus/balloons-isolcpus.cfg
@@ -1,0 +1,13 @@
+config:
+  balloonTypes:
+    - name: isolcpus
+      minCPUs: 1
+      minBalloons: 1
+      preferIsolCpus: true
+      namespaces:
+      - isolcpus
+  log:
+    debug:
+      - policy
+    klog:
+      skip_headers: true

--- a/test/e2e/policies.test-suite/balloons/n4c16/test22-isolcpus/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test22-isolcpus/code.var.sh
@@ -1,0 +1,65 @@
+reboot-node() {
+    vm-reboot
+    timeout=600 host-wait-vm-ssh-server $OUTPUT_DIR
+}
+
+restart-kubelet() {
+    vm-command "systemctl restart kubelet"
+    sleep 5
+    vm-wait-process --timeout 120 kube-apiserver
+    vm-command "cilium status --wait --wait-duration=120s --interactive=false"
+}
+
+cleanup-pods() {
+    vm-command "kubectl delete pod --all --now"
+    vm-command "kubectl delete namespace $ns --now"
+}
+
+cleanup() {
+    cleanup-pods
+    if [[ "$distro" == *fedora* ]]; then
+        fedora-set-kernel-cmdline ""
+    else
+        ubuntu-set-kernel-cmdline ""
+    fi
+    reboot-node
+    vm-command "grep -v isolcpus /proc/cmdline"
+    if [ $? -ne 0 ]; then
+        error "failed to unset isolcpus kernel commandline parameter"
+    fi
+    restart-kubelet
+    return 0
+}
+
+ns=isolcpus
+cleanup-pods
+
+vm-command "grep isolcpus=0,1 /proc/cmdline" || {
+    if [[ "$distro" == *fedora* ]]; then
+        fedora-set-kernel-cmdline "isolcpus=0,1"
+    else
+        ubuntu-set-kernel-cmdline "isolcpus=0,1"
+    fi
+    reboot-node
+    vm-command "grep isolcpus=0,1 /proc/cmdline" || {
+        error "failed to set isolcpus kernel commandline parameter"
+    }
+    restart-kubelet
+}
+
+helm-terminate
+helm_config=${TEST_DIR}/balloons-isolcpus.cfg helm-launch balloons
+vm-command "kubectl create namespace $ns"
+
+# pod0: should run on non-isolated CPUs
+CONTCOUNT=2 namespace="default" create balloons-busybox
+report allowed
+verify "set.union(cpus['pod0c0'], cpus['pod0c1']).isdisjoint({'cpu00', 'cpu01'})"
+
+# pod1: runs on system isolated CPUs
+CONTCOUNT=2 namespace="$ns" create balloons-busybox
+report allowed
+verify "cpus['pod1c0'] == {'cpu00', 'cpu01'}" 
+verify "cpus['pod1c1'] == {'cpu00', 'cpu01'}"
+
+cleanup


### PR DESCRIPTION
The isolcpus boot parameter allows you to isolate specific CPUs from
the general SMP balancing and scheduler algorithms. Currently, when a
balloon picks up CPUs, it does not differentiate between isolated and
non-isolated CPUs. This change improves the balloon's logic to:
1. Distinguish between isolated and non-isolated CPUs.
2. Allow users to preferably select isolated CPUs, though this is not guaranteed.
3. Avoid using isolated CPUs unless specifically requested by the user via CR.
