### PR TITLE
fixes: fix host-wait-vm-ssh-server, improve vm-reboot.

### DIFF
--- a/test/e2e/policies.test-suite/balloons/n4c16/test22-isolcpus/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test22-isolcpus/code.var.sh
@@ -1,6 +1,5 @@
 reboot-node() {
-    vm-reboot
-    timeout=600 host-wait-vm-ssh-server $OUTPUT_DIR
+    timeout=600 vm-reboot
 }
 
 restart-kubelet() {

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -915,32 +915,6 @@ $py_assertion
     return 0
 }
 
-host-wait-vm-ssh-server() {
-    local _vagrantdir="$1"
-    local _timeout=${timeout:-10}
-    local _waited
-
-    if [ -z "$_vagrantdir" ]; then
-        echo 1>&2 "host-wait-vm-ssh-server: missing vagrant directory"
-        return 1
-    fi
-
-    _waited=0; while (( $_waited < $_timeout )); do
-        if [ ! -f $_vagrantdir/.ssh-config ]; then
-            sleep 1
-        else
-            $SSH -o ConnectTimeout=1 node true
-            if [ $? == 0 ]; then
-                return 0
-            fi
-        fi
-        _waited=$((_waited + 1))
-    done
-
-    echo 1>&2 "host-wait-vm-ssh-server: timeout waiting for $_vagrantdir ssh server"
-    return 1
-}
-
 fedora-set-kernel-cmdline() {
     local e2e_defaults="$*"
     vm-command "mkdir -p /etc/default; touch /etc/default/grub; sed -i '/e2e:fedora-set-kernel-cmdline/d' /etc/default/grub"

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -936,15 +936,6 @@ ubuntu-set-kernel-cmdline() {
     }
 }
 
-vm-reboot() { # script API
-    # Usage: vm-reboot
-    #
-    # Reboots the virtual machine and waits that the ssh server starts
-    # responding again.
-    vm-command "reboot"
-    sleep 5
-}
-
 # Defaults to use in case the test case does not define these values.
 yaml_in_defaults="CPU=1 MEM=100M ISO=true CPUREQ=1 CPULIM=2 MEMREQ=100M MEMLIM=200M CONTCOUNT=1"
 


### PR DESCRIPTION
This PR fixes or improves a few functions in the e2e test script library, including 
- fix host-wait-vm-ssh-server being hasty
- reboot and wait for VM by vagrant.

Here's a more detailed description and reasoning for these changes:

ssh -o ConnectTimeout=$timeout's semantics is such that if connection establishment fails early for other reasons, eg. the host IP not being reachable, ssh exits immediately. Rework the waiting function with this in mind. Instead of counting iterations with the incorrect assumption that each iteration would take 1 second, calculate and use a deadline. Also, move the function to lib/host.bash, since that's where we used to keep all host-* script lib functions.

Don't use "vm-command reboot" for rebooting the VM. It is a bit unreliable and gets stuck too often. Use vagrant halt+ vagrant up instead. Moreover, once rebooted, wait for the VM to come up and start serving SSH connections, like the function comment suggests it would already do. Finally, move the the function to vm.bash, where we used to keep most of the vm-* script lib functions.
