### PR TITLE
e2e: fix command filenames in test output directories

### DIFF
--- a/test/e2e/lib/command.bash
+++ b/test/e2e/lib/command.bash
@@ -29,7 +29,7 @@ command-start() {
     COMMAND_COUNTER=$(( COMMAND_COUNTER + 1 ))
     local command_start_time=$(epochrealtime)
     local time_since_start=$(echo "$command_start_time - $command_init_time" | bc)
-    COMMAND_OUT_FILE="$COMMAND_OUTPUT_DIR/$(printf %04g $COMMAND_COUNTER)-$COMMAND_TARGET"
+    COMMAND_OUT_FILE="$COMMAND_OUTPUT_DIR/$(printf %04d $COMMAND_COUNTER)-$COMMAND_TARGET"
     echo "# start time: $time_since_start" > "$COMMAND_OUT_FILE" || {
         echo "cannot write command output to file \"$COMMAND_OUT_FILE\""
         exit 1


### PR DESCRIPTION
%04g-target formatting resulted in filenames like -1.0329e+121-vm in some environments. As COMMAND_COUNTER is a natural number, let us format it using %d for consistent results.