### PR TITLE
build: update controller-tools to v0.16.5.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -475,7 +475,7 @@ CLIENT_GEN ?= $(LOCALBIN)/client-gen
 GIT_CLONE    := git clone
 
 # External generation tool versions
-CONTROLLER_TOOLS_VERSION ?= v0.14.0
+CONTROLLER_TOOLS_VERSION ?= v0.16.5
 CLIENT_GEN_VERSION ?= v0.28.1
 CODE_GENERATOR_REPO ?= https://github.com/kubernetes/code-generator
 CODE_GENERATOR_VERSION ?= v0.28.1

--- a/config/crd/bases/config.nri_balloonspolicies.yaml
+++ b/config/crd/bases/config.nri_balloonspolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: balloonspolicies.config.nri
 spec:
   group: config.nri

--- a/config/crd/bases/config.nri_templatepolicies.yaml
+++ b/config/crd/bases/config.nri_templatepolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: templatepolicies.config.nri
 spec:
   group: config.nri

--- a/config/crd/bases/config.nri_topologyawarepolicies.yaml
+++ b/config/crd/bases/config.nri_topologyawarepolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: topologyawarepolicies.config.nri
 spec:
   group: config.nri

--- a/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
+++ b/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: balloonspolicies.config.nri
 spec:
   group: config.nri

--- a/deployment/helm/template/crds/config.nri_templatepolicies.yaml
+++ b/deployment/helm/template/crds/config.nri_templatepolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: templatepolicies.config.nri
 spec:
   group: config.nri

--- a/deployment/helm/topology-aware/crds/config.nri_topologyawarepolicies.yaml
+++ b/deployment/helm/topology-aware/crds/config.nri_topologyawarepolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: topologyawarepolicies.config.nri
 spec:
   group: config.nri


### PR DESCRIPTION
Update controller tools to v0.16.5, in particular to get CRD slice/array item pattern-based validation working using the +kubebuilder:validation:items:Pattern tag.