### PR TITLE
libmem: typo and thinko fixes.

### DIFF
--- a/pkg/resmgr/lib/memory/nodes.go
+++ b/pkg/resmgr/lib/memory/nodes.go
@@ -235,7 +235,7 @@ func ParseNodeMask(str string) (NodeMask, error) {
 				return 0, fmt.Errorf("%w: invalid range (%d - %d) in node mask %q",
 					ErrInvalidNodeMask, beg, end, str)
 			}
-			for id := beg; id < end; id++ {
+			for id := beg; id <= end; id++ {
 				if id > MaxNodeID {
 					return 0, fmt.Errorf("%w: invalid node ID in mask %q (range %d-%d)",
 						ErrInvalidNodeMask, str, beg, end)

--- a/pkg/resmgr/lib/memory/nodes.go
+++ b/pkg/resmgr/lib/memory/nodes.go
@@ -240,7 +240,7 @@ func ParseNodeMask(str string) (NodeMask, error) {
 				m |= (1 << id)
 			}
 		case 1:
-			id, err := strconv.ParseInt(minmax[1], 10, 32)
+			id, err := strconv.ParseInt(minmax[0], 10, 32)
 			if err != nil {
 				return 0, fmt.Errorf("%w: failed to parse node mask %q: %w",
 					ErrInvalidNodeMask, str, err)

--- a/pkg/resmgr/lib/memory/nodes.go
+++ b/pkg/resmgr/lib/memory/nodes.go
@@ -212,7 +212,7 @@ func NewNodeMask(ids ...ID) NodeMask {
 	return NodeMask(0).Set(ids...)
 }
 
-// ParseNodeMaskparses the given string representation of a NodeMask.
+// ParseNodeMask parses the given string representation of a NodeMask.
 func ParseNodeMask(str string) (NodeMask, error) {
 	m := NodeMask(0)
 	for _, s := range strings.Split(str, ",") {

--- a/pkg/resmgr/lib/memory/nodes.go
+++ b/pkg/resmgr/lib/memory/nodes.go
@@ -215,6 +215,9 @@ func NewNodeMask(ids ...ID) NodeMask {
 // ParseNodeMask parses the given string representation of a NodeMask.
 func ParseNodeMask(str string) (NodeMask, error) {
 	m := NodeMask(0)
+	if str == "" {
+		return m, nil
+	}
 	for _, s := range strings.Split(str, ",") {
 		switch minmax := strings.SplitN(s, "-", 2); len(minmax) {
 		case 2:

--- a/pkg/resmgr/lib/memory/nodes_test.go
+++ b/pkg/resmgr/lib/memory/nodes_test.go
@@ -22,6 +22,62 @@ import (
 	. "github.com/containers/nri-plugins/pkg/resmgr/lib/memory"
 )
 
+func TestParseNodeMask(t *testing.T) {
+	type testCase struct {
+		name   string
+		mask   string
+		result NodeMask
+		fail   bool
+	}
+	for _, tc := range []*testCase{
+		{
+			name:   "empty mask",
+			mask:   "",
+			result: NodeMask(0),
+		},
+		{
+			name:   "single node mask",
+			mask:   "0",
+			result: NewNodeMask(0),
+		},
+		{
+			name:   "multiple nodes mask, no ranges",
+			mask:   "0,2,4,6,8,11,17",
+			result: NewNodeMask(0, 2, 4, 6, 8, 11, 17),
+		},
+		{
+			name:   "multiple nodes mask, with ranges",
+			mask:   "0-5,11-17",
+			result: NewNodeMask(0, 1, 2, 3, 4, 5, 11, 12, 13, 14, 15, 16, 17),
+		},
+		{
+			name: "invalid mask, missing ID",
+			mask: "0,2,4,6,8,11,17,",
+			fail: true,
+		},
+		{
+			name: "invalid mask, invalid ID",
+			mask: "0,2,xyzzy,11",
+			fail: true,
+		},
+		{
+			name: "invalid mask, too large ID",
+			mask: "0,2,4,6,8,11,17,100",
+			fail: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := ParseNodeMask(tc.mask)
+			if tc.fail {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.result, m)
+			}
+		})
+	}
+}
+
 func TestMemsetString(t *testing.T) {
 	type testCase struct {
 		name   string


### PR DESCRIPTION
This patch set fixes
- a docstring/comment typo
- node mask parsing of empty masks
- node mask parsing ID range upper boundary (should be inclusive)
- node mask parsing incorrect slice index for single node IDs

It also adds an obviously necessary minimal test for `ParseNodeMask()`.