### PR TITLE
topology-aware: correctly reconfigure implicit affinities for configuration changes.

### DIFF
--- a/cmd/plugins/topology-aware/policy/mocks_test.go
+++ b/cmd/plugins/topology-aware/policy/mocks_test.go
@@ -22,6 +22,7 @@ import (
 	resmgr "github.com/containers/nri-plugins/pkg/apis/resmgr/v1alpha1"
 	"github.com/containers/nri-plugins/pkg/cpuallocator"
 	"github.com/containers/nri-plugins/pkg/resmgr/cache"
+	libmem "github.com/containers/nri-plugins/pkg/resmgr/lib/memory"
 	"github.com/containers/nri-plugins/pkg/sysfs"
 	system "github.com/containers/nri-plugins/pkg/sysfs"
 	"github.com/containers/nri-plugins/pkg/topology"
@@ -184,6 +185,9 @@ func (c *mockCPU) GetCachesByLevel(int) []*sysfs.Cache {
 	panic("unimplemented")
 }
 func (c *mockCPU) GetCacheByIndex(int) *sysfs.Cache {
+	panic("unimplemented")
+}
+func (c *mockCPU) GetNthLevelCacheCPUSet(n int) cpuset.CPUSet {
 	panic("unimplemented")
 }
 func (c *mockCPU) GetLastLevelCaches() []*sysfs.Cache {
@@ -531,6 +535,9 @@ func (m *mockContainer) PreserveCpuResources() bool {
 func (m *mockContainer) PreserveMemoryResources() bool {
 	return false
 }
+func (m *mockContainer) MemoryTypes() (libmem.TypeMask, error) {
+	return libmem.TypeMaskDRAM, nil
+}
 
 type mockPod struct {
 	name                               string
@@ -668,6 +675,8 @@ func (m *mockCache) EvaluateAffinity(*cache.Affinity) map[string]int32 {
 }
 func (m *mockCache) AddImplicitAffinities(map[string]cache.ImplicitAffinity) error {
 	return nil
+}
+func (m *mockCache) DeleteImplicitAffinities(...string) {
 }
 func (m *mockCache) GetActivePolicy() string {
 	panic("unimplemented")

--- a/cmd/plugins/topology-aware/policy/pools_test.go
+++ b/cmd/plugins/topology-aware/policy/pools_test.go
@@ -276,20 +276,6 @@ func TestWorkloadPlacement(t *testing.T) {
 			expectedRemainingNodes: []int{0, 1, 2, 3, 4, 5, 6},
 			expectedLeafNode:       false,
 		},
-		{
-			path: path.Join(dir, "sysfs", "server", "sys"),
-			name: "workload placement on a server system root node: memory doesn't fit to leaf",
-			req: &request{
-				memReq:    190000000000,
-				memLim:    190000000000,
-				memType:   memoryUnspec,
-				isolate:   false,
-				full:      28,
-				container: &mockContainer{},
-			},
-			expectedRemainingNodes: []int{2, 6},
-			expectedLeafNode:       false,
-		},
 	}
 	for _, tc := range tcases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/plugins/topology-aware/policy/topology-aware-policy.go
+++ b/cmd/plugins/topology-aware/policy/topology-aware-policy.go
@@ -111,7 +111,9 @@ func (p *policy) Setup(opts *policyapi.BackendOptions) error {
 		return policyError("failed to initialize %s policy: %w", PolicyName, err)
 	}
 
-	p.registerImplicitAffinities()
+	if err := p.registerImplicitAffinities(); err != nil {
+		return policyError("failed to initialize %s policy: %w", PolicyName, err)
+	}
 
 	log.Info("***** default CPU priority is %s", defaultPrio)
 
@@ -481,6 +483,10 @@ func (p *policy) Reconfigure(newCfg interface{}) error {
 
 	if err := p.initialize(); err != nil {
 		*p = savedPolicy
+		return policyError("failed to reconfigure: %v", err)
+	}
+
+	if err := p.registerImplicitAffinities(); err != nil {
 		return policyError("failed to reconfigure: %v", err)
 	}
 

--- a/pkg/resmgr/cache/affinity.go
+++ b/pkg/resmgr/cache/affinity.go
@@ -250,7 +250,7 @@ func (cch *cache) AddImplicitAffinities(implicit map[string]ImplicitAffinity) er
 }
 
 // DeleteImplicitAffinities removes a previously registered set of implicit affinities.
-func (cch *cache) DeleteImplicitAffinities(names []string) {
+func (cch *cache) DeleteImplicitAffinities(names ...string) {
 	for _, name := range names {
 		delete(cch.implicit, name)
 	}

--- a/pkg/resmgr/cache/cache.go
+++ b/pkg/resmgr/cache/cache.go
@@ -390,6 +390,8 @@ type Cache interface {
 	EvaluateAffinity(*Affinity) map[string]int32
 	// AddImplicitAffinities adds a set of implicit affinities (added to all containers).
 	AddImplicitAffinities(map[string]ImplicitAffinity) error
+	// DeleteImplicitAffinities deletes a set of implicit affinities by name.
+	DeleteImplicitAffinities(names ...string)
 
 	// GetActivePolicy returns the name of the active policy stored in the cache.
 	GetActivePolicy() string


### PR DESCRIPTION
Fix the handling of implicit affinities corresponding to the `colocate{Pods,Namespaces}` configuration settings. Unregister and reregister disabled and enabled implicit affinities as necessary when we receive a new configuration.