### PR TITLE
e2e: adjust $VM_HOSTNAME for policy node config usage.

### DIFF
--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -481,26 +481,31 @@ get-config-generation() {
     vm-command-q "kubectl get -n kube-system $resource -ojsonpath={.metadata.generation}"
 }
 
+get-hostname-for-vm() {
+    local node="${node:-$VM_HOSTNAME}"
+    echo ${node%.*}
+}
+
 get-config-node-status-generation() {
-    local resource="$1" node="${node:-$VM_HOSTNAME}"
+    local resource="$1" node="$(get-hostname-for-vm)"
     vm-command-q "kubectl get -n kube-system $resource \
                       -ojsonpath=\"{.status.nodes['$node'].generation}\""
 }
 
 get-config-node-status-result() {
-    local resource="$1" node="${node:-$VM_HOSTNAME}"
+    local resource="$1" node="$(get-hostname-for-vm)"
     vm-command-q "kubectl get -n kube-system $resource \
                      -ojsonpath=\"{.status.nodes['$node'].status}\""
 }
 
 get-config-node-status-error() {
-    local resource="$1" node="${node:-$VM_HOSTNAME}"
+    local resource="$1" node="$(get-hostname-for-vm)"
     vm-command-q "kubectl get -n kube-system $resource \
                       -ojsonpath=\"{.status.nodes['$node'].error}\""
 }
 
 wait-config-node-status() {
-    local resource="$1" node="${node:-$VM_HOSTNAME}"
+    local resource="$1" node="$(get-hostname-for-vm)"
     local timeout="${timeout:-5s}"
     local deadline=$(deadline-for-timeout $timeout)
     local generation jsonpath result errors


### PR DESCRIPTION
Take into account that $VM_HOSTNAME's like xyzzy-foobar-22.04 will propagate to the VM distro hostname as xyzzy-foobar-22.