### PR TITLE
resmgr: lifecycle overlap detection and workaround.

### DIFF
--- a/pkg/resmgr/cache/pod.go
+++ b/pkg/resmgr/cache/pod.go
@@ -93,12 +93,9 @@ func (p *pod) PrettyName() string {
 	}
 
 	namespace := p.GetNamespace()
-	switch namespace {
-	case "default":
-		p.prettyName = ""
-	case "":
+	if namespace == "" {
 		p.prettyName = "<unknown-namespace>/"
-	default:
+	} else {
 		p.prettyName = namespace + "/"
 	}
 

--- a/pkg/resmgr/flags.go
+++ b/pkg/resmgr/flags.go
@@ -18,7 +18,7 @@ import (
 	"flag"
 	"time"
 
-	nri "github.com/containerd/nri/pkg/api"
+	"github.com/containerd/nri/pkg/api"
 	"github.com/containers/nri-plugins/pkg/pidfile"
 )
 
@@ -54,7 +54,7 @@ func init() {
 		"NRI plugin name to register.")
 	flag.StringVar(&opt.NriPluginIdx, "nri-plugin-index", defaultPluginIndex,
 		"NRI plugin index to register.")
-	flag.StringVar(&opt.NriSocket, "nri-socket", nri.DefaultSocketPath,
+	flag.StringVar(&opt.NriSocket, "nri-socket", api.DefaultSocketPath,
 		"NRI unix domain socket path to connect to.")
 
 	flag.StringVar(&opt.PidFile, "pid-file", pidfile.GetPath(),

--- a/pkg/resmgr/nri.go
+++ b/pkg/resmgr/nri.go
@@ -671,7 +671,8 @@ func (p *nriPlugin) dump(dir, event string, args ...interface{}) {
 				return
 			}
 
-			p.Info("%s %s %s/%s:%s", dir, event, pod.GetNamespace(), pod.GetName(), ctr.GetName())
+			p.Info("%s %s %s/%s/%s (%s)", dir, event,
+				pod.GetNamespace(), pod.GetName(), ctr.GetName(), ctr.GetId())
 			p.dumpDetails(dir, event, ctr)
 		} else {
 			if len(args) < 1 {
@@ -723,7 +724,8 @@ func (p *nriPlugin) dump(dir, event string, args ...interface{}) {
 				return
 			}
 
-			p.Info("%s %s %s/%s:%s", dir, event, pod.GetNamespace(), pod.GetName(), ctr.GetName())
+			p.Info("%s %s %s/%s/%s (%s)", dir, event,
+				pod.GetNamespace(), pod.GetName(), ctr.GetName(), ctr.GetId())
 			p.dumpDetails(dir, event, ctr)
 			p.dumpDetails(dir, event, res)
 		} else {


### PR DESCRIPTION
We recently discovered a problem with the generated stream of container lifecycle events with some runtime versions. A side effect of this is that we get Create/Stop events for multiple container instances with seemingly overlapping lifecycle: the latter instance get created before the former one is stopped.

When undetected, such a false overlap might cause overcommit of resources, with both instances temporarily using the full resource set of the offending container. As a workaround, we now track containers also by fully qualified name ($namespace/pod/ctr) and internally generate an event for releasing the resources of the old instance whenever we notice that a creation event would cause a duplicate instance for the same name.