### PR TITLE
cache: update tests.

### DIFF
--- a/pkg/resmgr/cache/cache_test.go
+++ b/pkg/resmgr/cache/cache_test.go
@@ -42,9 +42,8 @@ var _ = Describe("Cache", func() {
 		c, _, _ = makePopulatedCache(nriPods, nil)
 
 		for _, nriPod := range nriPods {
-			pod, err := c.InsertPod(nriPod)
+			pod := c.InsertPod(nriPod, nil)
 			Expect(pod).ToNot(BeNil())
-			Expect(err).To(BeNil())
 		}
 	})
 
@@ -61,9 +60,8 @@ var _ = Describe("Cache", func() {
 		c, _, _ = makePopulatedCache(nriPods, nil)
 
 		for _, nriPod := range nriPods {
-			pod, err := c.InsertPod(nriPod)
+			pod := c.InsertPod(nriPod, nil)
 			Expect(pod).ToNot(BeNil())
-			Expect(err).To(BeNil())
 
 			chk, ok := c.LookupPod(pod.GetID())
 			Expect(chk).ToNot(BeNil())
@@ -107,9 +105,8 @@ func makePopulatedCache(nriPods []*nri.PodSandbox, nriCtrs []*nri.Container) (ca
 	)
 
 	for _, nriPod := range nriPods {
-		pod, err := c.InsertPod(nriPod)
+		pod := c.InsertPod(nriPod, nil)
 		Expect(pod).ToNot(BeNil())
-		Expect(err).To(BeNil())
 		pods = append(pods, pod)
 	}
 	for _, nriCtr := range nriCtrs {

--- a/pkg/resmgr/cache/pod_test.go
+++ b/pkg/resmgr/cache/pod_test.go
@@ -223,7 +223,7 @@ var _ = Describe("Pod", func() {
 
 		_, pods, _ = makePopulatedCache(nriPods, nil)
 
-		Expect(pods[0].PrettyName()).To(Equal(pods[0].GetName()))
+		Expect(pods[0].PrettyName()).To(Equal(pods[0].GetNamespace() + "/" + pods[0].GetName()))
 		Expect(pods[1].PrettyName()).To(Equal(pods[1].GetNamespace() + "/" + pods[1].GetName()))
 	})
 })


### PR DESCRIPTION
Update cache tests for updated `cache.InsertPod()` signature and `pod.PrettyName()` not omitting default namespace any more.