### PR TITLE
[stacked 3/5] metrics: simplify policy/backend metrics collection interface.

### DIFF
--- a/cmd/plugins/template/policy/template-policy.go
+++ b/cmd/plugins/template/policy/template-policy.go
@@ -116,19 +116,9 @@ func (p *policy) HandleEvent(e *events.Policy) (bool, error) {
 	return true, nil
 }
 
-// DescribeMetrics generates policy-specific prometheus metrics data descriptors.
-func (p *policy) DescribeMetrics() []*prometheus.Desc {
-	return nil
-}
-
-// PollMetrics provides policy metrics for monitoring.
-func (p *policy) PollMetrics() policyapi.Metrics {
-	return nil
-}
-
-// CollectMetrics generates prometheus metrics from cached/polled policy-specific metrics data.
-func (p *policy) CollectMetrics(policyapi.Metrics) ([]prometheus.Metric, error) {
-	return nil, nil
+// GetMetrics returns the policy-specific metrics collector.
+func (p *policy) GetMetrics() policyapi.Metrics {
+	return &NoMetrics{}
 }
 
 // GetTopologyZones returns the policy/pool data for 'topology zone' CRDs.
@@ -144,4 +134,14 @@ func (p *policy) ExportResourceData(c cache.Container) map[string]string {
 // Initialize or reinitialize the policy.
 func (p *policy) initialize() error {
 	return nil
+}
+
+type NoMetrics struct{}
+
+func (*NoMetrics) Describe(chan<- *prometheus.Desc) {
+	return
+}
+
+func (*NoMetrics) Collect(chan<- prometheus.Metric) {
+	return
 }

--- a/config/crd/bases/config.nri_balloonspolicies.yaml
+++ b/config/crd/bases/config.nri_balloonspolicies.yaml
@@ -324,6 +324,7 @@ spec:
                     default:
                       enabled:
                       - policy
+                      - buildinfo
                     description: Metrics defines which metrics to collect.
                     properties:
                       enabled:

--- a/config/crd/bases/config.nri_templatepolicies.yaml
+++ b/config/crd/bases/config.nri_templatepolicies.yaml
@@ -96,6 +96,7 @@ spec:
                     default:
                       enabled:
                       - policy
+                      - buildinfo
                     description: Metrics defines which metrics to collect.
                     properties:
                       enabled:

--- a/config/crd/bases/config.nri_topologyawarepolicies.yaml
+++ b/config/crd/bases/config.nri_topologyawarepolicies.yaml
@@ -123,6 +123,7 @@ spec:
                     default:
                       enabled:
                       - policy
+                      - buildinfo
                     description: Metrics defines which metrics to collect.
                     properties:
                       enabled:

--- a/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
+++ b/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
@@ -324,6 +324,7 @@ spec:
                     default:
                       enabled:
                       - policy
+                      - buildinfo
                     description: Metrics defines which metrics to collect.
                     properties:
                       enabled:

--- a/deployment/helm/template/crds/config.nri_templatepolicies.yaml
+++ b/deployment/helm/template/crds/config.nri_templatepolicies.yaml
@@ -96,6 +96,7 @@ spec:
                     default:
                       enabled:
                       - policy
+                      - buildinfo
                     description: Metrics defines which metrics to collect.
                     properties:
                       enabled:

--- a/deployment/helm/topology-aware/crds/config.nri_topologyawarepolicies.yaml
+++ b/deployment/helm/topology-aware/crds/config.nri_topologyawarepolicies.yaml
@@ -123,6 +123,7 @@ spec:
                     default:
                       enabled:
                       - policy
+                      - buildinfo
                     description: Metrics defines which metrics to collect.
                     properties:
                       enabled:

--- a/pkg/apis/config/v1alpha1/instrumentation/config.go
+++ b/pkg/apis/config/v1alpha1/instrumentation/config.go
@@ -49,6 +49,6 @@ type Config struct {
 	// +optional
 	PrometheusExport bool `json:"prometheusExport,omitempty"`
 	// Metrics defines which metrics to collect.
-	// +kubebuilder:default={"enabled": {"policy"}}
+	// +kubebuilder:default={"enabled": {"policy", "buildinfo"}}
 	Metrics *metrics.Config `json:"metrics,omitempty"`
 }

--- a/pkg/metrics/collectors/collectors.go
+++ b/pkg/metrics/collectors/collectors.go
@@ -1,0 +1,66 @@
+// Copyright The NRI Plugins Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collectors
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+
+	logger "github.com/containers/nri-plugins/pkg/log"
+	"github.com/containers/nri-plugins/pkg/metrics"
+	"github.com/containers/nri-plugins/pkg/version"
+)
+
+var (
+	log = logger.Get("metrics")
+)
+
+func NewVersionInfoCollector(v, b string) prometheus.Collector {
+	return prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: "version_info",
+			Help: "A metric with constant '1' value labeled by version and build info.",
+			ConstLabels: prometheus.Labels{
+				"version": v,
+				"build":   b,
+			},
+		},
+		func() float64 { return 1 },
+	)
+}
+
+func init() {
+	var (
+		collectors = map[string]prometheus.Collector{
+			"buildinfo":   collectors.NewBuildInfoCollector(),
+			"golang":      collectors.NewGoCollector(),
+			"process":     collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+			"versioninfo": NewVersionInfoCollector(version.Version, version.Build),
+		}
+		options = []metrics.RegisterOption{
+			metrics.WithGroup("standard"),
+			metrics.WithCollectorOptions(
+				metrics.WithoutNamespace(),
+				metrics.WithoutSubsystem(),
+			),
+		}
+	)
+
+	for name, collector := range collectors {
+		if err := metrics.Register(name, collector, options...); err != nil {
+			log.Error("failed to register %s collector: %v", name, err)
+		}
+	}
+}

