### PR TITLE
e2e: switch default test distro to fedora/40-cloud-base.

### DIFF
--- a/test/e2e/playbook/provision.yaml
+++ b/test/e2e/playbook/provision.yaml
@@ -139,13 +139,23 @@
       when: ansible_facts['distribution'] == "Ubuntu"
 
     - name: Install rpm packages
-      ansible.builtin.dnf:
-        pkg:
-          - iproute-tc
-          - grubby
-        state: present
-        update_cache: true
       when: ansible_facts['distribution'] == "Fedora"
+      block:
+        - name: Common rpm packages
+          ansible.builtin.dnf:
+            pkg:
+              - iproute-tc
+              - grubby
+            state: present
+            update_cache: true
+        - name: Extra python3 rpm packages for ansible
+          ansible.builtin.dnf:
+            pkg:
+              - python3-libselinux
+              - python3-packaging
+            state:
+              present
+          when: ansible_facts['distribution_major_version'] | int >= 40
 
     - name: Disable SELinux
       ansible.posix.selinux:

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 TITLE="NRI Resource Policy End-to-End Testing"
-DEFAULT_DISTRO=${DEFAULT_DISTRO:-"generic/fedora37"}
+DEFAULT_DISTRO=${DEFAULT_DISTRO:-"fedora/40-cloud-base"}
 
 # Other tested distros
 #    generic/ubuntu2204

--- a/test/e2e/run_tests.sh
+++ b/test/e2e/run_tests.sh
@@ -3,7 +3,7 @@
 TESTS_DIR="$1"
 RUN_SH="${0%/*}/run.sh"
 
-DEFAULT_DISTRO=${DEFAULT_DISTRO:-"generic/fedora37"}
+DEFAULT_DISTRO=${DEFAULT_DISTRO:-"fedora/40-cloud-base"}
 
 k8scri=${k8scri:="containerd"}
 


### PR DESCRIPTION
Fedora 37 is EOL. Switch default test distro to fedora 40 and use cloud base image.