### PR TITLE
cpuallocator: golangci-lint fixes.

### DIFF
--- a/pkg/cpuallocator/allocator.go
+++ b/pkg/cpuallocator/allocator.go
@@ -57,9 +57,6 @@ type allocatorHelper struct {
 	prefer        CPUPriority   // CPU priority to prefer
 	cnt           int           // number of CPUs to allocate
 	result        cpuset.CPUSet // set of CPUs allocated
-
-	pkgs []sysfs.CPUPackage // physical CPU packages, sorted by preference
-	cpus []sysfs.CPU        // CPU cores, sorted by preference
 }
 
 // CPUAllocator is an interface for a generic CPU allocator
@@ -942,7 +939,6 @@ func (a *allocatorHelper) takeCacheGroups() {
 	a.result = result
 	a.from = from
 	a.cnt = 0
-	return
 }
 
 // Allocate full idle CPU cores.

--- a/pkg/cpuallocator/cpuallocator_test.go
+++ b/pkg/cpuallocator/cpuallocator_test.go
@@ -15,7 +15,6 @@
 package cpuallocator
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -30,7 +29,7 @@ import (
 
 func TestAllocatorHelper(t *testing.T) {
 	// Create tmpdir and decompress testdata there
-	tmpdir, err := ioutil.TempDir("", "nri-resource-policy-test-")
+	tmpdir, err := os.MkdirTemp("", "nri-resource-policy-test-")
 	if err != nil {
 		t.Fatalf("failed to create tmpdir: %v", err)
 	}
@@ -108,7 +107,7 @@ func TestClusteredAllocation(t *testing.T) {
 	}
 
 	// Create tmpdir and decompress testdata there
-	tmpdir, err := ioutil.TempDir("", "nri-resource-policy-test-")
+	tmpdir, err := os.MkdirTemp("", "nri-resource-policy-test-")
 	if err != nil {
 		t.Fatalf("failed to create tmpdir: %v", err)
 	}
@@ -324,7 +323,7 @@ func TestClusteredCoreKindAllocation(t *testing.T) {
 	}
 
 	// Create tmpdir and decompress testdata there
-	tmpdir, err := ioutil.TempDir("", "nri-resource-policy-test-")
+	tmpdir, err := os.MkdirTemp("", "nri-resource-policy-test-")
 	if err != nil {
 		t.Fatalf("failed to create tmpdir: %v", err)
 	}


### PR DESCRIPTION
Fix golangci-lint issues.