### PR TITLE
resmgr: eliminate extra RDT class 'overlay'.

### DIFF
--- a/pkg/resmgr/cache/cache.go
+++ b/pkg/resmgr/cache/cache.go
@@ -42,8 +42,6 @@ const (
 	CPU = "cpu"
 	// NRI marks changes that can be applied by NRI.
 	NRI = "nri"
-	// RDT marks changes that can be applied by the RDT controller.
-	RDT = "rdt"
 	// BlockIO marks changes that can be applied by the BlockIO controller.
 	BlockIO = "blockio"
 
@@ -344,7 +342,6 @@ type container struct {
 	Tags          map[string]string // container tags (local dynamic labels)
 
 	CgroupDir    string // cgroup directory relative to a(ny) controller.
-	RDTClass     string // RDT class this container is assigned to.
 	BlockIOClass string // Block I/O class this container is assigned to.
 	ToptierLimit int64  // Top tier memory limit.
 

--- a/pkg/resmgr/cache/container.go
+++ b/pkg/resmgr/cache/container.go
@@ -918,12 +918,25 @@ func (c *container) GetCgroupDir() string {
 }
 
 func (c *container) SetRDTClass(class string) {
-	c.RDTClass = class
-	c.markPending(RDT)
+	switch req := c.getPendingRequest().(type) {
+	case *nri.ContainerAdjustment:
+		req.SetLinuxRDTClass(class)
+	case *nri.ContainerUpdate:
+		req.SetLinuxRDTClass(class)
+	default:
+		log.Error("%s: can't set RDT class (%s): incorrect pending request type %T",
+			c.PrettyName(), class, c.request)
+		return
+	}
+
+	c.ensureLinuxResources()
+	c.Ctr.Linux.Resources.RdtClass = nri.String(class)
+
+	c.markPending(NRI)
 }
 
 func (c *container) GetRDTClass() string {
-	return c.RDTClass
+	return c.Ctr.GetLinux().GetResources().GetRdtClass().GetValue()
 }
 
 func (c *container) SetBlockIOClass(class string) {


### PR DESCRIPTION
Eliminate cache level RDT class 'overlay' and start tracking container RDT class using the NRI provided container member field alone. Update RDT class setter to generate a container adjustment or update.