--- a/pkg/resmgr/main/main.go
+++ b/pkg/resmgr/main/main.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/containers/nri-plugins/pkg/agent"
 	"github.com/containers/nri-plugins/pkg/instrumentation"
+	_ "github.com/containers/nri-plugins/pkg/metrics/collectors"
 	"github.com/containers/nri-plugins/pkg/resmgr"
 	"github.com/containers/nri-plugins/pkg/resmgr/policy"
 

--- a/pkg/resmgr/policy/metrics.go
+++ b/pkg/resmgr/policy/metrics.go
@@ -35,21 +35,9 @@ func (c *PolicyCollector) register() error {
 }
 
 func (c *PolicyCollector) Describe(ch chan<- *prometheus.Desc) {
-	for _, d := range c.policy.active.DescribeMetrics() {
-		ch <- d
-	}
+	c.policy.active.GetMetrics().Describe(ch)
 }
 
 func (c *PolicyCollector) Collect(ch chan<- prometheus.Metric) {
-	polled := c.policy.active.PollMetrics()
-
-	collected, err := c.policy.active.CollectMetrics(polled)
-	if err != nil {
-		log.Error("failed to collect metrics: %v", err)
-		return
-	}
-
-	for _, m := range collected {
-		ch <- m
-	}
+	c.policy.active.GetMetrics().Collect(ch)
 }

--- a/pkg/resmgr/policy/policy.go
+++ b/pkg/resmgr/policy/policy.go
@@ -115,12 +115,8 @@ type Backend interface {
 	HandleEvent(*events.Policy) (bool, error)
 	// ExportResourceData provides resource data to export for the container.
 	ExportResourceData(cache.Container) map[string]string
-	// DescribeMetrics generates policy-specific prometheus metrics data descriptors.
-	DescribeMetrics() []*prometheus.Desc
-	// PollMetrics provides policy metrics for monitoring.
-	PollMetrics() Metrics
-	// CollectMetrics generates prometheus metrics from cached/polled policy-specific metrics data.
-	CollectMetrics(Metrics) ([]prometheus.Metric, error)
+	// GetMetrics returns the policy-specific metrics collector.
+	GetMetrics() Metrics
 	// GetTopologyZones returns the policy/pool data for 'topology zone' CRDs.
 	GetTopologyZones() []*TopologyZone
 }
@@ -151,7 +147,11 @@ type Policy interface {
 	GetTopologyZones() []*TopologyZone
 }
 
-type Metrics interface{}
+// Metrics is the interface we expect policy-specific metrics to implement.
+type Metrics interface {
+	Describe(chan<- *prometheus.Desc)
+	Collect(chan<- prometheus.Metric)
+}
 
 // Node resource topology resource and attribute names.
 // XXX TODO(klihub): We'll probably need to add similar unified consts


### PR DESCRIPTION
Notes: This PR is *stacked on top* of #404.

Simplify the policy-backend metrics collection interface, reducing it to a single `GetMetrics()` call and a returned `policy.Metrics` interface, which simply implements the native prometheus collector interface with `Describe()` and `Collect()`. Update policy implementations accordingly.
