### PR TITLE
e2e: containerd 2.0.0. provisioning fixup.

### DIFF
--- a/test/e2e/playbook/provision.yaml
+++ b/test/e2e/playbook/provision.yaml
@@ -312,7 +312,7 @@
           when: ansible_facts['distribution'] == "Fedora"
           ansible.builtin.lineinfile:
             path: /etc/containerd/config.toml
-            regexp: ' *bin_dir *= *"/opt/cni/bin" *'
+            regexp: ' *bin_dir *= *./opt/cni/bin. *'
             line: 'bin_dir = "/usr/libexec/cni"'
 
     - name: Configure bridge CNI plugin


### PR DESCRIPTION
Accept both double and single quotes when looking for cni_bin_dir configuration value to replace.