### PR TITLE
e2e: fix qemu option generation and vm-setup for single node test VMs.

### DIFF
--- a/test/e2e/lib/topology2qemuopts.py
+++ b/test/e2e/lib/topology2qemuopts.py
@@ -360,26 +360,34 @@ def qemuopts(numalist):
         raise ValueError("no initial memory in any NUMA node - cannot boot with hotpluggable memory")
 
     if separated_output_vars == True:
+        extras = "EXTRA:"
+        if nodecount > 1:
+            extras = (extras + ", ".join(map(lambda x: "\"" + x + "\"", numaparams)) +
+                      " " +
+                      ", ".join(map(lambda x: "\"" + x + "\"", deviceparams)) +
+                      "," +
+                      ", ".join(map(lambda x: "\"" + x + "\"", objectparams)) + "|"
+                      )
+
         return ("MACHINE:" + machineparam + "|" +
                 "CPU:" + cpuparam + "|" +
                 "MEM:" + memparam + "|" +
-                "EXTRA:" +
-                ", ".join(map(lambda x: "\"" + x + "\"", numaparams)) +
-                " " +
-                ", ".join(map(lambda x: "\"" + x + "\"", deviceparams)) +
-                "," +
-                ", ".join(map(lambda x: "\"" + x + "\"", objectparams)) + "|"
+                extras
                 )
     else:
-        return (machineparam + " " +
-            cpuparam + " " +
-            memparam + " " +
+        extras = ""
+        if nodecount > 1:
+            extras = (" " + memparam + " " +
             " ".join(numaparams) +
             " " +
             " ".join(deviceparams) +
             " " +
             " ".join(objectparams)
             )
+        return (machineparam + " " +
+                cpuparam +
+                extras
+                )
 
 def main(input_file):
     try:

--- a/test/e2e/lib/vm.bash
+++ b/test/e2e/lib/vm.bash
@@ -115,7 +115,7 @@ vm-setup() {
     CPU=$(echo $VM_QEMU_CPUMEM | sed 's/MACHINE:.*CPU:-smp \([^|]*\).*/\1/g')
     MEM=$(echo $VM_QEMU_CPUMEM | sed 's/MACHINE:.*CPU:.*MEM:-m \([^|]*\).*/\1/g')
     EXTRA_ARGS=$(echo $VM_QEMU_CPUMEM | sed 's/MACHINE:.*CPU:.*MEM:.*EXTRA:\([^|]*\).*/\1/g')
-    EXTRA_ARGS+=", \"-monitor\", \"unix:monitor.sock,server,nowait\""
+    EXTRA_ARGS+="${EXTRA_ARGS:+,} \"-monitor\", \"unix:monitor.sock,server,nowait\""
 
     VM_MONITOR="(cd \"$output_dir\" && socat STDIO unix-connect:monitor.sock)"
 


### PR DESCRIPTION
This patch set fixes

- `topology2qemuopts` to generate correct qemu options for single node VM topologies
- `vm-setup()` to not expect unconditional memory-related options in EXTRA_ARGS

With these fixes in place it is now possible to generate and boot single node multi-socket test VMs.