### PR TITLE
balloons: add support for power efficient & high performance cores

### DIFF
--- a/config/crd/bases/config.nri_balloonspolicies.yaml
+++ b/config/crd/bases/config.nri_balloonspolicies.yaml
@@ -195,6 +195,14 @@ spec:
                       items:
                         type: string
                       type: array
+                    preferCoreType:
+                      description: |-
+                        preferCoreType: prefer performance or efficient (P/E) CPU cores on
+                        hybrid architectures.
+                      enum:
+                      - efficient
+                      - performance
+                      type: string
                     preferIsolCpus:
                       default: false
                       description: 'preferIsolCpus: prefer kernel isolated cpus'

--- a/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
+++ b/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
@@ -195,6 +195,14 @@ spec:
                       items:
                         type: string
                       type: array
+                    preferCoreType:
+                      description: |-
+                        preferCoreType: prefer performance or efficient (P/E) CPU cores on
+                        hybrid architectures.
+                      enum:
+                      - efficient
+                      - performance
+                      type: string
                     preferIsolCpus:
                       default: false
                       description: 'preferIsolCpus: prefer kernel isolated cpus'

--- a/docs/resource-policy/policy/balloons.md
+++ b/docs/resource-policy/policy/balloons.md
@@ -154,6 +154,9 @@ Balloons policy parameters:
     separate `cpu.classes` objects, see below.
   - `preferCloseToDevices`: prefer creating new balloons close to
     listed devices. List of strings
+  - `preferCoreType`:  specifies preferences of the core type which
+    could be either power efficient (`efficient`) or high performance
+    (`performance`).
   - `preferSpreadingPods`: if `true`, containers of the same pod
     should be spread to different balloons of this type. The default
     is `false`: prefer placing containers of the same pod to the same
@@ -168,7 +171,7 @@ Balloons policy parameters:
     preferring exclusive CPUs, as long as there are enough free
     CPUs. The default is `false`: prefer filling and inflating
     existing balloons over creating new ones.
-  - `preferIsolCpus`: if `true`,prefer system isolated CPUs (refer to
+  - `preferIsolCpus`: if `true`, prefer system isolated CPUs (refer to
     kernel command line parameter "isolcpus") for this balloon. Warning:
     if there are not enough isolated CPUs in the system for balloons that
     prefer them, balloons may include normal CPUs, too. This kind of

--- a/pkg/apis/config/v1alpha1/resmgr/policy/balloons/config.go
+++ b/pkg/apis/config/v1alpha1/resmgr/policy/balloons/config.go
@@ -219,6 +219,11 @@ type BalloonDef struct {
 	// preferIsolCpus: prefer kernel isolated cpus
 	// +kubebuilder:default:=false
 	PreferIsolCpus bool `json:"preferIsolCpus,omitempty"`
+	// preferCoreType: prefer performance or efficient (P/E) CPU cores on
+	// hybrid architectures.
+	// +optional
+	// +kubebuilder:validation:Enum:=efficient;performance
+	PreferCoreType string `json:"preferCoreType,omitempty"`
 }
 
 // String stringifies a BalloonDef


### PR DESCRIPTION
Introduce a new parameter `coreType` in Balloons policy for allowing users to express their preference of selecting P-high performance or power efficient cores.