### PR TITLE
resmgr: fix "qosclass" in policy expressions

### DIFF
--- a/pkg/apis/resmgr/v1alpha1/expression.go
+++ b/pkg/apis/resmgr/v1alpha1/expression.go
@@ -292,8 +292,10 @@ func ResolveRef(subject Evaluable, spec string) (string, bool, error) {
 
 	s, ok := obj.(string)
 	if !ok {
-		return "", false, exprError("%s: failed to resolve %q: non-string type %T",
+		err := exprError("%s: failed to resolve %q: non-string type %T",
 			subject, spec, obj)
+		log.Error("internal error: %s", err)
+		return "", false, err
 	}
 
 	log.Debug("resolved %q in %s => %s", spec, subject, s)

--- a/pkg/resmgr/cache/container.go
+++ b/pkg/resmgr/cache/container.go
@@ -1027,7 +1027,7 @@ func (c *container) EvalKey(key string) interface{} {
 	case resmgr.KeyNamespace:
 		return c.GetNamespace()
 	case resmgr.KeyQOSClass:
-		return c.GetQOSClass()
+		return string(c.GetQOSClass())
 	case resmgr.KeyLabels:
 		return c.Ctr.GetLabels()
 	case resmgr.KeyTags:


### PR DESCRIPTION
Resolving "qosclass" failed silently and returned an empty string due to error when "casting" object from interface{} to string. This fails because the resolved value behind the interface{} is of type k8s.io/api/core/v1.PodQOSClass and not (directly) a string. Making sure that the interface{} is directly a string solves the problem.