### PR TITLE
fixes: copy assigned memory zone in grant clone.

### DIFF
--- a/cmd/plugins/topology-aware/policy/cache.go
+++ b/cmd/plugins/topology-aware/policy/cache.go
@@ -123,6 +123,7 @@ func (p *policy) reinstateGrants(grants map[string]Grant) error {
 }
 
 type cachedGrant struct {
+	PrettyName string
 	Exclusive  string
 	Part       int
 	CPUType    cpuClass
@@ -136,6 +137,7 @@ type cachedGrant struct {
 
 func newCachedGrant(cg Grant) *cachedGrant {
 	ccg := &cachedGrant{}
+	ccg.PrettyName = cg.GetContainer().PrettyName()
 	ccg.Exclusive = cg.ExclusiveCPUs().String()
 	ccg.Part = cg.CPUPortion()
 	ccg.CPUType = cg.CPUType()

--- a/cmd/plugins/topology-aware/policy/resources.go
+++ b/cmd/plugins/topology-aware/policy/resources.go
@@ -993,6 +993,8 @@ func (cg *grant) Clone() Grant {
 		cpuType:    cg.CPUType(),
 		cpuPortion: cg.SharedPortion(),
 		memType:    cg.MemoryType(),
+		memZone:    cg.GetMemoryZone(),
+		memSize:    cg.GetMemorySize(),
 		coldStart:  cg.ColdStart(),
 	}
 }


### PR DESCRIPTION
When cloning a grant, copy also the assigned memory zone. Failing to do so can result in errors like this during reconfiguration:

```
E: failed to reinstate grants verbatim: topology-aware: failed to get libmem offer for pool "NUMA node #1", grant of default/test/c2: libmem: invalid NodeMask: request without affinity
```

Additionally, also include the container's pretty name in saved grants, just to help post-mortem interpretation.