### PR TITLE
balloons: add support for cpu frequency governor tuning

### DIFF
--- a/config/crd/bases/config.nri_balloonspolicies.yaml
+++ b/config/crd/bases/config.nri_balloonspolicies.yaml
@@ -265,6 +265,9 @@ spec:
                               description: EnergyPerformancePreference for CPUs in
                                 this class.
                               type: integer
+                            freqGovernor:
+                              description: CPUFreq Governor for this class.
+                              type: string
                             maxFreq:
                               description: MaxFreq is the maximum frequency for this
                                 class.

--- a/config/crd/bases/config.nri_templatepolicies.yaml
+++ b/config/crd/bases/config.nri_templatepolicies.yaml
@@ -55,6 +55,9 @@ spec:
                               description: EnergyPerformancePreference for CPUs in
                                 this class.
                               type: integer
+                            freqGovernor:
+                              description: CPUFreq Governor for this class.
+                              type: string
                             maxFreq:
                               description: MaxFreq is the maximum frequency for this
                                 class.

--- a/config/crd/bases/config.nri_topologyawarepolicies.yaml
+++ b/config/crd/bases/config.nri_topologyawarepolicies.yaml
@@ -69,6 +69,9 @@ spec:
                               description: EnergyPerformancePreference for CPUs in
                                 this class.
                               type: integer
+                            freqGovernor:
+                              description: CPUFreq Governor for this class.
+                              type: string
                             maxFreq:
                               description: MaxFreq is the maximum frequency for this
                                 class.

--- a/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
+++ b/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
@@ -265,6 +265,9 @@ spec:
                               description: EnergyPerformancePreference for CPUs in
                                 this class.
                               type: integer
+                            freqGovernor:
+                              description: CPUFreq Governor for this class.
+                              type: string
                             maxFreq:
                               description: MaxFreq is the maximum frequency for this
                                 class.

--- a/deployment/helm/template/crds/config.nri_templatepolicies.yaml
+++ b/deployment/helm/template/crds/config.nri_templatepolicies.yaml
@@ -55,6 +55,9 @@ spec:
                               description: EnergyPerformancePreference for CPUs in
                                 this class.
                               type: integer
+                            freqGovernor:
+                              description: CPUFreq Governor for this class.
+                              type: string
                             maxFreq:
                               description: MaxFreq is the maximum frequency for this
                                 class.

--- a/deployment/helm/topology-aware/crds/config.nri_topologyawarepolicies.yaml
+++ b/deployment/helm/topology-aware/crds/config.nri_topologyawarepolicies.yaml
@@ -69,6 +69,9 @@ spec:
                               description: EnergyPerformancePreference for CPUs in
                                 this class.
                               type: integer
+                            freqGovernor:
+                              description: CPUFreq Governor for this class.
+                              type: string
                             maxFreq:
                               description: MaxFreq is the maximum frequency for this
                                 class.

--- a/pkg/apis/config/v1alpha1/resmgr/control/cpu/config.go
+++ b/pkg/apis/config/v1alpha1/resmgr/control/cpu/config.go
@@ -30,4 +30,6 @@ type Class struct {
 	UncoreMinFreq uint `json:"uncoreMinFreq,omitempty"`
 	// UncoreMaxFreq is the maximum uncore frequency for this class.
 	UncoreMaxFreq uint `json:"uncoreMaxFreq,omitempty"`
+	// CPUFreq Governor for this class.
+	FreqGovernor string `json:"freqGovernor,omitempty"`
 }

--- a/pkg/resmgr/control/cpu/api.go
+++ b/pkg/resmgr/control/cpu/api.go
@@ -61,6 +61,9 @@ func Assign(c cache.Cache, class string, cpus ...int) error {
 		if err := ctl.enforceCpufreq(class, cpus...); err != nil {
 			log.Error("cpufreq enforcement failed: %v", err)
 		}
+		if err := ctl.enforceCpufreqGovernor(class, cpus...); err != nil {
+			log.Error("cpufreq governor enforcement failed: %v", err)
+		}
 		if err := ctl.enforceUncore(assignments, cpus...); err != nil {
 			log.Error("uncore frequency enforcement failed: %v", err)
 		}


### PR DESCRIPTION
This commit introduces a new field in the balloons configuration CR, enabling users to specify CPU frequency governor mode preferences.