### PR TITLE
e2e: pull and save runtime logs after each test.

### DIFF
--- a/test/e2e/lib/vm.bash
+++ b/test/e2e/lib/vm.bash
@@ -588,3 +588,19 @@ vm-stop-log-collection() {
     local log_file="${log_file:-nri-resource-policy.output.txt}"
     vm-command "fuser --kill $log_file 2>/dev/null || :"
 }
+
+vm-seconds-now() {
+    vm-command-q "date +%s"
+}
+
+vm-seconds-since() {
+    echo $(( $(vm-seconds-now) - $1 + 1 ))
+}
+
+vm-pull-journal() {
+    local _service="${service:+-u} ${service:-} "
+    local _since="${since:+--since }${since:-}"
+
+    vm-command-q "journalctl $_service $_since" || \
+        command-error "failed to pull journal logs (service: ${service:-all}, since: ${since:--}"
+}

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -944,7 +944,13 @@ eval "${yaml_in_defaults}"
 
 # Run test/demo
 TEST_FAILURES=""
+test_start_secs=$(vm-seconds-now)
+
 test-user-code
+
+test_span_secs="$(vm-seconds-since $test_start_secs)"
+since="-$(( test_span_secs + 5 ))s"
+service="${k8scri}" since="$since" vm-pull-journal > "${TEST_OUTPUT_DIR}"/runtime."${k8scri}".log
 
 # If there are any nri-resource-policy logs in the DUT, copy them back to host.
 host-command "$SCP $VM_HOSTNAME:nri-resource-policy.output.txt \"${TEST_OUTPUT_DIR}/\"" ||


### PR DESCRIPTION
Pull and save runtime logs for the duration of the test run after each test.