### PR TITLE
fixes: fix vagrant dotenv loading and default qemu directory.

### DIFF
--- a/test/e2e/files/Vagrantfile.in
+++ b/test/e2e/files/Vagrantfile.in
@@ -3,6 +3,7 @@
 
 ENV['VAGRANT_DEFAULT_PROVIDER'] = 'qemu'
 
+require 'dotenv'
 Dotenv.load("env")
 
 # Distro image to use

--- a/test/e2e/files/Vagrantfile.in
+++ b/test/e2e/files/Vagrantfile.in
@@ -76,7 +76,7 @@ Vagrant.configure("2") do |config|
     qemu.net_device = "virtio-net-pci"
     qemu.extra_netdev_args = "net=192.168.76.0/24,dhcpstart=192.168.76.9"
     qemu.ssh_port = SSH_PORT
-    qemu.qemu_dir = "/usr/share/OVMF"
+    qemu.qemu_dir = "QEMU_DIR"
     qemu.smp = "QEMU_SMP"
     qemu.extra_qemu_args = ["-enable-kvm",QEMU_EXTRA_ARGS]
   end

--- a/test/e2e/lib/vm.bash
+++ b/test/e2e/lib/vm.bash
@@ -99,6 +99,7 @@ vm-setup() {
     local vagrantdir="$output_dir"
     local files="$nri_resource_policy_src/test/e2e/files"
     local distro_name=$(printf '%s\n' "$distro" | sed -e 's/[\/&]/\\&/g')
+    local qemu_dir="${qemu_dir:-/usr/share/qemu}"
 
     mkdir -p "$inventory"
     if [ ! -f "$inventory/vagrant.ini" ]; then
@@ -132,6 +133,7 @@ vm-setup() {
 	    -e "s/QEMU_MEM/$MEM/" \
 	    -e "s/QEMU_SMP/$CPU/" \
 	    -e "s/QEMU_EXTRA_ARGS/$EXTRA_ARGS/" \
+            -e "s:QEMU_DIR:$qemu_dir:" \
 	    "$files/Vagrantfile.in" > "$vagrantdir/Vagrantfile.erb"
     fi
 

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -10,6 +10,7 @@ DEFAULT_DISTRO=${DEFAULT_DISTRO:-"fedora/40-cloud-base"}
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 SRC_DIR=$(realpath "$SCRIPT_DIR/../..")
 LIB_DIR=$(realpath "$SCRIPT_DIR/lib")
+qemu_dir="${qemu_dir:-/usr/share/qemu}"
 
 export OUTPUT_DIR=${outdir:-"$SCRIPT_DIR"/output}
 


### PR DESCRIPTION
Fix e2e test vagrant setup to
- explicitly require 'dotenv' before dotenv-loading an environment file
- make the vagrant qemu directory configurable using the qemu_dir shell variable
- use a default qemu directory which works on recent Fedora and OpenSUSE distros 