### PR TITLE
e2e: adjust metrics test for updated PrettyName().

### DIFF
--- a/test/e2e/policies.test-suite/balloons/n4c16/test02-prometheus-metrics/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test02-prometheus-metrics/code.var.sh
@@ -30,7 +30,7 @@ unset POD_ANNOTATION
 report allowed
 verify-metrics-has-line 'balloon="default\[0\]"'
 verify-metrics-has-line 'balloon="reserved\[0\]"'
-verify-metrics-has-line 'balloons{balloon="full-core\[0\]",balloon_type="full-core",containers="pod0/pod0c0,pod0/pod0c1",cpu_class="normal",cpus=".*",cpus_allowed=".*",cpus_allowed_count="2",cpus_count="2",cpus_max="2",cpus_min="2",dies="p[01]d0",dies_count="1",groups="",mems="[0-3]",numas="p[01]d0n[0-3]",numas_count="1",packages="p[01]",packages_count="1",sharedidlecpus="",sharedidlecpus_count="0",tot_req_millicpu="(199|200)"} 2'
+verify-metrics-has-line 'balloons{balloon="full-core\[0\]",balloon_type="full-core",containers="default/pod0/pod0c0,default/pod0/pod0c1",cpu_class="normal",cpus=".*",cpus_allowed=".*",cpus_allowed_count="2",cpus_count="2",cpus_max="2",cpus_min="2",dies="p[01]d0",dies_count="1",groups="",mems="[0-3]",numas="p[01]d0n[0-3]",numas_count="1",packages="p[01]",packages_count="1",sharedidlecpus="",sharedidlecpus_count="0",tot_req_millicpu="(199|200)"} 2'
 verify 'len(cpus["pod0c0"]) == 1' \
        'len(cpus["pod0c1"]) == 2' \
        'cpus["pod0c0"].issubset(cpus["pod0c1"])'


### PR DESCRIPTION
Fix metrics test verification to match the recently updated `cache.container.PrettyName()`. My apologies... this should have been already fixed in the original commit daafb632ed24.