### PR TITLE
agent,resmgr: merge PodResources{List,Map}, cache last List() result.

### DIFF
--- a/pkg/agent/pod-resource-api.go
+++ b/pkg/agent/pod-resource-api.go
@@ -51,7 +51,7 @@ func (a *Agent) GoGetPodResources(ns, pod string, timeout time.Duration) <-chan 
 }
 
 // ListPodResources lists all pods' resources.
-func (a *Agent) ListPodResources(timeout time.Duration) (podresapi.PodResourcesList, error) {
+func (a *Agent) ListPodResources(timeout time.Duration) (*podresapi.PodResourcesList, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -59,12 +59,12 @@ func (a *Agent) ListPodResources(timeout time.Duration) (podresapi.PodResourcesL
 }
 
 // GoListPodResources lists all pods' resources asynchronously.
-func (a *Agent) GoListPodResources(timeout time.Duration) <-chan podresapi.PodResourcesList {
+func (a *Agent) GoListPodResources(timeout time.Duration) <-chan *podresapi.PodResourcesList {
 	if !a.podResCli.HasClient() {
 		return nil
 	}
 
-	ch := make(chan podresapi.PodResourcesList, 1)
+	ch := make(chan *podresapi.PodResourcesList, 1)
 
 	go func() {
 		defer close(ch)

--- a/pkg/agent/podresapi/resources_test.go
+++ b/pkg/agent/podresapi/resources_test.go
@@ -1,0 +1,318 @@
+// Copyright The NRI Plugins Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podresapi_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	api "k8s.io/kubelet/pkg/apis/podresources/v1"
+
+	. "github.com/containers/nri-plugins/pkg/agent/podresapi"
+)
+
+func TestGetContainer(t *testing.T) {
+	type testCase struct {
+		name              string
+		podResources      *api.PodResources
+		containerName     string
+		expectedContainer *ContainerResources
+	}
+
+	for _, tc := range []*testCase{
+		{
+			name:              "no containers",
+			podResources:      &api.PodResources{},
+			containerName:     "test",
+			expectedContainer: nil,
+		},
+		{
+			name: "container not found",
+			podResources: &api.PodResources{
+				Containers: []*api.ContainerResources{
+					{
+						Name: "test1",
+					},
+				},
+			},
+			containerName:     "test",
+			expectedContainer: nil,
+		},
+		{
+			name: "the only container found",
+			podResources: &api.PodResources{
+				Containers: []*api.ContainerResources{
+					{
+						Name: "test",
+					},
+				},
+			},
+			containerName: "test",
+			expectedContainer: &ContainerResources{
+				&api.ContainerResources{
+					Name: "test",
+				},
+			},
+		},
+		{
+			name: "one of many containers found",
+			podResources: &api.PodResources{
+				Containers: []*api.ContainerResources{
+					{
+						Name: "test1",
+					},
+					{
+						Name: "test2",
+					},
+					{
+						Name: "test3",
+					},
+				},
+			},
+			containerName: "test2",
+			expectedContainer: &ContainerResources{
+				&api.ContainerResources{
+					Name: "test2",
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &PodResources{tc.podResources}
+
+			ct := p.GetContainer(tc.containerName)
+			require.Equal(t, tc.expectedContainer, ct)
+		})
+	}
+}
+
+func TestPodResourcesList(t *testing.T) {
+	type lookup struct {
+		Namespace string
+		Pod       string
+	}
+	type testCase struct {
+		name         string
+		podResources []*api.PodResources
+		lookup       []*lookup
+		expect       []*PodResources
+	}
+
+	for _, tc := range []*testCase{
+		{
+			name:         "no pod resources",
+			podResources: []*api.PodResources{},
+			lookup: []*lookup{
+				{
+					Namespace: "test",
+					Pod:       "pod1",
+				},
+			},
+			expect: []*PodResources{
+				nil,
+			},
+		},
+		{
+			name: "pod not found",
+			podResources: []*api.PodResources{
+				{
+					Namespace: "test",
+					Name:      "pod1",
+				},
+			},
+			lookup: []*lookup{
+				{
+					Namespace: "test",
+					Pod:       "pod2",
+				},
+			},
+			expect: []*PodResources{
+				nil,
+			},
+		},
+		{
+			name: "the only pod found",
+			podResources: []*api.PodResources{
+				{
+					Namespace: "test",
+					Name:      "pod1",
+				},
+			},
+			lookup: []*lookup{
+				{
+					Namespace: "test",
+					Pod:       "pod1",
+				},
+			},
+			expect: []*PodResources{
+				{
+					&api.PodResources{
+						Namespace: "test",
+						Name:      "pod1",
+					},
+				},
+			},
+		},
+		{
+			name: "one of many pods found",
+			podResources: []*api.PodResources{
+				{
+					Namespace: "test",
+					Name:      "pod1",
+				},
+				{
+					Namespace: "test",
+					Name:      "pod2",
+				},
+				{
+					Namespace: "test",
+					Name:      "pod3",
+				},
+			},
+			lookup: []*lookup{
+				{
+					Namespace: "test",
+					Pod:       "pod2",
+				},
+			},
+			expect: []*PodResources{
+				{
+					&api.PodResources{
+						Namespace: "test",
+						Name:      "pod2",
+					},
+				},
+			},
+		},
+		{
+			name: "all of many pods found",
+			podResources: []*api.PodResources{
+				{
+					Namespace: "test1",
+					Name:      "pod1",
+				},
+				{
+					Namespace: "test1",
+					Name:      "pod2",
+				},
+				{
+					Namespace: "test1",
+					Name:      "pod3",
+				},
+				{
+					Namespace: "test2",
+					Name:      "pod4",
+				},
+				{
+					Namespace: "test3",
+					Name:      "pod5",
+				},
+				{
+					Namespace: "test3",
+					Name:      "pod6",
+				},
+				{
+					Namespace: "test1",
+					Name:      "pod7",
+				},
+			},
+			lookup: []*lookup{
+				{
+					Namespace: "test3",
+					Pod:       "pod5",
+				},
+				{
+					Namespace: "test1",
+					Pod:       "pod7",
+				},
+				{
+					Namespace: "test3",
+					Pod:       "pod6",
+				},
+				{
+					Namespace: "test2",
+					Pod:       "pod4",
+				},
+				{
+					Namespace: "test1",
+					Pod:       "pod3",
+				},
+
+				{
+					Namespace: "test1",
+					Pod:       "pod2",
+				},
+
+				{
+					Namespace: "test1",
+					Pod:       "pod1",
+				},
+			},
+			expect: []*PodResources{
+				{
+					&api.PodResources{
+						Namespace: "test3",
+						Name:      "pod5",
+					},
+				},
+				{
+					&api.PodResources{
+						Namespace: "test1",
+						Name:      "pod7",
+					},
+				},
+				{
+					&api.PodResources{
+						Namespace: "test3",
+						Name:      "pod6",
+					},
+				},
+				{
+					&api.PodResources{
+						Namespace: "test2",
+						Name:      "pod4",
+					},
+				},
+				{
+					&api.PodResources{
+						Namespace: "test1",
+						Name:      "pod3",
+					},
+				},
+				{
+					&api.PodResources{
+						Namespace: "test1",
+						Name:      "pod2",
+					},
+				},
+				{
+					&api.PodResources{
+						Namespace: "test1",
+						Name:      "pod1",
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewPodResourcesList(tc.podResources)
+
+			for i, l := range tc.lookup {
+				p := r.GetPodResources(l.Namespace, l.Pod)
+				require.Equal(t, tc.expect[i], p)
+			}
+		})
+	}
+}

--- a/pkg/resmgr/cache/cache.go
+++ b/pkg/resmgr/cache/cache.go
@@ -423,7 +423,7 @@ type Cache interface {
 	Save() error
 
 	// RefreshPods purges/inserts stale/new pods/containers using a pod sandbox list response.
-	RefreshPods([]*nri.PodSandbox, <-chan podresapi.PodResourcesList) ([]Pod, []Pod, []Container)
+	RefreshPods([]*nri.PodSandbox, <-chan *podresapi.PodResourcesList) ([]Pod, []Pod, []Container)
 	// RefreshContainers purges/inserts stale/new containers using a container list response.
 	RefreshContainers([]*nri.Container) ([]Container, []Container)
 
@@ -641,7 +641,7 @@ func (cch *cache) LookupContainerByCgroup(path string) (Container, bool) {
 }
 
 // RefreshPods purges/inserts stale/new pods/containers into the cache.
-func (cch *cache) RefreshPods(pods []*nri.PodSandbox, resCh <-chan podresapi.PodResourcesList) ([]Pod, []Pod, []Container) {
+func (cch *cache) RefreshPods(pods []*nri.PodSandbox, resCh <-chan *podresapi.PodResourcesList) ([]Pod, []Pod, []Container) {
 	valid := make(map[string]struct{})
 
 	add := []Pod{}
@@ -673,10 +673,9 @@ func (cch *cache) RefreshPods(pods []*nri.PodSandbox, resCh <-chan podresapi.Pod
 
 	if resCh != nil {
 		podResList := <-resCh
-		if len(podResList) > 0 {
-			podResMap := podResList.Map()
+		if podResList.Len() > 0 {
 			for _, pod := range cch.Pods {
-				pod.setPodResources(podResMap.GetPod(pod.GetNamespace(), pod.GetName()))
+				pod.setPodResources(podResList.GetPodResources(pod.GetNamespace(), pod.GetName()))
 			}
 		}
 	}


### PR DESCRIPTION
Merge `PodResourceMap` into `PodResourcesList`. Avoid unnecessary re-listing of pod resources by caching the result of the last `List()` and trying to reuse it to look up resources.