### PR TITLE
golang-fixup: bump go version for memory-qos, too.

### DIFF
--- a/cmd/plugins/memory-qos/Dockerfile
+++ b/cmd/plugins/memory-qos/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.22
+ARG GO_VERSION=1.23
 
 FROM golang:${GO_VERSION}-bullseye AS builder
 


### PR DESCRIPTION
Fixup commit with unsaved editor buffer snafu. Missed in the review of #458. 