### PR TITLE
e2e: bridge CNI setup fixes for Fedora/containerd. 

### DIFF
--- a/test/e2e/playbook/provision.yaml
+++ b/test/e2e/playbook/provision.yaml
@@ -306,6 +306,23 @@
             regexp: ' *bin_dir *= *"/opt/cni/bin" *'
             line: 'bin_dir = "/usr/libexec/cni"'
 
+    - name: Configure bridge CNI plugin
+      when: cni_plugin == "bridge"
+      block:
+        - name: Copy CNI bridge plugin configuration
+          ansible.builtin.copy:
+            src: "{{ nri_resource_policy_src }}/test/e2e/files/10-bridge.conf.in"
+            dest: "/etc/cni/net.d/10-bridge.conf"
+            owner: root
+            group: root
+            mode: '0644'
+
+        - name: Update CNI bridge plugin configuration
+          ansible.builtin.replace:
+            path: /etc/cni/net.d/10-bridge.conf
+            regexp: '(CNI_NETWORK)'
+            replace: "{{ network }}"
+
     - name: Setup NRI
       ansible.builtin.file:
         path: "{{ item }}"
@@ -425,23 +442,6 @@
           with_items:
             - cilium install --wait
             - cilium status --wait
-
-    - name: Configure bridge CNI plugin
-      when: cni_plugin == "bridge"
-      block:
-        - name: Copy CNI bridge plugin configuration
-          ansible.builtin.copy:
-            src: "{{ nri_resource_policy_src }}/test/e2e/files/10-bridge.conf.in"
-            dest: "/etc/cni/net.d/10-bridge.conf"
-            owner: root
-            group: root
-            mode: '0644'
-
-        - name: Update CNI bridge plugin configuration
-          ansible.builtin.replace:
-            path: /etc/cni/net.d/10-bridge.conf
-            regexp: 'CNI_NETWORK'
-            replace: "{{ network }}"
 
     - name: Generate join command
       ansible.builtin.command:

--- a/test/e2e/playbook/provision.yaml
+++ b/test/e2e/playbook/provision.yaml
@@ -290,12 +290,21 @@
 
     - name: Configure containerd
       when: is_containerd
-      ansible.builtin.shell: "{{ item }}"
-      with_items:
-        - mkdir -p /etc/containerd
-        - containerd config default > /etc/containerd/config.toml
-        - sed -i 's/^.*disabled_plugins *= *.*$/disabled_plugins = []/' /etc/containerd/config.toml
-        - sed -i 's/SystemdCgroup = false/SystemdCgroup = true/g' /etc/containerd/config.toml
+      block:
+        - name: Create containerd configuration
+          ansible.builtin.shell: "{{ item }}"
+          with_items:
+            - mkdir -p /etc/containerd
+            - containerd config default > /etc/containerd/config.toml
+            - sed -i 's/^.*disabled_plugins *= *.*$/disabled_plugins = []/' /etc/containerd/config.toml
+            - sed -i 's/SystemdCgroup = false/SystemdCgroup = true/g' /etc/containerd/config.toml
+
+        - name: Update CNI plugin directory on Fedora
+          when: ansible_facts['distribution'] == "Fedora"
+          ansible.builtin.lineinfile:
+            path: /etc/containerd/config.toml
+            regexp: ' *bin_dir *= *"/opt/cni/bin" *'
+            line: 'bin_dir = "/usr/libexec/cni"'
 
     - name: Setup NRI
       ansible.builtin.file:


### PR DESCRIPTION
Fix e2e tests runnning with bridge CNI plugin on fedora. In particular,

- fix non-default CNI plugin binary path on fedora
- configure bridge CNI plugin earlier during provisoning

These fixes should ensure that the node does not stay lingering in NotReady state, causing false test failures/positives.