### PR TITLE
e2e: use bridge CNI plugin by default.

### DIFF
--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -19,7 +19,7 @@ export COMMAND_OUTPUT_DIR="$TEST_OUTPUT_DIR"/commands
 
 distro=${distro:-$DEFAULT_DISTRO}
 export k8scri=${k8scri:-"containerd"}
-export cni_plugin=${cni_plugin:-cilium}
+export cni_plugin=${cni_plugin:-bridge}
 export cni_release=${cni_release:-latest}
 TOPOLOGY_DIR=${TOPOLOGY_DIR:=e2e}
 


### PR DESCRIPTION
*Note: This PR is stacked and depends on #361.*

The latest cilium release is [broken](https://github.com/cilium/cilium-cli/issues/2795). Let's switch to use the bridge plugin by default.