### PR TITLE
[stacked 5/5] metrics: add topology-aware policy metrics collection.

### DIFF
--- a/cmd/plugins/topology-aware/policy/metrics.go
+++ b/cmd/plugins/topology-aware/policy/metrics.go
@@ -1,0 +1,324 @@
+// Copyright The NRI Plugins Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topologyaware
+
+import (
+	"slices"
+	"strings"
+
+	libmem "github.com/containers/nri-plugins/pkg/resmgr/lib/memory"
+	policyapi "github.com/containers/nri-plugins/pkg/resmgr/policy"
+	"github.com/containers/nri-plugins/pkg/utils/cpuset"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type TopologyAwareMetrics struct {
+	p         *policy
+	ZoneNames []string
+	Zones     map[string]*Zone
+	Metrics   Metrics
+}
+
+type Zone struct {
+	Name                 string
+	Cpus                 cpuset.CPUSet
+	Mems                 libmem.NodeMask
+	SharedPool           cpuset.CPUSet
+	SharedAssigned       int
+	SharedAvailable      int
+	MemCapacity          int64
+	MemAssigned          int64
+	MemAvailable         int64
+	ContainerCount       int
+	SharedContainerCount int
+}
+
+type Metrics struct {
+	zone                 *prometheus.GaugeVec
+	cpuSharedCapacity    *prometheus.GaugeVec
+	cpuSharedAssigned    *prometheus.GaugeVec
+	cpuSharedAvailable   *prometheus.GaugeVec
+	memCapacity          *prometheus.GaugeVec
+	memAssigned          *prometheus.GaugeVec
+	memAvailable         *prometheus.GaugeVec
+	containerCount       *prometheus.GaugeVec
+	sharedContainerCount *prometheus.GaugeVec
+}
+
+const (
+	metricsSubsystem = "topologyaware"
+)
+
+func (p *policy) GetMetrics() policyapi.Metrics {
+	return p.metrics
+}
+
+func (p *policy) NewTopologyAwareMetrics() *TopologyAwareMetrics {
+	m := &TopologyAwareMetrics{
+		p:     p,
+		Zones: make(map[string]*Zone),
+		Metrics: Metrics{
+			zone: prometheus.NewGaugeVec(
+				prometheus.GaugeOpts{
+					Subsystem: metricsSubsystem,
+					Name:      "zone_cpu_capacity",
+					Help:      "A topology zone of CPUs.",
+				},
+				[]string{
+					"zone",
+					"cpus",
+					"mems",
+				},
+			),
+			cpuSharedCapacity: prometheus.NewGaugeVec(
+				prometheus.GaugeOpts{
+					Subsystem: metricsSubsystem,
+					Name:      "zone_cpu_shared_capacity",
+					Help:      "Capacity of shared CPU pool of a topology zone.",
+				},
+				[]string{
+					"zone",
+					"cpus",
+				},
+			),
+			cpuSharedAssigned: prometheus.NewGaugeVec(
+				prometheus.GaugeOpts{
+					Subsystem: metricsSubsystem,
+					Name:      "zone_cpu_shared_assigned",
+					Help:      "Assigned amount of shared CPU pool of a topology zone.",
+				},
+				[]string{
+					"zone",
+					"cpus",
+				},
+			),
+			cpuSharedAvailable: prometheus.NewGaugeVec(
+				prometheus.GaugeOpts{
+					Subsystem: metricsSubsystem,
+					Name:      "zone_cpu_shared_available",
+					Help:      "Available amount of shared CPU pool of a topology zone.",
+				},
+				[]string{
+					"zone",
+					"cpus",
+				},
+			),
+			memCapacity: prometheus.NewGaugeVec(
+				prometheus.GaugeOpts{
+					Subsystem: metricsSubsystem,
+					Name:      "zone_mem_capacity",
+					Help:      "Memory capacity of a topology zone.",
+				},
+				[]string{
+					"zone",
+					"mems",
+				},
+			),
+			memAssigned: prometheus.NewGaugeVec(
+				prometheus.GaugeOpts{
+					Subsystem: metricsSubsystem,
+					Name:      "zone_mem_assigned",
+					Help:      "Amount of assigned memory of a topology zone.",
+				},
+				[]string{
+					"zone",
+					"mems",
+				},
+			),
+			memAvailable: prometheus.NewGaugeVec(
+				prometheus.GaugeOpts{
+					Subsystem: metricsSubsystem,
+					Name:      "zone_mem_available",
+					Help:      "Amount of available memory of a topology zone.",
+				},
+				[]string{
+					"zone",
+					"mems",
+				},
+			),
+			containerCount: prometheus.NewGaugeVec(
+				prometheus.GaugeOpts{
+					Subsystem: metricsSubsystem,
+					Name:      "zone_container_count",
+					Help:      "Number of containers assigned to a topology zone.",
+				},
+				[]string{
+					"zone",
+				},
+			),
+			sharedContainerCount: prometheus.NewGaugeVec(
+				prometheus.GaugeOpts{
+					Subsystem: metricsSubsystem,
+					Name:      "zone_shared_container_count",
+					Help:      "Number of containers in the shared CPU pool of a topology zone.",
+				},
+				[]string{
+					"zone",
+				},
+			),
+		},
+	}
+
+	for _, pool := range p.pools {
+		var (
+			name = pool.Name()
+			mems = libmem.NewNodeMask(pool.GetMemset(memoryAll).Members()...)
+			capa = pool.GetSupply().(*supply)
+			cpus = capa.ReservedCPUs().Union(capa.IsolatedCPUs()).Union(capa.SharableCPUs())
+			zone = &Zone{
+				Name:        name,
+				Cpus:        cpus,
+				Mems:        mems,
+				MemCapacity: p.memAllocator.ZoneCapacity(mems),
+			}
+		)
+
+		m.Zones[name] = zone
+		m.ZoneNames = append(m.ZoneNames, name)
+
+		m.Metrics.zone.WithLabelValues(
+			zone.Name,
+			zone.Cpus.String(),
+			zone.Mems.String(),
+		).Set(float64(zone.Cpus.Size()))
+
+		m.Metrics.memCapacity.WithLabelValues(
+			zone.Name,
+			zone.Mems.String(),
+		).Set(float64(zone.MemCapacity))
+	}
+
+	slices.SortFunc(m.ZoneNames, func(a, b string) int {
+		poolA, poolB := p.nodes[a], p.nodes[b]
+		if diff := poolA.RootDistance() - poolB.RootDistance(); diff != 0 {
+			return diff
+		}
+		return strings.Compare(a, b)
+	})
+
+	m.Update()
+
+	return m
+}
+
+func (m *TopologyAwareMetrics) Describe(ch chan<- *prometheus.Desc) {
+	if m == nil {
+		return
+	}
+
+	m.Metrics.zone.Describe(ch)
+	m.Metrics.cpuSharedCapacity.Describe(ch)
+	m.Metrics.cpuSharedAssigned.Describe(ch)
+	m.Metrics.cpuSharedAvailable.Describe(ch)
+	m.Metrics.memCapacity.Describe(ch)
+	m.Metrics.memAssigned.Describe(ch)
+	m.Metrics.memAvailable.Describe(ch)
+	m.Metrics.containerCount.Describe(ch)
+	m.Metrics.sharedContainerCount.Describe(ch)
+}
+
+func (m *TopologyAwareMetrics) Collect(ch chan<- prometheus.Metric) {
+	if m == nil {
+		return
+	}
+
+	m.Update()
+
+	m.Metrics.zone.Collect(ch)
+	m.Metrics.cpuSharedCapacity.Collect(ch)
+	m.Metrics.cpuSharedAssigned.Collect(ch)
+	m.Metrics.cpuSharedAvailable.Collect(ch)
+	m.Metrics.memCapacity.Collect(ch)
+	m.Metrics.memAssigned.Collect(ch)
+	m.Metrics.memAvailable.Collect(ch)
+	m.Metrics.containerCount.Collect(ch)
+	m.Metrics.sharedContainerCount.Collect(ch)
+}
+
+// Update updates our metrics.
+func (m *TopologyAwareMetrics) Update() {
+	if m == nil {
+		return
+	}
+
+	p := m.p
+	for _, pool := range p.pools {
+		log.Debug("updating metrics for pool %s...", pool.Name())
+
+		var (
+			zone       = m.Zones[pool.Name()]
+			free       = pool.FreeSupply().(*supply)
+			mems       = libmem.NewNodeMask(pool.GetMemset(memoryAll).Members()...)
+			sharedPool = free.SharableCPUs().Union(free.ReservedCPUs())
+			containers = 0
+			sharedctrs = 0
+		)
+
+		if zone == nil {
+			log.Error("metrics zone not found for pool %s", pool.Name())
+			continue
+		}
+
+		for _, g := range p.allocations.grants {
+			if g.GetCPUNode().Name() == pool.Name() {
+				containers++
+				if g.ReservedPortion() != 0 || g.CPUPortion() != 0 {
+					sharedctrs++
+				}
+			}
+		}
+
+		zone.SharedPool = sharedPool
+		zone.SharedAssigned = free.GrantedReserved() + free.GrantedShared()
+		zone.SharedAvailable = free.AllocatableSharedCPU()
+		zone.MemAssigned = p.memAllocator.ZoneUsage(mems)
+		zone.MemAvailable = p.memAllocator.ZoneAvailable(mems)
+		zone.ContainerCount = containers
+		zone.SharedContainerCount = sharedctrs
+
+		m.Metrics.cpuSharedCapacity.WithLabelValues(
+			zone.Name,
+			zone.SharedPool.String(),
+		).Set(float64(zone.SharedPool.Size()))
+
+		m.Metrics.cpuSharedAssigned.WithLabelValues(
+			zone.Name,
+			zone.SharedPool.String(),
+		).Set(float64(zone.SharedAssigned) / 1000.0)
+
+		m.Metrics.cpuSharedAvailable.WithLabelValues(
+			zone.Name,
+			zone.SharedPool.String(),
+		).Set(float64(zone.SharedAvailable) / 1000.0)
+
+		m.Metrics.memAssigned.WithLabelValues(
+			zone.Name,
+			zone.Mems.MemsetString(),
+		).Set(float64(zone.MemAssigned))
+
+		m.Metrics.memAvailable.WithLabelValues(
+			zone.Name,
+			zone.Mems.MemsetString(),
+		).Set(float64(zone.MemAvailable))
+
+		m.Metrics.containerCount.WithLabelValues(
+			zone.Name,
+		).Set(float64(zone.ContainerCount))
+
+		m.Metrics.sharedContainerCount.WithLabelValues(
+			zone.Name,
+		).Set(float64(zone.SharedContainerCount))
+	}
+}

--- a/cmd/plugins/topology-aware/policy/topology-aware-policy.go
+++ b/cmd/plugins/topology-aware/policy/topology-aware-policy.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	"github.com/containers/nri-plugins/pkg/utils/cpuset"
-	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	cfgapi "github.com/containers/nri-plugins/pkg/apis/config/v1alpha1/resmgr/policy/topologyaware"
@@ -420,24 +419,6 @@ func (p *policy) ExportResourceData(c cache.Container) map[string]string {
 	}
 
 	return data
-}
-
-func (p *policy) GetMetrics() policyapi.Metrics {
-	return p.metrics
-}
-
-func (p *policy) NewTopologyAwareMetrics() *TopologyAwareMetrics {
-	return &TopologyAwareMetrics{}
-}
-
-type TopologyAwareMetrics struct{}
-
-func (*TopologyAwareMetrics) Describe(ch chan<- *prometheus.Desc) {
-	return
-}
-
-func (*TopologyAwareMetrics) Collect(ch chan<- prometheus.Metric) {
-	return
 }
 
 // reallocateResources reallocates the given containers using the given pool hints

