### PR TITLE
fix: clean up plugin at the beginning/end of tests.

### DIFF
--- a/test/e2e/policies.test-suite/balloons/n4c16/test22-isolcpus/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test22-isolcpus/code.var.sh
@@ -62,3 +62,4 @@ verify "cpus['pod1c0'] == {'cpu00', 'cpu01'}"
 verify "cpus['pod1c1'] == {'cpu00', 'cpu01'}"
 
 cleanup
+helm-terminate

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test00-basic-placement/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test00-basic-placement/code.var.sh
@@ -20,6 +20,7 @@ vm-command "grep isolcpus /proc/cmdline" && {
 }
 
 # Do a fresh start
+helm-terminate
 helm_config=$(instantiate helm-config.yaml) helm-launch topology-aware
 
 # pod0: Test that 4 guaranteed containers eligible for isolated CPU allocation


### PR DESCRIPTION
This PR fixes failing nightly runs. They fail because the latest introduced case does not clean up the plugin and the first topology-aware test case does start by properly cleaning up potential leftover plugin instances from earlier cases. This PR should fix both.