### PR TITLE
memtierd: allow overriding go version for image build.

### DIFF
--- a/cmd/plugins/memtierd/Dockerfile
+++ b/cmd/plugins/memtierd/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.22-bullseye AS builder
+ARG GO_VERSION=1.22
+
+FROM golang:${GO_VERSION}-bullseye AS builder
 
 ARG IMAGE_VERSION
 ARG BUILD_VERSION


### PR DESCRIPTION
Align with the rest of the plugins, allowing GO_VERSION to override the golang version used to build the image. This should prevent `nri-memtierd` image build failures after a go patch-level version bump in `go.mod`, when the image has been recently built with the same minor go version, but with a smaller patch level.