--- a/docs/resource-policy/policy/topology-aware.md
+++ b/docs/resource-policy/policy/topology-aware.md
@@ -146,6 +146,16 @@ behavior. These options can be supplied as part of the effective
     CPU allocations. For a more detailed discussion of CPU prioritization see
     the [cpu allocator](../developers-guide/cpu-allocator.md) documentation.
 
+Additionally, the following sub-configuration is available for instrumentation:
+
+- `instrumentation`: configures runtime instrumentation.
+  - `httpEndpoint`: the address the HTTP server listens on. Example:
+    `:8891`.
+  - `prometheusExport`: if set to True, metrics about system and topology zone
+     resource assignment are readable through `/metrics` from the configured
+     `httpEndpoint`.
+  - `reportPeriod`: `/metrics` aggregation interval for polled metrics.
+
 ## Policy CPU Allocation Preferences
 
 There are a number of workload properties this policy actively checks to decide
@@ -760,3 +770,23 @@ metadata:
 
 <!-- Links -->
 [configuration]: ../configuration.md
+
+## Metrics and Debugging
+
+In order to enable more verbose logging and metrics exporting from the
+topology-aware policy, enable instrumentation and policy debugging from
+the nri-resource-policy global config:
+
+```yaml
+instrumentation:
+  # The topology-aware policy can exports various system and topology
+  # zone utilisation metrics. Accessible in command line with
+  # curl --silent http://$localhost_or_pod_IP:8891/metrics
+  HTTPEndpoint: :8891
+  PrometheusExport: true
+  metrics:
+    enabled: # use '*' instead for all available metrics
+    - policy
+logger:
+  Debug: policy
+```

