### PR TITLE
balloons: set frequency scaling governor only when requested

### DIFF
--- a/pkg/resmgr/control/cpu/api.go
+++ b/pkg/resmgr/control/cpu/api.go
@@ -61,9 +61,6 @@ func Assign(c cache.Cache, class string, cpus ...int) error {
 		if err := ctl.enforceCpufreq(class, cpus...); err != nil {
 			log.Error("cpufreq enforcement failed: %v", err)
 		}
-		if err := ctl.enforceCpufreqGovernor(class, cpus...); err != nil {
-			log.Error("cpufreq governor enforcement failed: %v", err)
-		}
 		if err := ctl.enforceUncore(assignments, cpus...); err != nil {
 			log.Error("uncore frequency enforcement failed: %v", err)
 		}


### PR DESCRIPTION
Avoid enforcing the frequency scaling governor if the user hasn't explicitly requested it. Previously, we attempted to set it regardless, leading to unnecessary error logs. Furthermore, fix formatting issue when logging error case.