### PR TITLE
e2e-runner: generate summary for all tests.

### DIFF
--- a/scripts/testing/e2e-runner
+++ b/scripts/testing/e2e-runner
@@ -247,7 +247,7 @@ generate_summary() {
         return
     fi
 
-    for vm in $RESULT_DIR/n[0-9]*c[0-9]*-c*; do
+    for vm in $RESULT_DIR/n[0-9]*-c*; do
         echo "${vm##*/}:" >> "$summary"
         for dir in $(find $vm/$TEST_SUITE_DIR -name 'test[0-9]*-*' -type d); do
             for f in  $dir/*.output; do


### PR DESCRIPTION
Relax test VM name globbing to discover and include all tests in the generated test summary.