### PR TITLE
topology-aware: fix mockCache.RefresPods.

### DIFF
--- a/cmd/plugins/topology-aware/policy/mocks_test.go
+++ b/cmd/plugins/topology-aware/policy/mocks_test.go
@@ -701,7 +701,7 @@ func (m *mockCache) GetPolicyEntry(string, interface{}) bool {
 func (m *mockCache) Save() error {
 	return nil
 }
-func (m *mockCache) RefreshPods([]*nri.PodSandbox, <-chan podresapi.PodResourcesList) ([]cache.Pod, []cache.Pod, []cache.Container) {
+func (m *mockCache) RefreshPods([]*nri.PodSandbox, <-chan *podresapi.PodResourcesList) ([]cache.Pod, []cache.Pod, []cache.Container) {
 	panic("unimplemented")
 }
 func (m *mockCache) RefreshContainers([]*nri.Container) ([]cache.Container, []cache.Container) {


### PR DESCRIPTION
This PR fixes a problem that crept in via #423, which was branched off before #450 and was not rebased once that got merged.