### PR TITLE
.github: allow lint action code annotations.

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,6 +11,11 @@ on:
       - main
       - "release-*"
 
+permissions:
+  contents: read
+  # allow checks write access to let the action annotate code in PRs
+  checks: write
+
 jobs:
   golangci-lint:
     name: golangci-lint


### PR DESCRIPTION
Enable golangci-lint action write access to checks, to allow the action to annotate code in PRs.