### PR TITLE
topology-aware: add missing SingleThreadForCPUs() to mockSysfs.

### DIFF
--- a/cmd/plugins/topology-aware/policy/mocks_test.go
+++ b/cmd/plugins/topology-aware/policy/mocks_test.go
@@ -254,6 +254,9 @@ func (fake *mockSystem) CoreKindCPUs(sysfs.CoreKind) cpuset.CPUSet {
 func (fake *mockSystem) AllThreadsForCPUs(cpuset.CPUSet) cpuset.CPUSet {
 	return cpuset.New()
 }
+func (fake *mockSystem) SingleThreadForCPUs(cpuset.CPUSet) cpuset.CPUSet {
+	return cpuset.New()
+}
 func (fake *mockSystem) Offlined() cpuset.CPUSet {
 	return cpuset.New()
 }


### PR DESCRIPTION
Fix broken mockSysfs by adding missing, recently introduced SingleThreadForCPUs().