### PR TITLE
[stacked 2/5] metrics: add de-facto standard collectors.

### DIFF
--- a/config/crd/bases/config.nri_balloonspolicies.yaml
+++ b/config/crd/bases/config.nri_balloonspolicies.yaml
@@ -324,6 +324,7 @@ spec:
                     default:
                       enabled:
                       - policy
+                      - buildinfo
                     description: Metrics defines which metrics to collect.
                     properties:
                       enabled:

--- a/config/crd/bases/config.nri_templatepolicies.yaml
+++ b/config/crd/bases/config.nri_templatepolicies.yaml
@@ -96,6 +96,7 @@ spec:
                     default:
                       enabled:
                       - policy
+                      - buildinfo
                     description: Metrics defines which metrics to collect.
                     properties:
                       enabled:

--- a/config/crd/bases/config.nri_topologyawarepolicies.yaml
+++ b/config/crd/bases/config.nri_topologyawarepolicies.yaml
@@ -123,6 +123,7 @@ spec:
                     default:
                       enabled:
                       - policy
+                      - buildinfo
                     description: Metrics defines which metrics to collect.
                     properties:
                       enabled:

--- a/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
+++ b/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
@@ -324,6 +324,7 @@ spec:
                     default:
                       enabled:
                       - policy
+                      - buildinfo
                     description: Metrics defines which metrics to collect.
                     properties:
                       enabled:

--- a/deployment/helm/template/crds/config.nri_templatepolicies.yaml
+++ b/deployment/helm/template/crds/config.nri_templatepolicies.yaml
@@ -96,6 +96,7 @@ spec:
                     default:
                       enabled:
                       - policy
+                      - buildinfo
                     description: Metrics defines which metrics to collect.
                     properties:
                       enabled:

--- a/deployment/helm/topology-aware/crds/config.nri_topologyawarepolicies.yaml
+++ b/deployment/helm/topology-aware/crds/config.nri_topologyawarepolicies.yaml
@@ -123,6 +123,7 @@ spec:
                     default:
                       enabled:
                       - policy
+                      - buildinfo
                     description: Metrics defines which metrics to collect.
                     properties:
                       enabled:

--- a/pkg/apis/config/v1alpha1/instrumentation/config.go
+++ b/pkg/apis/config/v1alpha1/instrumentation/config.go
@@ -49,6 +49,6 @@ type Config struct {
 	// +optional
 	PrometheusExport bool `json:"prometheusExport,omitempty"`
 	// Metrics defines which metrics to collect.
-	// +kubebuilder:default={"enabled": {"policy"}}
+	// +kubebuilder:default={"enabled": {"policy", "buildinfo"}}
 	Metrics *metrics.Config `json:"metrics,omitempty"`
 }

--- a/pkg/metrics/collectors/collectors.go
+++ b/pkg/metrics/collectors/collectors.go
@@ -1,0 +1,66 @@
+// Copyright The NRI Plugins Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collectors
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+
+	logger "github.com/containers/nri-plugins/pkg/log"
+	"github.com/containers/nri-plugins/pkg/metrics"
+	"github.com/containers/nri-plugins/pkg/version"
+)
+
+var (
+	log = logger.Get("metrics")
+)
+
+func NewVersionInfoCollector(v, b string) prometheus.Collector {
+	return prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: "version_info",
+			Help: "A metric with constant '1' value labeled by version and build info.",
+			ConstLabels: prometheus.Labels{
+				"version": v,
+				"build":   b,
+			},
+		},
+		func() float64 { return 1 },
+	)
+}
+
+func init() {
+	var (
+		collectors = map[string]prometheus.Collector{
+			"buildinfo":   collectors.NewBuildInfoCollector(),
+			"golang":      collectors.NewGoCollector(),
+			"process":     collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+			"versioninfo": NewVersionInfoCollector(version.Version, version.Build),
+		}
+		options = []metrics.RegisterOption{
+			metrics.WithGroup("standard"),
+			metrics.WithCollectorOptions(
+				metrics.WithoutNamespace(),
+				metrics.WithoutSubsystem(),
+			),
+		}
+	)
+
+	for name, collector := range collectors {
+		if err := metrics.Register(name, collector, options...); err != nil {
+			log.Error("failed to register %s collector: %v", name, err)
+		}
+	}
+}

--- a/pkg/resmgr/main/main.go
+++ b/pkg/resmgr/main/main.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/containers/nri-plugins/pkg/agent"
 	"github.com/containers/nri-plugins/pkg/instrumentation"
+	_ "github.com/containers/nri-plugins/pkg/metrics/collectors"
 	"github.com/containers/nri-plugins/pkg/resmgr"
 	"github.com/containers/nri-plugins/pkg/resmgr/policy"
 


### PR DESCRIPTION
Notes: This PR is *stacked on top* of #403.

Add a `metrics/collectors` subpackage to register the fairly standard `buildinfo`, `process` and `golang` runtime collectors. Turn on the `buildinfo` collector by default.