### PR TITLE
[resmgr RDT+blkio 2/2]: set initial classes adjustment.

### DIFF
--- a/pkg/resmgr/nri.go
+++ b/pkg/resmgr/nri.go
@@ -684,6 +684,9 @@ func (p *nriPlugin) getPendingUpdates(skip *api.Container) []*api.ContainerUpdat
 				u.SetLinuxBlockIOClass(bioc)
 			}
 			if rdtc := c.GetRDTClass(); rdtc != "" {
+				if rdtc == cache.RDTClassPodQoS {
+					rdtc = string(c.GetQOSClass())
+				}
 				u.SetLinuxRDTClass(rdtc)
 			}
 			updates = append(updates, u)

--- a/pkg/resmgr/nri.go
+++ b/pkg/resmgr/nri.go
@@ -665,6 +665,17 @@ func (p *nriPlugin) getPendingAdjustment(container *api.Container) *api.Containe
 		for _, ctrl := range c.GetPending() {
 			c.ClearPending(ctrl)
 		}
+		if adjust != nil {
+			if bioc := c.GetBlockIOClass(); bioc != "" {
+				adjust.SetLinuxBlockIOClass(bioc)
+			}
+			if rdtc := c.GetRDTClass(); rdtc != "" {
+				if rdtc == cache.RDTClassPodQoS {
+					rdtc = string(c.GetQOSClass())
+				}
+				adjust.SetLinuxRDTClass(rdtc)
+			}
+		}
 		return adjust
 	}
 


### PR DESCRIPTION
Note #1: this PR is stacked on #478.
Note #2: this PR shouldn't be merged before a fix is merged to containerd to interpret an initial empty blockio config file as a soft disable for blockio configuration.

The current code sets RDT and block I/O for container updates, but not for initial adjustment. This PR implements the missing adjustment bits.

