### PR TITLE
helm: new balloons default configuration

### DIFF
--- a/deployment/helm/balloons/values.yaml
+++ b/deployment/helm/balloons/values.yaml
@@ -10,23 +10,36 @@ image:
 
 config:
   reservedResources:
-    cpu: 750m
-  idleCPUClass: normal
+    cpu: 1000m
+
   allocatorTopologyBalancing: true
+
   balloonTypes:
-  - name: default
-    namespaces:
-      - default
-    minCPUs: 1
-    minBalloons: 0
-    allocatorPriority: normal
-    shareIdleCPUsInSame: system
+  - name: dedicated-cpus
+    matchExpressions:
+    - key: qosclass
+      operator: In
+      values:
+      - Guaranteed
+    preferNewBalloons: true
+    preferSpreadingPods: true
+
+  - name: shared-local-cpus
+    matchExpressions:
+    - key: qosclass
+      operator: In
+      values:
+      - BestEffort
+      - Burstable
+    shareIdleCPUsInSame: package
+    preferNewBalloons: true
+    maxBalloons: 2
+    preferSpreadingPods: false
+
   reservedPoolNamespaces:
     - kube-system
   log:
     source: true
-    klog:
-      skip_headers: true
   instrumentation:
     reportPeriod: 60s
     samplingRatePerMillion: 0


### PR DESCRIPTION
Introduce a default configuration where Guaranteed containers are all executed on dedicated CPUs while BestEffort and Burstable share CPUs in package (socket) level.