### PR TITLE
balloons: add support for explicit CPUs

### DIFF
--- a/config/crd/bases/config.nri_balloonspolicies.yaml
+++ b/config/crd/bases/config.nri_balloonspolicies.yaml
@@ -195,6 +195,9 @@ spec:
                       items:
                         type: string
                       type: array
+                    preferCpus:
+                      description: 'preferCpus: user-preferred set of CPUs.'
+                      type: string
                     preferIsolCpus:
                       default: false
                       description: 'preferIsolCpus: prefer kernel isolated cpus'

--- a/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
+++ b/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
@@ -195,6 +195,9 @@ spec:
                       items:
                         type: string
                       type: array
+                    preferCpus:
+                      description: 'preferCpus: user-preferred set of CPUs.'
+                      type: string
                     preferIsolCpus:
                       default: false
                       description: 'preferIsolCpus: prefer kernel isolated cpus'

--- a/docs/resource-policy/policy/balloons.md
+++ b/docs/resource-policy/policy/balloons.md
@@ -154,6 +154,10 @@ Balloons policy parameters:
     separate `cpu.classes` objects, see below.
   - `preferCloseToDevices`: prefer creating new balloons close to
     listed devices. List of strings
+  - `preferCpus`: prefer allocating CPUs from an explicitly defined
+    set of CPUs. Warning: when combining `preferIsolCpus` with `preferCpus`,
+    priority will be given to isolated CPUs over the user-specified
+    set of CPUs.
   - `preferSpreadingPods`: if `true`, containers of the same pod
     should be spread to different balloons of this type. The default
     is `false`: prefer placing containers of the same pod to the same
@@ -168,7 +172,7 @@ Balloons policy parameters:
     preferring exclusive CPUs, as long as there are enough free
     CPUs. The default is `false`: prefer filling and inflating
     existing balloons over creating new ones.
-  - `preferIsolCpus`: if `true`,prefer system isolated CPUs (refer to
+  - `preferIsolCpus`: if `true`, prefer system isolated CPUs (refer to
     kernel command line parameter "isolcpus") for this balloon. Warning:
     if there are not enough isolated CPUs in the system for balloons that
     prefer them, balloons may include normal CPUs, too. This kind of

--- a/pkg/apis/config/v1alpha1/resmgr/policy/balloons/config.go
+++ b/pkg/apis/config/v1alpha1/resmgr/policy/balloons/config.go
@@ -219,6 +219,8 @@ type BalloonDef struct {
 	// preferIsolCpus: prefer kernel isolated cpus
 	// +kubebuilder:default:=false
 	PreferIsolCpus bool `json:"preferIsolCpus,omitempty"`
+	// preferCpus: user-preferred set of CPUs.
+	PreferCpus string `json:"preferCpus,omitempty"`
 }
 
 // String stringifies a BalloonDef

--- a/test/e2e/policies.test-suite/balloons/n4c16/test22-isolcpus/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test22-isolcpus/code.var.sh
@@ -51,15 +51,21 @@ helm_config=${TEST_DIR}/balloons-isolcpus.cfg helm-launch balloons
 vm-command "kubectl create namespace $ns"
 
 # pod0: should run on non-isolated CPUs
-CONTCOUNT=2 namespace="default" create balloons-busybox
+CONTCOUNT=2 CPU=1 namespace="default" create balloons-busybox
 report allowed
-verify "set.union(cpus['pod0c0'], cpus['pod0c1']).isdisjoint({'cpu00', 'cpu01'})"
+verify "set.union(cpus['pod0c0'], cpus['pod0c1']).isdisjoint({'cpu00', 'cpu01', 'cpu14', 'cpu15'})"
 
 # pod1: runs on system isolated CPUs
-CONTCOUNT=2 namespace="$ns" create balloons-busybox
+CONTCOUNT=2 CPU=1 namespace="$ns" create balloons-busybox
 report allowed
 verify "cpus['pod1c0'] == {'cpu00', 'cpu01'}" 
 verify "cpus['pod1c1'] == {'cpu00', 'cpu01'}"
+
+# pod2: runs on system isolated CPUs
+CONTCOUNT=2 CPU=1 namespace="$ns" create balloons-busybox
+report allowed
+verify "cpus['pod2c0'] == {'cpu00', 'cpu01', 'cpu14', 'cpu15'}"
+verify "cpus['pod2c1'] == {'cpu00', 'cpu01', 'cpu14', 'cpu15'}"
 
 cleanup
 helm-terminate

--- a/test/e2e/policies.test-suite/balloons/n4c16/test23-explicit/balloons-isolcpus.cfg
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test23-explicit/balloons-isolcpus.cfg
@@ -1,12 +1,11 @@
 config:
   balloonTypes:
-    - name: isolcpus
+    - name: explicit
       minCPUs: 1
       minBalloons: 1
-      preferIsolCpus: true
-      preferCpus: 14-15
+      preferCpus: 0-3
       namespaces:
-      - isolcpus
+      - explicit
   log:
     debug:
       - policy

--- a/test/e2e/policies.test-suite/balloons/n4c16/test23-explicit/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test23-explicit/code.var.sh
@@ -1,0 +1,25 @@
+cleanup() {
+    vm-command "kubectl delete pod --all --now"
+    vm-command "kubectl delete namespace $ns --now"
+}
+
+ns=explicit
+cleanup
+
+helm-terminate
+helm_config=${TEST_DIR}/balloons-isolcpus.cfg helm-launch balloons
+vm-command "kubectl create namespace $ns"
+
+# pod0: should not run on non-explicit CPUs
+CONTCOUNT=1 CPU=1 namespace="default" create balloons-busybox
+report allowed
+verify "set.union(cpus['pod0c0']).isdisjoint({'cpu00', 'cpu01', 'cpu02', 'cpu03'})"
+
+# pod1: runs on user preferred CPUs
+CONTCOUNT=2 CPU=1 namespace="$ns" create balloons-busybox
+report allowed
+verify "cpus['pod1c0'] == {'cpu00', 'cpu01'}" 
+verify "cpus['pod1c1'] == {'cpu00', 'cpu01'}"
+
+cleanup
+helm-terminate


### PR DESCRIPTION
Introduce a new parameter (`preferCpus`) in Balloons policy for giving preferred CPU sets on each balloon type. 
When combining `preferIsolCpus` with `preferCpus`, priority will be given to isolated CPUs over the user-specified set of CPUs if these are two different sets. 