### PR TITLE
build: enable building debug binaries and images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,11 @@ LDFLAGS    = \
              -X=github.com/containers/nri-plugins/pkg/version.Build=$(BUILD_BUILDID) \
              -B 0x$(RANDOM_ID)"
 
+ifeq ($(DEBUG),1)
+    GCFLAGS ?= -gcflags "all=-N -l"
+    DOCKER_BUILD_DEBUG := --build-arg DEBUG=1
+endif
+
 # Documentation-related variables
 SPHINXOPTS    ?= -W
 SPHINXBUILD   = sphinx-build
@@ -139,12 +144,12 @@ verify: verify-godeps verify-fmt verify-generate verify-build verify-docs
 build-plugins: $(foreach bin,$(PLUGINS),$(BIN_PATH)/$(bin))
 
 build-plugins-static:
-	$(MAKE) STATIC=1 build-plugins
+	$(MAKE) STATIC=1 DEBUG=$(DEBUG) build-plugins
 
 build-binaries: $(foreach bin,$(BINARIES),$(BIN_PATH)/$(bin))
 
 build-binaries-static:
-	$(MAKE) STATIC=1 build-binaries
+	$(MAKE) STATIC=1 DEBUG=$(DEBUG) build-binaries
 
 build-images: images
 
@@ -236,6 +241,7 @@ image.%:
 	tag=$(patsubst image.%,%,$@); \
 	$(DOCKER_BUILD) . -f "$$dir/Dockerfile" \
 	    --build-arg GO_VERSION=$(GO_VERSION) \
+	    $(DOCKER_BUILD_DEBUG) \
 	    --build-arg IMAGE_VERSION=$(IMAGE_VERSION) \
 	    --build-arg BUILD_VERSION=$(BUILD_VERSION) \
 	    --build-arg BUILD_BUILDID=$(BUILD_BUILDID) \
@@ -507,7 +513,7 @@ generate-manifests: controller-gen
 generate-types: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="./docs/license-header.go.txt" paths="./pkg/apis/..."
 
-# client generation rules 
+# client generation rules
 .PHONY: generate-clients
 generate-clients: $(GENERATE_GROUPS)
 	$(GENERATE_GROUPS) client \

--- a/cmd/plugins/balloons/Dockerfile
+++ b/cmd/plugins/balloons/Dockerfile
@@ -5,7 +5,15 @@ FROM golang:${GO_VERSION}-bullseye AS builder
 ARG IMAGE_VERSION
 ARG BUILD_VERSION
 ARG BUILD_BUILDID
+ARG DEBUG=0
+
 WORKDIR /go/builder
+
+RUN mkdir -p /debug-extras; \
+    if [ "$DEBUG" = 1 ]; then \
+        mkdir -p /debug-extras/bin; \
+          GOBIN=/debug-extras/bin go install -tags osusergo,netgo -ldflags "-extldflags=-static" github.com/go-delve/delve/cmd/dlv@latest; \
+    fi
 
 # Fetch go dependencies in a separate layer for caching
 COPY go.mod go.sum ./
@@ -16,10 +24,24 @@ RUN go mod download
 COPY . .
 
 RUN make clean
-RUN make IMAGE_VERSION=${IMAGE_VERSION} BUILD_VERSION=${BUILD_VERSION} BUILD_BUILDID=${BUILD_BUILDID} PLUGINS=nri-resource-policy-balloons build-plugins-static
+RUN make IMAGE_VERSION=${IMAGE_VERSION} BUILD_VERSION=${BUILD_VERSION} BUILD_BUILDID=${BUILD_BUILDID} PLUGINS=nri-resource-policy-balloons DEBUG=$DEBUG V=$DEBUG build-plugins-static
+
+RUN cpgodir() { \
+        mkdir -p $2; \
+        find $1 -name '*.s' -o -name '*.go' | grep -v -E '/test/|/testdata/|_test.go' \
+        | xargs -I {} cp --parents {} $2; \
+    }; \
+    if [ "$DEBUG" = 1 ]; then \
+        cpgodir /go/pkg /debug-extras; \
+        cpgodir /go/builder/pkg /debug-extras; \
+        cpgodir /go/builder/cmd /debug-extras; \
+        cpgodir /go/builder/vendor /debug-extras; \
+        cpgodir /usr/local/go /debug-extras; \
+    fi
 
 FROM gcr.io/distroless/static
 
 COPY --from=builder /go/builder/build/bin/nri-resource-policy-balloons /bin/nri-resource-policy-balloons
+COPY --from=builder /debug-extras /
 
 ENTRYPOINT ["/bin/nri-resource-policy-balloons"]

--- a/cmd/plugins/topology-aware/Dockerfile
+++ b/cmd/plugins/topology-aware/Dockerfile
@@ -5,7 +5,15 @@ FROM golang:${GO_VERSION}-bullseye AS builder
 ARG IMAGE_VERSION
 ARG BUILD_VERSION
 ARG BUILD_BUILDID
+ARG DEBUG=0
+
 WORKDIR /go/builder
+
+RUN mkdir -p /debug-extras; \
+    if [ "$DEBUG" = 1 ]; then \
+        mkdir -p /debug-extras/bin; \
+          GOBIN=/debug-extras/bin go install -tags osusergo,netgo -ldflags "-extldflags=-static" github.com/go-delve/delve/cmd/dlv@latest; \
+    fi
 
 # Fetch go dependencies in a separate layer for caching
 COPY go.mod go.sum ./
@@ -16,10 +24,24 @@ RUN go mod download
 COPY . .
 
 RUN make clean
-RUN make IMAGE_VERSION=${IMAGE_VERSION} BUILD_VERSION=${BUILD_VERSION} BUILD_BUILDID=${BUILD_BUILDID} PLUGINS=nri-resource-policy-topology-aware build-plugins-static
+RUN make IMAGE_VERSION=${IMAGE_VERSION} BUILD_VERSION=${BUILD_VERSION} BUILD_BUILDID=${BUILD_BUILDID} PLUGINS=nri-resource-policy-topology-aware DEBUG=$DEBUG V=$DEBUG build-plugins-static
+
+RUN cpgodir() { \
+        mkdir -p $2; \
+        find $1 -name '*.s' -o -name '*.go' | grep -v -E '/test/|/testdata/|_test.go' \
+        | xargs -I {} cp --parents {} $2; \
+    }; \
+    if [ "$DEBUG" = 1 ]; then \
+        cpgodir /go/pkg /debug-extras; \
+        cpgodir /go/builder/pkg /debug-extras; \
+        cpgodir /go/builder/cmd /debug-extras; \
+        cpgodir /go/builder/vendor /debug-extras; \
+        cpgodir /usr/local/go /debug-extras; \
+    fi
 
 FROM gcr.io/distroless/static
 
 COPY --from=builder /go/builder/build/bin/nri-resource-policy-topology-aware /bin/nri-resource-policy-topology-aware
+COPY --from=builder /debug-extras /
 
 ENTRYPOINT ["/bin/nri-resource-policy-topology-aware"]


### PR DESCRIPTION
Builds debug versions of binaries with "make DEBUG=1" and images with "make DEBUG=1 images". Debug images contain dlv and source files. If a NRI resource policy has been deployed using the debug image, you can attach debugger to it with:

kubectl exec -n kube-system -it nri-resource-policy-POD -- dlv attach 1

For now, the intention is to provide an easy way to build and deploy debuggable images to local e2e test vms. Therefore, debug images are tagged exactly like normal images, and e2e tests use them as is.