### PR TITLE
e2e: revert qemu topology option generation breaking commit.

### DIFF
--- a/test/e2e/lib/topology2qemuopts.py
+++ b/test/e2e/lib/topology2qemuopts.py
@@ -360,34 +360,26 @@ def qemuopts(numalist):
         raise ValueError("no initial memory in any NUMA node - cannot boot with hotpluggable memory")
 
     if separated_output_vars == True:
-        extras = "EXTRA:"
-        if nodecount > 1:
-            extras = (extras + ", ".join(map(lambda x: "\"" + x + "\"", numaparams)) +
-                      " " +
-                      ", ".join(map(lambda x: "\"" + x + "\"", deviceparams)) +
-                      "," +
-                      ", ".join(map(lambda x: "\"" + x + "\"", objectparams)) + "|"
-                      )
-
         return ("MACHINE:" + machineparam + "|" +
                 "CPU:" + cpuparam + "|" +
                 "MEM:" + memparam + "|" +
-                extras
+                "EXTRA:" +
+                ", ".join(map(lambda x: "\"" + x + "\"", numaparams)) +
+                " " +
+                ", ".join(map(lambda x: "\"" + x + "\"", deviceparams)) +
+                "," +
+                ", ".join(map(lambda x: "\"" + x + "\"", objectparams)) + "|"
                 )
     else:
-        extras = ""
-        if nodecount > 1:
-            extras = (" " + memparam + " " +
+        return (machineparam + " " +
+            cpuparam + " " +
+            memparam + " " +
             " ".join(numaparams) +
             " " +
             " ".join(deviceparams) +
             " " +
             " ".join(objectparams)
             )
-        return (machineparam + " " +
-                cpuparam +
-                extras
-                )
 
 def main(input_file):
     try:


### PR DESCRIPTION
This reverts commit 74c95ab6897d218b63f1d371021cc3ea6fda6960.

The reverted commit failed to realize that semantically the 'nodes' topology parameter is 'nodes-per-die'. Therefore it broke qemu topology option generation for configs which had '"nodes": 1'.