### PR TITLE
scripts: clean up all tests VMs after test.

### DIFF
--- a/scripts/testing/e2e-runner
+++ b/scripts/testing/e2e-runner
@@ -201,7 +201,7 @@ cleanup_test_vms() {
 
     info "cleaning up test VMs..."
     must-cd "$WORKTREE"
-    for src in test/e2e/n[0-9]*c[0-9]*-c*; do
+    for src in test/e2e/n[0-9]*-c*; do
         (cd "$src" && vagrant destroy --force)
     done
 }


### PR DESCRIPTION
Update test VM directory glob pattern to `test/e2e/n[0-9]*-c*`. This should also catch and clean up the latest VM topology addition (n6-hbm-cxl-fedora-40-cloud-base-containerd) which is now left lingering after nightly test runs.