--- a/pkg/resmgr/policy/metrics.go
+++ b/pkg/resmgr/policy/metrics.go
@@ -15,13 +15,21 @@
 package policy
 
 import (
+	"strconv"
+	"sync"
+
 	"github.com/prometheus/client_golang/prometheus"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/containers/nri-plugins/pkg/metrics"
+	"github.com/containers/nri-plugins/pkg/resmgr/cache"
+	system "github.com/containers/nri-plugins/pkg/sysfs"
+	"github.com/containers/nri-plugins/pkg/utils/cpuset"
 )
 
 type PolicyCollector struct {
 	policy *policy
+	block  sync.Mutex
 }
 
 func (p *policy) newPolicyCollector() *PolicyCollector {
@@ -40,4 +48,223 @@ func (c *PolicyCollector) Describe(ch chan<- *prometheus.Desc) {
 
 func (c *PolicyCollector) Collect(ch chan<- prometheus.Metric) {
 	c.policy.active.GetMetrics().Collect(ch)
+}
+
+const (
+	nodeCapacity = iota
+	nodeUsage
+	nodeContainers
+	cpuAllocation
+	cpuContainers
+	metricsCount
+)
+
+type (
+	SystemCollector struct {
+		cache   cache.Cache
+		system  system.System
+		Nodes   map[int]*NodeMetric
+		Cpus    map[int]*CpuMetric
+		Metrics []*prometheus.GaugeVec
+	}
+	NodeMetric struct {
+		Id             int
+		IdLabel        string
+		Type           string
+		Capacity       int64
+		Usage          int64
+		ContainerCount int
+	}
+	CpuMetric struct {
+		Id             int
+		IdLabel        string
+		Allocation     int
+		ContainerCount int
+	}
+)
+
+func (p *policy) newSystemCollector() *SystemCollector {
+	s := &SystemCollector{
+		cache:   p.cache,
+		system:  p.system,
+		Nodes:   map[int]*NodeMetric{},
+		Cpus:    map[int]*CpuMetric{},
+		Metrics: make([]*prometheus.GaugeVec, metricsCount, metricsCount),
+	}
+
+	s.Metrics[nodeCapacity] = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "mem_node_capacity",
+			Help: "Capacity of the memory node.",
+		},
+		[]string{
+			"node_id",
+		},
+	)
+	s.Metrics[nodeUsage] = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "mem_node_usage",
+			Help: "Usage of the memory node",
+		},
+		[]string{
+			"node_id",
+		},
+	)
+	s.Metrics[nodeContainers] = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "mem_node_container_count",
+			Help: "Number of containers assigned to the memory node.",
+		},
+		[]string{
+			"node_id",
+		},
+	)
+	s.Metrics[cpuAllocation] = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "cpu_allocation",
+			Help: "Total allocation of the CPU.",
+		},
+		[]string{
+			"cpu_id",
+		},
+	)
+	s.Metrics[cpuContainers] = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "cpu_container_count",
+			Help: "Number of containers assigned to the CPU.",
+		},
+		[]string{
+			"cpu_id",
+		},
+	)
+
+	for _, id := range s.system.NodeIDs() {
+		var (
+			sys        = s.system.Node(id)
+			capa, used = s.getMemInfo(sys)
+			node       = &NodeMetric{
+				Id:       sys.ID(),
+				IdLabel:  strconv.Itoa(sys.ID()),
+				Type:     sys.GetMemoryType().String(),
+				Capacity: capa,
+				Usage:    used,
+			}
+		)
+		s.Nodes[id] = node
+	}
+
+	for _, id := range s.system.CPUIDs() {
+		cpu := &CpuMetric{
+			Id:      id,
+			IdLabel: strconv.Itoa(id),
+		}
+		s.Cpus[id] = cpu
+	}
+
+	return s
+}
+
+func (s *SystemCollector) Describe(ch chan<- *prometheus.Desc) {
+	s.Metrics[nodeCapacity].Describe(ch)
+	s.Metrics[nodeUsage].Describe(ch)
+	s.Metrics[nodeContainers].Describe(ch)
+	s.Metrics[cpuAllocation].Describe(ch)
+	s.Metrics[cpuContainers].Describe(ch)
+}
+
+func (s *SystemCollector) Collect(ch chan<- prometheus.Metric) {
+	s.Update()
+	s.Metrics[nodeCapacity].Collect(ch)
+	s.Metrics[nodeUsage].Collect(ch)
+	s.Metrics[nodeContainers].Collect(ch)
+	s.Metrics[cpuAllocation].Collect(ch)
+	s.Metrics[cpuContainers].Collect(ch)
+}
+
+func (s *SystemCollector) register() error {
+	return metrics.Register("system", s, metrics.WithGroup("policy"))
+}
+
+func (s *SystemCollector) Update() {
+	for _, n := range s.Nodes {
+		sys := s.system.Node(n.Id)
+		capa, used := s.getMemInfo(sys)
+
+		if n.Capacity == 0 {
+			n.Capacity = capa
+			s.Metrics[nodeCapacity].WithLabelValues(n.IdLabel).Set(float64(n.Capacity))
+		}
+
+		n.Usage = used
+		n.ContainerCount = 0
+	}
+
+	for _, c := range s.Cpus {
+		c.ContainerCount = 0
+		c.Allocation = 0
+	}
+
+	for _, ctr := range s.cache.GetContainers() {
+		switch ctr.GetState() {
+		case cache.ContainerStateCreated:
+		case cache.ContainerStateRunning:
+		default:
+			continue
+		}
+
+		var (
+			cpu, mem = s.getCpuAndMemset(ctr)
+			req, _   = s.getCpuResources(ctr)
+		)
+
+		for _, id := range mem.List() {
+			if n, ok := s.Nodes[id]; ok {
+				n.ContainerCount++
+			}
+		}
+
+		for _, id := range cpu.List() {
+			if c, ok := s.Cpus[id]; ok {
+				c.ContainerCount++
+				if cpu.Size() > 0 {
+					c.Allocation += req / cpu.Size()
+				}
+			}
+		}
+	}
+
+	for _, n := range s.Nodes {
+		s.Metrics[nodeUsage].WithLabelValues(n.IdLabel).Set(float64(n.Usage))
+	}
+	for _, c := range s.Cpus {
+		s.Metrics[cpuAllocation].WithLabelValues(c.IdLabel).Set(float64(c.Allocation))
+		s.Metrics[cpuContainers].WithLabelValues(c.IdLabel).Set(float64(c.ContainerCount))
+	}
+}
+
+func (s *SystemCollector) getMemInfo(n system.Node) (capacity, used int64) {
+	if n != nil {
+		if i, _ := n.MemoryInfo(); i != nil {
+			return int64(i.MemTotal), int64(i.MemUsed)
+		}
+	}
+	return 0, 0
+}
+
+func (s *SystemCollector) getCpuAndMemset(ctr cache.Container) (cpu, mem cpuset.CPUSet) {
+	cset, _ := cpuset.Parse(ctr.GetCpusetCpus())
+	mset, _ := cpuset.Parse(ctr.GetCpusetMems())
+	return cset, mset
+}
+
+func (s *SystemCollector) getCpuResources(ctr cache.Container) (request, limit int) {
+	res := ctr.GetResourceRequirements()
+	if qty, ok := res.Requests[v1.ResourceCPU]; ok {
+		request = int(qty.MilliValue())
+	}
+	if qty, ok := res.Limits[v1.ResourceCPU]; ok {
+		limit = int(qty.MilliValue())
+	}
+
+	return request, limit
 }

--- a/pkg/resmgr/policy/policy.go
+++ b/pkg/resmgr/policy/policy.go
@@ -204,6 +204,7 @@ type policy struct {
 	system    system.System    // system/HW/topology info
 	sendEvent SendEventFn      // function to send event up to the resource manager
 	pcollect  *PolicyCollector // policy metrics collector
+	scollect  *SystemCollector // system metrics collector
 }
 
 // backend is a registered Backend.
@@ -237,6 +238,12 @@ func NewPolicy(backend Backend, cache cache.Cache, o *Options) (Policy, error) {
 		return nil, policyError("failed to register policy collector: %v", err)
 	}
 	p.pcollect = pcollect
+
+	scollect := p.newSystemCollector()
+	if err = scollect.register(); err != nil {
+		return nil, policyError("failed to register system collector: %v", err)
+	}
+	p.scollect = scollect
 
 	return p, nil
 }


### PR DESCRIPTION
Notes: This PR is *stacked on top* of #405.

Implement metrics collection for the topology-aware policy. Currently we collect for each pool/zone
    - name, cpuset and memset
    - shared pool capacity, allocation, available amount
    - memory capacity, allocation, available amount
    - number of containers
    - number of containers in the shared pool
