### PR TITLE
WIP: balloons: add RDT support

### DIFF
--- a/cmd/plugins/balloons/policy/balloons-policy.go
+++ b/cmd/plugins/balloons/policy/balloons-policy.go
@@ -1679,6 +1679,9 @@ func (p *balloons) assignContainer(c cache.Container, bln *Balloon) {
 	bln.PodIDs[podID] = append(bln.PodIDs[podID], c.GetID())
 	bln.updateGroups(c, 1)
 	p.updatePinning(bln)
+	if bln.Def.RdtClass != "" {
+		c.SetRDTClass(bln.Def.RdtClass)
+	}
 }
 
 // dismissContainer removes a container from a balloon

--- a/config/crd/bases/config.nri_balloonspolicies.yaml
+++ b/config/crd/bases/config.nri_balloonspolicies.yaml
@@ -268,6 +268,13 @@ spec:
                         placed on separate balloons. The default is false: prefer
                         placing containers of a pod to the same balloon(s).
                       type: boolean
+                    rdtClass:
+                      description: |-
+                        RdtClass controls RDT class of processes in the containers
+                        of a balloon. The default is empty: no RDT class is set. If
+                        defined, processes will be added to the directory
+                        corresponding the class in the resctrl file system.
+                      type: string
                     shareIdleCPUsInSame:
                       description: |-
                         ShareIdleCpusInSame <topology-level>: if there are idle

--- a/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
+++ b/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
@@ -268,6 +268,13 @@ spec:
                         placed on separate balloons. The default is false: prefer
                         placing containers of a pod to the same balloon(s).
                       type: boolean
+                    rdtClass:
+                      description: |-
+                        RdtClass controls RDT class of processes in the containers
+                        of a balloon. The default is empty: no RDT class is set. If
+                        defined, processes will be added to the directory
+                        corresponding the class in the resctrl file system.
+                      type: string
                     shareIdleCPUsInSame:
                       description: |-
                         ShareIdleCpusInSame <topology-level>: if there are idle

--- a/docs/resource-policy/policy/balloons.md
+++ b/docs/resource-policy/policy/balloons.md
@@ -188,6 +188,10 @@ Balloons policy parameters:
   - `cpuClass` specifies the name of the CPU class according to which
     CPUs of balloons are configured. Class properties are defined in
     separate `cpu.classes` objects, see below.
+  - `rdtClass` specifies the name of the RDT class. Corresponding
+    class of service (COS) must exist in the resctrl file
+    system. Containers in the balloon are assigned to the class. Refer
+    to resctrl file system for configuring classes.
   - `pinMemory` overrides policy-level `pinMemory` in balloons of this
     type.
   - `memoryTypes` is a list of allowed memory types for containers in

--- a/pkg/apis/config/v1alpha1/resmgr/policy/balloons/config.go
+++ b/pkg/apis/config/v1alpha1/resmgr/policy/balloons/config.go
@@ -202,6 +202,11 @@ type BalloonDef struct {
 	// CpuClass controls how CPUs of a balloon are (re)configured
 	// whenever a balloon is created, inflated or deflated.
 	CpuClass string `json:"cpuClass,omitempty"`
+	// RdtClass controls RDT class of processes in the containers
+	// of a balloon. The default is empty: no RDT class is set. If
+	// defined, processes will be added to the directory
+	// corresponding the class in the resctrl file system.
+	RdtClass string `json:"rdtClass,omitempty"`
 	// MinBalloons is the number of balloon instances that always
 	// exist even if they would become empty. At init this number
 	// of instances will be created before assigning any

--- a/test/e2e/policies.test-suite/balloons/n4c16/test14-rdt/balloons-rdt.cfg
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test14-rdt/balloons-rdt.cfg
@@ -1,0 +1,23 @@
+config:
+  allocatorTopologyBalancing: true
+  reservedResources:
+    cpu: 750m
+  pinCPU: false
+  pinMemory: false
+  balloonTypes:
+  - name: balloon-gold
+    rdtClass: rdt-class-gold
+    matchExpressions:
+    - key: name
+      operator: In
+      values:
+      - container-gold
+  log:
+    debug:
+      - resource-manager
+      - cache
+      - policy
+      - sysfs
+    source: true
+    klog:
+      skip_headers: true

--- a/test/e2e/policies.test-suite/balloons/n4c16/test14-rdt/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test14-rdt/code.var.sh
@@ -1,0 +1,20 @@
+helm-terminate
+helm_config=$TEST_DIR/balloons-rdt.cfg helm-launch balloons
+
+cleanup() {
+    vm-command "kubectl delete pods --all --now"
+    helm-terminate
+    vm-command "rm -f /var/lib/nri-resource-policy/cache" || true
+}
+cleanup
+
+# pod0c{0,1,2}: one container per free L2 group
+CPUREQ="1500m" MEMREQ="100M" CPULIM="1500m" MEMLIM="100M"
+POD_ANNOTATION="balloon.balloons.resource-policy.nri.io/container.pod0c1: balloon-gold" CONTCOUNT=3 create balloons-busybox
+report allowed
+
+breakpoint
+echo "DELME: forced to fail to avoid cleanup
+exit 1
+
+cleanup


### PR DESCRIPTION
This PR adds rudimentary RDT support to balloons.

Assuming that resctrl file system is mounted and a Class of Service (COS) defined, processes in containers whose balloon has matching `rdtClass`, will be placed into that RDT class.