### PR TITLE
apis/config: use consistent assignment in +kubebuilder:validation tags.

### DIFF
--- a/pkg/apis/config/v1alpha1/resmgr/policy/balloons/config.go
+++ b/pkg/apis/config/v1alpha1/resmgr/policy/balloons/config.go
@@ -221,12 +221,12 @@ type BalloonDef struct {
 	// for the time being we prevent its usage through CRDs.
 	PreferFarFromDevices []string `json:"-"`
 	// preferIsolCpus: prefer kernel isolated cpus
-	// +kubebuilder:default:=false
+	// +kubebuilder:default=false
 	PreferIsolCpus bool `json:"preferIsolCpus,omitempty"`
 	// preferCoreType: prefer performance or efficient (P/E) CPU cores on
 	// hybrid architectures.
 	// +optional
-	// +kubebuilder:validation:Enum:=efficient;performance
+	// +kubebuilder:validation:Enum=efficient;performance
 	PreferCoreType string `json:"preferCoreType,omitempty"`
 }
 


### PR DESCRIPTION
Use consistently '=' for assignment (instead of ':=') in +kubebuilder:validation tags. Both versions work, but we have earlier used '=' everywhere, so let's stick to that.