### PR TITLE
codespell: ignore more files.

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
-skip = .git,*.pdf,*.svg,go.sum,go.mod,./cmd/plugins/topology-aware/policy
+skip = .git,build,testdata,n[0-9]*,*.pdf,*.svg,*.png,*.tar.*,go.sum,go.mod,./cmd/plugins/topology-aware/policy
 ignore-words = .codespellignorewords
 exclude-file = .codespellignorelines


### PR DESCRIPTION
Ignore the build directory, test directories (at the top level), PNG files and tarballs.

codespell just keeps on giving...