### PR TITLE
cpuallocator, plugins: handle priority as an option.

### DIFF
--- a/cmd/plugins/balloons/policy/balloons-policy.go
+++ b/cmd/plugins/balloons/policy/balloons-policy.go
@@ -612,7 +612,7 @@ func (p *balloons) newBalloon(blnDef *BalloonDef, confCpus bool) (*Balloon, erro
 	if err != nil {
 		return nil, balloonsError("failed to choose a cpuset for allocating MinCpus: %d from free cpus %q", blnDef.MinCpus, p.freeCpus)
 	}
-	cpus, err = p.cpuAllocator.AllocateCpus(&addFromCpus, blnDef.MinCpus, blnDef.AllocatorPriority.Value())
+	cpus, err = p.cpuAllocator.AllocateCpus(&addFromCpus, blnDef.MinCpus, blnDef.AllocatorPriority.Value().Option())
 	if err != nil {
 		return nil, balloonsError("could not allocate minCpus (%d) for balloon %s[%d]: %w", blnDef.MinCpus, blnDef.Name, freeInstance, err)
 	}
@@ -650,7 +650,7 @@ func (p *balloons) deleteBalloon(bln *Balloon) {
 	p.balloons = remainingBalloons
 	p.forgetCpuClass(bln)
 	p.freeCpus = p.freeCpus.Union(bln.Cpus)
-	p.cpuAllocator.ReleaseCpus(&bln.Cpus, bln.Cpus.Size(), bln.Def.AllocatorPriority.Value())
+	p.cpuAllocator.ReleaseCpus(&bln.Cpus, bln.Cpus.Size(), bln.Def.AllocatorPriority.Value().Option())
 }
 
 // freeBalloon clears a balloon and deletes it if allowed.
@@ -1374,7 +1374,7 @@ func (p *balloons) resizeBalloon(bln *Balloon, newMilliCpus int) error {
 			return balloonsError("resize/inflate: failed to choose a cpuset for allocating additional %d CPUs: %w", cpuCountDelta, err)
 		}
 		log.Debugf("- allocating %d CPUs from %q", cpuCountDelta, addFromCpus)
-		newCpus, err := p.cpuAllocator.AllocateCpus(&addFromCpus, newCpuCount-oldCpuCount, bln.Def.AllocatorPriority.Value())
+		newCpus, err := p.cpuAllocator.AllocateCpus(&addFromCpus, newCpuCount-oldCpuCount, bln.Def.AllocatorPriority.Value().Option())
 		if err != nil {
 			return balloonsError("resize/inflate: allocating %d CPUs for %s failed: %w", cpuCountDelta, bln, err)
 		}
@@ -1391,7 +1391,7 @@ func (p *balloons) resizeBalloon(bln *Balloon, newMilliCpus int) error {
 			return balloonsError("resize/deflate: failed to choose a cpuset for releasing %d CPUs: %w", -cpuCountDelta, err)
 		}
 		log.Debugf("- releasing %d CPUs from cpuset %q", -cpuCountDelta, removeFromCpus)
-		_, err = p.cpuAllocator.ReleaseCpus(&removeFromCpus, -cpuCountDelta, bln.Def.AllocatorPriority.Value())
+		_, err = p.cpuAllocator.ReleaseCpus(&removeFromCpus, -cpuCountDelta, bln.Def.AllocatorPriority.Value().Option())
 		if err != nil {
 			return balloonsError("resize/deflate: releasing %d CPUs from %s failed: %w", -cpuCountDelta, bln, err)
 		}

--- a/cmd/plugins/topology-aware/policy/mocks_test.go
+++ b/cmd/plugins/topology-aware/policy/mocks_test.go
@@ -713,11 +713,11 @@ func (m *mockCache) WriteFile(string, string, os.FileMode, []byte) error {
 
 type mockCPUAllocator struct{}
 
-func (m *mockCPUAllocator) AllocateCpus(from *cpuset.CPUSet, cnt int, prefer cpuallocator.CPUPriority) (cpuset.CPUSet, error) {
+func (m *mockCPUAllocator) AllocateCpus(from *cpuset.CPUSet, cnt int, options ...cpuallocator.Option) (cpuset.CPUSet, error) {
 	return cpuset.New(0), nil
 }
 
-func (m *mockCPUAllocator) ReleaseCpus(from *cpuset.CPUSet, cnt int, prefer cpuallocator.CPUPriority) (cpuset.CPUSet, error) {
+func (m *mockCPUAllocator) ReleaseCpus(from *cpuset.CPUSet, cnt int, options ...cpuallocator.Option) (cpuset.CPUSet, error) {
 	return cpuset.New(0), nil
 }
 

--- a/cmd/plugins/topology-aware/policy/resources.go
+++ b/cmd/plugins/topology-aware/policy/resources.go
@@ -510,7 +510,7 @@ func (cs *supply) Reserve(g Grant, o *libmem.Offer) (map[string]libmem.NodeMask,
 
 // takeCPUs takes up to cnt CPUs from a given CPU set to another.
 func (cs *supply) takeCPUs(from, to *cpuset.CPUSet, cnt int, prio cpuPrio) (cpuset.CPUSet, error) {
-	cset, err := cs.node.Policy().cpuAllocator.AllocateCpus(from, cnt, prio)
+	cset, err := cs.node.Policy().cpuAllocator.AllocateCpus(from, cnt, prio.Option())
 	if err != nil {
 		return cset, err
 	}

--- a/cmd/plugins/topology-aware/policy/topology-aware-policy.go
+++ b/cmd/plugins/topology-aware/policy/topology-aware-policy.go
@@ -584,7 +584,7 @@ func (p *policy) checkConstraints() error {
 		// Use CpuAllocator to pick reserved CPUs among
 		// allowed ones. Because using those CPUs is allowed,
 		// they remain (they are put back) in the allowed set.
-		cset, err := p.cpuAllocator.AllocateCpus(&p.allowed, p.reserveCnt, normalPrio)
+		cset, err := p.cpuAllocator.AllocateCpus(&p.allowed, p.reserveCnt, normalPrio.Option())
 		p.allowed = p.allowed.Union(cset)
 		if err != nil {
 			log.Fatal("cannot reserve %dm CPUs for ReservedResources from AvailableResources: %s", qty.MilliValue(), err)

--- a/pkg/cpuallocator/allocator.go
+++ b/pkg/cpuallocator/allocator.go
@@ -34,8 +34,6 @@ type AllocFlag uint
 const (
 	// AllocIdlePackages requests allocation of full idle packages.
 	AllocIdlePackages AllocFlag = 1 << iota
-	// AllocIdleNodes requests allocation of full idle NUMA nodes.
-	AllocIdleNodes
 	// AllocIdleClusters requests allocation of full idle CPU clusters.
 	AllocIdleClusters
 	// AllocCacheGroups requests allocation and splitting of idle and used cache groups

--- a/pkg/cpuallocator/allocator.go
+++ b/pkg/cpuallocator/allocator.go
@@ -94,6 +94,14 @@ func WithPriority(p CPUPriority) Option {
 	}
 }
 
+// WithAllocFlags sets the allocation flags for the allocation.
+func WithAllocFlags(flags AllocFlag) Option {
+	return func(a *allocatorHelper) error {
+		a.flags = flags
+		return nil
+	}
+}
+
 type cpuAllocator struct {
 	logger.Logger
 	sys           sysfs.System  // wrapped sysfs.System instance


### PR DESCRIPTION
Turn priority of CPUs to allocate/release into an opaque option passed to `cpuallocator.{Allocate,Release}Cpus()`. This should make it much easier to add new options to the allocator in the future.