### PR TITLE
sysfs: enable faking CPU cache configurations using OVERRIDE_SYS_CACHES

### DIFF
--- a/pkg/sysfs/system.go
+++ b/pkg/sysfs/system.go
@@ -1678,8 +1678,12 @@ func (sys *system) saveCache(c *Cache) *Cache {
 		caches := sys.caches
 		sys.caches = make([][NumCacheTypes]map[idset.ID]*Cache, c.level)
 		copy(sys.caches, caches)
-		for ct := 0; ct < NumCacheTypes; ct++ {
-			sys.caches[c.level-1][ct] = make(map[idset.ID]*Cache)
+		for levelIdx := 0; levelIdx < c.level; levelIdx++ {
+			for ct := 0; ct < NumCacheTypes; ct++ {
+				if sys.caches[levelIdx][ct] == nil {
+					sys.caches[levelIdx][ct] = make(map[idset.ID]*Cache)
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR is an enabler for testing CPU allocations when there are several CPUs that share the same level 2 cache.