### PR TITLE
topology-aware: allocate burstable container memory by requests.

### DIFF
--- a/cmd/plugins/topology-aware/policy/pools.go
+++ b/cmd/plugins/topology-aware/policy/pools.go
@@ -747,6 +747,19 @@ func (p *policy) compareScores(request Request, pools []Node, scores map[int]Sco
 		}
 		log.Debug("  - offer memory types are a tie (%s vs %s)", t1, t2)
 
+		if req, lim := request.MemAmountToAllocate(), request.MemoryLimit(); req != lim {
+			capa1, capa2 := p.poolZoneCapacity(node1, memType), p.poolZoneCapacity(node2, memType)
+			if (lim != 0 && capa1 >= lim && capa2 < lim) || (lim == 0 && capa1 > capa2) {
+				log.Debug("   - %s loses on memory offer burstability", node2.Name())
+				return true
+			}
+			if (lim != 0 && capa1 < lim && capa2 >= lim) || (lim == 0 && capa2 > capa1) {
+				log.Debug("   - %s loses on memory offer burstability", node1.Name())
+				return false
+			}
+			log.Debug("  - memory offers burstability are a TIE")
+		}
+
 		if m1.Size() < m2.Size() {
 			log.Debug("   - %s loses on memory offer (%s less tight than %s)",
 				node2.Name(), m2, m1)

--- a/cmd/plugins/topology-aware/policy/resources.go
+++ b/cmd/plugins/topology-aware/policy/resources.go
@@ -111,6 +111,8 @@ type Request interface {
 	MemoryType() memoryType
 	// MemAmountToAllocate retuns how much memory we need to reserve for a request.
 	MemAmountToAllocate() int64
+	// MemoryLimit returns the memory limit for the request.
+	MemoryLimit() int64
 	// ColdStart returns the cold start timeout.
 	ColdStart() time.Duration
 }
@@ -750,9 +752,13 @@ func (cr *request) Isolate() bool {
 
 // MemAmountToAllocate retuns how much memory we need to reserve for a request.
 func (cr *request) MemAmountToAllocate() int64 {
-	if cr.memLim == 0 && cr.memReq != 0 {
+	if cr.memReq != 0 {
 		return cr.memReq
 	}
+	return cr.memLim
+}
+
+func (cr *request) MemoryLimit() int64 {
 	return cr.memLim
 }
 

--- a/pkg/kubernetes/resources_test.go
+++ b/pkg/kubernetes/resources_test.go
@@ -1,0 +1,44 @@
+// Copyright The NRI Plugins Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	. "github.com/containers/nri-plugins/pkg/kubernetes"
+)
+
+func TestCalculateOomAdjToMemReqEstimates(t *testing.T) {
+	const (
+		K int64 = 1024
+		M int64 = 1024 * K
+		G int64 = 1024 * M
+	)
+
+	for capacity := int64(4 * G); capacity <= (1024+512)*G; capacity += 4 * G {
+		SetMemoryCapacity(capacity)
+		for adj := int64(MinBurstableOOMScoreAdj); adj <= MaxBurstableOOMScoreAdj; adj++ {
+			req := OomAdjToMemReq(adj, capacity)
+			require.NotNil(t, req,
+				"capacity %d, adj %d: OomAdjToMemReq() returned nil", capacity, adj)
+
+			chk := MemReqToOomAdj(*req)
+			require.Equal(t, adj, chk,
+				"capacity %d, adj %d: req=%d, chk=%d != adj\n", capacity, adj, *req, chk)
+		}
+	}
+}

--- a/pkg/resmgr/cache/container.go
+++ b/pkg/resmgr/cache/container.go
@@ -292,7 +292,8 @@ func isReadOnlyDevice(rules []*nri.LinuxDeviceCgroup, d *nri.LinuxDevice) bool {
 func (c *container) estimateResourceRequirements() {
 	r := c.Ctr.GetLinux().GetResources()
 	qosClass := c.GetQOSClass()
-	c.Requirements = estimateResourceRequirements(r, qosClass)
+	oomAdj := c.Ctr.GetLinux().GetOomScoreAdj().GetValue()
+	c.Requirements = estimateResourceRequirements(r, qosClass, oomAdj)
 }
 
 func (c *container) setDefaultClasses() {
@@ -472,8 +473,9 @@ func (c *container) GetPodResources() *podresapi.ContainerResources {
 
 func (c *container) SetResourceUpdates(r *nri.LinuxResources) bool {
 	r = mergeNRIResources(r, c.Ctr.GetLinux().GetResources())
-
-	updated := estimateResourceRequirements(r, c.GetQOSClass())
+	qosClass := c.GetQOSClass()
+	oomAdj := c.Ctr.GetLinux().GetOomScoreAdj().GetValue()
+	updated := estimateResourceRequirements(r, qosClass, oomAdj)
 
 	same := true
 	orig := c.Requirements

--- a/test/e2e/files/burstable.yaml.in
+++ b/test/e2e/files/burstable.yaml.in
@@ -32,6 +32,8 @@ spec:
         memory: ${MEMREQ}
       limits:
         cpu: ${CPULIM}
+        $( ( [ -n "$MEMLIM" ] && [ "$MEMLIM" != "0" ] ) && echo "
         memory: ${MEMLIM}
+        ")
   "; done )
   terminationGracePeriodSeconds: 1

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test14-burstable/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test14-burstable/code.var.sh
@@ -1,0 +1,27 @@
+# Test that burstable container allocation behaves as expected.
+
+helm-terminate
+helm_config=$(COLOCATE_PODS=true instantiate helm-config.yaml) helm-launch topology-aware
+
+vm-command "kubectl delete pods --all --now"
+
+# pod0, pod1, pod2, and pod3 have total memory limit which
+# exceeds the total node capacity. They would not fit the
+# node if memory was allocated by limit, but they should
+# fit if memory is allocated by request.
+CPUREQ=1 CPULIM=2 MEMREQ=100M MEMLIM=2.5G create burstable
+CPUREQ=1 CPULIM=2 MEMREQ=200M MEMLIM=5G create burstable
+CPUREQ=1 CPULIM=2 MEMREQ=100M MEMLIM=2.5G create burstable
+CPUREQ=1 CPULIM=2 MEMREQ=200M MEMLIM=0 create burstable
+
+# pod0 and pod2 have limits that require 2 NUMA nodes.
+# pod1 requires all 4 NUMA nodes. pod3 is unlimited, so
+# it should also get all NUMA nodes.
+report allowed
+verify \
+    'len(nodes["pod0c0"]) == 2' \
+    'len(nodes["pod1c0"]) == 4' \
+    'len(nodes["pod2c0"]) == 2' \
+    'len(nodes["pod3c0"]) == 4'
+
+helm-terminate


### PR DESCRIPTION
This patch series updates resource management common infra and the topology aware policy to

- pre-calculate a table of OOM Score adjustment to minimum memory request esimates
- use this table to estimate memory request for burstable containers based on their OOM score adjustment
- allocate memory for containers using memory requests (instead of limits)
- prefer pools with enough attached memory to fulfill both a containers memory request and limit

With these patches in place, the K8s scheduler and the NRI reference policies should be better aligned about the amount of available memory on the node.

Notes:
The estimate table is calculated assuming the simpler/simplest request-to-oom-adj formula, IOW assuming 0 pod level extra resource requests.