### PR TITLE
topology-aware: rework building the topology pool tree.

### DIFF
--- a/cmd/plugins/topology-aware/policy/mocks_test.go
+++ b/cmd/plugins/topology-aware/policy/mocks_test.go
@@ -80,6 +80,10 @@ func (fake *mockSystemNode) DistanceFrom(id idset.ID) int {
 	return 0
 }
 
+func (fake *mockSystemNode) ClosestNodes() ([]idset.IDSet, []int) {
+	return []idset.IDSet{}, []int{}
+}
+
 type mockCPUPackage struct {
 }
 

--- a/cmd/plugins/topology-aware/policy/mocks_test.go
+++ b/cmd/plugins/topology-aware/policy/mocks_test.go
@@ -321,6 +321,19 @@ func (fake *mockSystem) NodeIDs() []idset.ID {
 	}
 	return ids
 }
+
+func (fake *mockSystem) FilterNodes(ids []idset.ID, filters ...sysfs.NodeFilter) idset.IDSet {
+	return idset.NewIDSet()
+}
+
+func (fake *mockSystem) FilterNode(id idset.ID, filters ...sysfs.NodeFilter) bool {
+	return true
+}
+
+func (fake *mockSystem) ClosestNodes(id idset.ID, filters ...sysfs.NodeFilter) ([]idset.IDSet, []int) {
+	return []idset.IDSet{}, []int{}
+}
+
 func (fake *mockSystem) SetCPUFrequencyLimits(min, max uint64, cpus idset.IDSet) error {
 	return nil
 }

--- a/pkg/sysfs/system_test.go
+++ b/pkg/sysfs/system_test.go
@@ -211,3 +211,78 @@ var _ = DescribeTable("P-/E-Core CPU detection",
 	Entry("P-Cores", "sample1", PerformanceCore, "0-7"),
 	Entry("E-Cores", "sample1", EfficientCore, "8-15"),
 )
+
+var _ = DescribeTable("neighbor nodes by distance",
+	func(node ID, closest []idset.IDSet, distances []int) {
+		sys := sampleSysfs["sample2"]
+		Expect(sys).ToNot(BeNil())
+		nodes, dists := sys.Node(node).ClosestNodes()
+		Expect(nodes).To(Equal(closest))
+		Expect(dists).To(Equal(distances))
+	},
+
+	Entry("node #0", 0,
+		[]idset.IDSet{
+			idset.NewIDSet(2),
+			idset.NewIDSet(4),
+			idset.NewIDSet(1, 3),
+			idset.NewIDSet(5, 6, 7),
+		},
+		[]int{11, 17, 21, 28},
+	),
+	Entry("node #1", 1,
+		[]idset.IDSet{
+			idset.NewIDSet(3),
+			idset.NewIDSet(6),
+			idset.NewIDSet(0, 2),
+			idset.NewIDSet(4, 5, 7),
+		},
+		[]int{11, 17, 21, 28},
+	),
+	Entry("node #2", 2,
+		[]idset.IDSet{
+			idset.NewIDSet(0),
+			idset.NewIDSet(5),
+			idset.NewIDSet(1, 3),
+			idset.NewIDSet(4, 6, 7),
+		},
+		[]int{11, 17, 21, 28},
+	),
+	Entry("node #3", 3,
+		[]idset.IDSet{
+			idset.NewIDSet(1),
+			idset.NewIDSet(7),
+			idset.NewIDSet(0, 2),
+			idset.NewIDSet(4, 5, 6),
+		},
+		[]int{11, 17, 21, 28},
+	),
+	Entry("node #4", 4,
+		[]idset.IDSet{
+			idset.NewIDSet(0),
+			idset.NewIDSet(1, 2, 3, 5, 6, 7),
+		},
+		[]int{17, 28},
+	),
+	Entry("node #5", 5,
+		[]idset.IDSet{
+			idset.NewIDSet(2),
+			idset.NewIDSet(0, 1, 3, 4, 6, 7),
+		},
+		[]int{17, 28},
+	),
+	Entry("node #6", 6,
+		[]idset.IDSet{
+			idset.NewIDSet(1),
+			idset.NewIDSet(0, 2, 3, 4, 5, 7),
+		},
+		[]int{17, 28},
+	),
+	Entry("node #7", 7,
+		[]idset.IDSet{
+			idset.NewIDSet(3),
+			idset.NewIDSet(0, 1, 2, 4, 5, 6),
+		},
+		[]int{17, 28},
+	),
+)


### PR DESCRIPTION
This PR reworks and simplifies how the tree of pools is built in the topology-aware policy, using the detected hardware topology.

We now build the tree by walking the topology from sockets to dies to NUMA nodes closest to dies. We assign local CPU and memory close these CPUs in tandem to each pool as we build the tree. Once the tree is built, we go through each pool node again and assign CPUless NUMA nodes to the same nodes where their closest NUMA nodes with CPUs are assigned to.

Like earlier, the tree is constructed to be minimal. If the system has a single socket, we omit the virtual root and use the sole socket as the root pool to represent the whole system (since it would have the same resources as its parent virtual root node). If a socket has a single die, we omit that die from the subtree under the socket (since it would have the same resources as its parent socket node). If a die has a single close NUMA node, we omit the tree node that would represent CPUs close to a die-local NUMA node (since it would have the same resources as its parent die or socket node).