### PR TITLE
resmgr,agent: propagate startup config error back to CR.

### DIFF
--- a/pkg/resmgr/resource-manager.go
+++ b/pkg/resmgr/resource-manager.go
@@ -128,17 +128,17 @@ func (m *resmgr) Start() error {
 	return nil
 }
 
-func (m *resmgr) updateConfig(newCfg interface{}) error {
+func (m *resmgr) updateConfig(newCfg interface{}) (bool, error) {
 	if newCfg == nil {
-		return fmt.Errorf("can't run without effective configuration...")
+		return false, fmt.Errorf("can't run without effective configuration...")
 	}
 
 	cfg, ok := newCfg.(cfgapi.ResmgrConfig)
 	if !ok {
 		if !m.running {
-			log.Fatalf("got initial configuration of unexpected type %T", newCfg)
+			return true, fmt.Errorf("got initial configuration of unexpected type %T", newCfg)
 		} else {
-			return fmt.Errorf("got configuration of unexpected type %T", newCfg)
+			return false, fmt.Errorf("got configuration of unexpected type %T", newCfg)
 		}
 	}
 
@@ -151,17 +151,17 @@ func (m *resmgr) updateConfig(newCfg interface{}) error {
 		log.InfoBlock("  <initial config> ", "%s", dump)
 
 		if err := m.start(cfg); err != nil {
-			log.Fatalf("failed to start with initial configuration: %v", err)
+			return true, fmt.Errorf("failed to start with initial configuration: %v", err)
 		}
 
 		m.running = true
-		return nil
+		return false, nil
 	}
 
 	log.Infof("configuration update %s (generation %d):", meta.GetName(), meta.GetGeneration())
 	log.InfoBlock("  <updated config> ", "%s", dump)
 
-	return m.reconfigure(cfg)
+	return false, m.reconfigure(cfg)
 }
 
 // Start resource management once we acquired initial configuration.

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test12-config-status/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test12-config-status/code.var.sh
@@ -1,4 +1,13 @@
-helm-terminate
+CONFIG_GROUP="group.test"
+
+cleanup() {
+    vm-command "kubectl delete -n kube-system topologyawarepolicies.config.nri/default" || :
+    vm-command "kubectl delete -n kube-system topologyawarepolicies.config.nri/$CONFIG_GROUP" || :
+    vm-command "kubectl label nodes --all config.nri/group-" || :
+    helm-terminate || :
+}
+
+cleanup
 helm_config=$(instantiate helm-config.yaml) helm-launch topology-aware
 
 sleep 1
@@ -12,6 +21,7 @@ vm-command "kubectl wait -n kube-system topologyawarepolicies/default \
     error "expected initial Success status"
 }
 
+# verify propagation of errors back to source CR
 vm-put-file $(RESERVED_CPU=750x instantiate custom-config.yaml) broken-config.yaml
 vm-command "kubectl apply -f broken-config.yaml"
 
@@ -26,3 +36,19 @@ vm-command "kubectl wait -n kube-system topologyawarepolicies/default \
 }
 
 helm-terminate
+
+# verify propagation of initial configuration errors back to source CR
+vm-put-file $(CONFIG_NAME="$CONFIG_GROUP" RESERVED_CPU=750x instantiate custom-config.yaml) \
+            broken-group-config.yaml
+vm-command "kubectl apply -f broken-group-config.yaml" || \
+    error "failed to install broken group config"
+vm-command "kubectl label nodes --all config.nri/group=test" || \
+    error "failed to label nodes for group config"
+
+expect_error=1 launch_timeout=5s helm_config=$(instantiate helm-config.yaml) helm-launch topology-aware
+get-config-node-status-error topologyawarepolicies/$CONFIG_GROUP | \
+    grep "failed to parse" | grep -q 750x || {
+    error "expected initial error not found in status"
+}
+
+cleanup

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test12-config-status/custom-config.yaml.in
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test12-config-status/custom-config.yaml.in
@@ -1,7 +1,7 @@
 apiVersion: config.nri/v1alpha1
 kind: TopologyAwarePolicy
 metadata:
-  name: default
+  name: ${CONFIG_NAME:-default}
   namespace: kube-system
 spec:
   pinCPU: true

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -502,7 +502,7 @@ get-config-node-status-result() {
 get-config-node-status-error() {
     local resource="$1" node="$(get-hostname-for-vm)"
     vm-command-q "kubectl get -n kube-system $resource \
-                      -ojsonpath=\"{.status.nodes['$node'].error}\""
+                      -ojsonpath=\"{.status.nodes['$node'].errors}\""
 }
 
 wait-config-node-status() {


### PR DESCRIPTION
Update the agent's config notification callback signature and the resmgr notification callaback to propagate errors for the initial configuration back to the source CR before exiting.