### PR TITLE
balloons: do not require minFreq and maxFreq in CPU classes

### DIFF
--- a/config/crd/bases/config.nri_balloonspolicies.yaml
+++ b/config/crd/bases/config.nri_balloonspolicies.yaml
@@ -319,9 +319,6 @@ spec:
                               description: UncoreMinFreq is the minimum uncore frequency
                                 for this class.
                               type: integer
-                          required:
-                          - maxFreq
-                          - minFreq
                           type: object
                         type: object
                     required:

--- a/config/crd/bases/config.nri_templatepolicies.yaml
+++ b/config/crd/bases/config.nri_templatepolicies.yaml
@@ -90,9 +90,6 @@ spec:
                               description: UncoreMinFreq is the minimum uncore frequency
                                 for this class.
                               type: integer
-                          required:
-                          - maxFreq
-                          - minFreq
                           type: object
                         type: object
                     required:

--- a/config/crd/bases/config.nri_topologyawarepolicies.yaml
+++ b/config/crd/bases/config.nri_topologyawarepolicies.yaml
@@ -104,9 +104,6 @@ spec:
                               description: UncoreMinFreq is the minimum uncore frequency
                                 for this class.
                               type: integer
-                          required:
-                          - maxFreq
-                          - minFreq
                           type: object
                         type: object
                     required:

--- a/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
+++ b/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
@@ -319,9 +319,6 @@ spec:
                               description: UncoreMinFreq is the minimum uncore frequency
                                 for this class.
                               type: integer
-                          required:
-                          - maxFreq
-                          - minFreq
                           type: object
                         type: object
                     required:

--- a/deployment/helm/template/crds/config.nri_templatepolicies.yaml
+++ b/deployment/helm/template/crds/config.nri_templatepolicies.yaml
@@ -90,9 +90,6 @@ spec:
                               description: UncoreMinFreq is the minimum uncore frequency
                                 for this class.
                               type: integer
-                          required:
-                          - maxFreq
-                          - minFreq
                           type: object
                         type: object
                     required:

--- a/deployment/helm/topology-aware/crds/config.nri_topologyawarepolicies.yaml
+++ b/deployment/helm/topology-aware/crds/config.nri_topologyawarepolicies.yaml
@@ -104,9 +104,6 @@ spec:
                               description: UncoreMinFreq is the minimum uncore frequency
                                 for this class.
                               type: integer
-                          required:
-                          - maxFreq
-                          - minFreq
                           type: object
                         type: object
                     required:

--- a/pkg/apis/config/v1alpha1/resmgr/control/cpu/config.go
+++ b/pkg/apis/config/v1alpha1/resmgr/control/cpu/config.go
@@ -21,9 +21,9 @@ type Config struct {
 
 type Class struct {
 	// MinFreq is the minimum frequency for this class.
-	MinFreq uint `json:"minFreq"`
+	MinFreq uint `json:"minFreq,omitempty"`
 	// MaxFreq is the maximum frequency for this class.
-	MaxFreq uint `json:"maxFreq"`
+	MaxFreq uint `json:"maxFreq,omitempty"`
 	// EnergyPerformancePreference for CPUs in this class.
 	EnergyPerformancePreference uint `json:"energyPerformancePreference,omitempty"`
 	// UncoreMinFreq is the minimum uncore frequency for this class.

--- a/pkg/resmgr/control/cpu/cpu.go
+++ b/pkg/resmgr/control/cpu/cpu.go
@@ -129,21 +129,22 @@ func (ctl *cpuctl) enforceCpufreq(class string, cpus ...int) error {
 		return fmt.Errorf("non-existent cpu class %q", class)
 	}
 
-	min := int(c.MinFreq)
-	max := int(c.MaxFreq)
-	log.Debug("enforcing cpu frequency limits {%d, %d} from class %q on %v", min, max, class, cpus)
-
-	if err := utils.SetCPUsScalingMinFreq(cpus, min); err != nil {
-		return fmt.Errorf("Cannot set min freq %d: %w", min, err)
+	if min := int(c.MinFreq); min > 0 {
+		log.Debug("enforcing cpu frequency min %d from class %q on %v", min, class, cpus)
+		if err := utils.SetCPUsScalingMinFreq(cpus, min); err != nil {
+			return fmt.Errorf("Cannot set min freq %d: %w", min, err)
+		}
 	}
 
-	if err := utils.SetCPUsScalingMaxFreq(cpus, max); err != nil {
-		return fmt.Errorf("Cannot set max freq %d: %w", max, err)
+	if max := int(c.MaxFreq); max > 0 {
+		log.Debug("enforcing cpu frequency max %d from class %q on %v", max, class, cpus)
+		if err := utils.SetCPUsScalingMaxFreq(cpus, max); err != nil {
+			return fmt.Errorf("Cannot set max freq %d: %w", max, err)
+		}
 	}
 
 	if governor := c.FreqGovernor; governor != "" {
 		log.Debug("enforcing cpu frequency governor %q from class %q on %v", governor, class, cpus)
-
 		if err := utils.SetScalingGovernorForCPUs(cpus, governor); err != nil {
 			return fmt.Errorf("cannot set cpufreq governor %q: %w", governor, err)
 		}


### PR DESCRIPTION
Allow CPU classes to specify only freqGovernor instead of requiring min and max frequencies.