### PR TITLE
balloons: improve handling of containers with no CPU requests

### DIFF
--- a/cmd/plugins/balloons/policy/balloons-policy.go
+++ b/cmd/plugins/balloons/policy/balloons-policy.go
@@ -666,6 +666,16 @@ func (p *balloons) fillableBalloonInstances(blnDef *BalloonDef, fm FillMethod, c
 				return []*Balloon{bln}, nil
 			}
 		}
+		// Creating a new balloon and placing a container
+		// (even a best effort one) to it always requires at
+		// least one CPU. Make sure this is doable.
+		if p.freeCpus.Size() == 0 || p.freeCpus.Size() < blnDef.MinCpus {
+			if fm == FillNewBalloonMust {
+				return nil, balloonsError("not enough CPUs to create new balloon for container %s requesting %s mCPU. free CPUs: %s",
+					c.PrettyName(), reqMilliCpus, p.freeCpus.Size())
+			}
+			return nil, nil
+		}
 		newBln, err := p.newBalloon(blnDef, false)
 		if err != nil {
 			if fm == FillNewBalloonMust {


### PR DESCRIPTION
Containers without CPU requests always pile up to the first balloon where they fit.

This patch enables having multiple balloons in the system so that this kind of containers will be spread equally into them.

This patch is an enabler to fix the issue #385.