### PR TITLE
libmem: golangci-lint fixes.

### DIFF
--- a/pkg/resmgr/lib/memory/allocator.go
+++ b/pkg/resmgr/lib/memory/allocator.go
@@ -305,7 +305,10 @@ func (a *Allocator) allocate(req *Request) (retErr error) {
 
 	defer func() {
 		if retErr != nil {
-			a.revertJournal(req)
+			_, err := a.revertJournal(req)
+			if err != nil {
+				log.Warn("failed to revert journal on error: %v", err)
+			}
 		}
 	}()
 
@@ -337,7 +340,10 @@ func (a *Allocator) realloc(req *Request, nodes NodeMask, types TypeMask) (zone 
 
 	defer func() {
 		if retErr != nil {
-			a.revertJournal(nil)
+			_, err := a.revertJournal(nil)
+			if err != nil {
+				log.Warn("failed to revert journal on error: %v", err)
+			}
 		}
 	}()
 

--- a/pkg/resmgr/lib/memory/allocator_test.go
+++ b/pkg/resmgr/lib/memory/allocator_test.go
@@ -16,7 +16,6 @@ package libmem_test
 
 import (
 	"fmt"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -1155,7 +1154,7 @@ func TestRealloc(t *testing.T) {
 				require.Equal(t, tc.updates, updates, "updated nodes")
 			}
 
-			nodes, updates, err = a.Realloc(tc.id, tc.newNodes, tc.newTypes)
+			nodes, _, err = a.Realloc(tc.id, tc.newNodes, tc.newTypes)
 
 			if !tc.fail {
 				require.Nil(t, err, "unexpected realloc failure")
@@ -1450,14 +1449,4 @@ func (s *testSetup) nodes(t *testing.T) []*Node {
 	}
 
 	return nodes
-}
-
-var (
-	nextID = 1
-)
-
-func newID() string {
-	id := strconv.Itoa(nextID)
-	nextID++
-	return id
 }

--- a/pkg/resmgr/lib/memory/request_test.go
+++ b/pkg/resmgr/lib/memory/request_test.go
@@ -95,7 +95,6 @@ func TestHumanReadableSize(t *testing.T) {
 func TestRequestString(t *testing.T) {
 	type testCase struct {
 		name   string
-		aff    NodeMask
 		req    *Request
 		result string
 	}

--- a/pkg/resmgr/lib/memory/types.go
+++ b/pkg/resmgr/lib/memory/types.go
@@ -153,10 +153,6 @@ const (
 	TypeMaskAll  TypeMask = (TypeMaskHBM << 1) - 1 // all types of memory
 )
 
-var (
-	typeMaskToString map[TypeMask]string
-)
-
 // NewTypeMask returns a TypeMask containing the given memory types.
 func NewTypeMask(types ...Type) TypeMask {
 	m := TypeMask(0)


### PR DESCRIPTION
Fix golangci-lint issues.