### PR TITLE
[resmgr RDT+blkio 1/2]: resolve QoS-to-RDT class markers in updates.

### DIFF
--- a/pkg/resmgr/nri.go
+++ b/pkg/resmgr/nri.go
@@ -684,6 +684,9 @@ func (p *nriPlugin) getPendingUpdates(skip *api.Container) []*api.ContainerUpdat
 				u.SetLinuxBlockIOClass(bioc)
 			}
 			if rdtc := c.GetRDTClass(); rdtc != "" {
+				if rdtc == cache.RDTClassPodQoS {
+					rdtc = string(c.GetQOSClass())
+				}
 				u.SetLinuxRDTClass(rdtc)
 			}
 			updates = append(updates, u)


### PR DESCRIPTION
When generating container updates, the current code leaves a QoS-to-RDT-Class marker unresolved, which is a leftover from CRI Resource Manager where the RDT controller did the final resolution. We have no such logic in NRI enabled runtimes, so resolve QoS class markers before generating an container update.