### PR TITLE
system: add a helper for finding CPUs sharing caches

### DIFF
--- a/cmd/plugins/topology-aware/policy/mocks_test.go
+++ b/cmd/plugins/topology-aware/policy/mocks_test.go
@@ -263,6 +263,9 @@ func (fake *mockSystem) AllThreadsForCPUs(cpuset.CPUSet) cpuset.CPUSet {
 func (fake *mockSystem) SingleThreadForCPUs(cpuset.CPUSet) cpuset.CPUSet {
 	return cpuset.New()
 }
+func (fake *mockSystem) AllCPUsSharingNthLevelCacheWithCPUs(int, cpuset.CPUSet) cpuset.CPUSet {
+	return cpuset.New()
+}
 func (fake *mockSystem) Offlined() cpuset.CPUSet {
 	return cpuset.New()
 }

--- a/pkg/sysfs/system.go
+++ b/pkg/sysfs/system.go
@@ -120,6 +120,7 @@ type System interface {
 	CoreKinds() []CoreKind
 	AllThreadsForCPUs(cpuset.CPUSet) cpuset.CPUSet
 	SingleThreadForCPUs(cpuset.CPUSet) cpuset.CPUSet
+	AllCPUsSharingNthLevelCacheWithCPUs(int, cpuset.CPUSet) cpuset.CPUSet
 
 	Offlined() cpuset.CPUSet
 	Isolated() cpuset.CPUSet
@@ -709,6 +710,19 @@ func (sys *system) AllThreadsForCPUs(cpus cpuset.CPUSet) cpuset.CPUSet {
 	for _, id := range cpus.UnsortedList() {
 		if cpu, ok := sys.cpus[id]; ok {
 			all = all.Union(cpu.ThreadCPUSet())
+		}
+	}
+	return all
+}
+
+func (sys *system) AllCPUsSharingNthLevelCacheWithCPUs(n int, cpus cpuset.CPUSet) cpuset.CPUSet {
+	all := cpuset.New()
+	for _, id := range cpus.UnsortedList() {
+		if all.Contains(id) {
+			continue
+		}
+		if cpu, ok := sys.cpus[id]; ok {
+			all = all.Union(cpu.GetNthLevelCacheCPUSet(n))
 		}
 	}
 	return all


### PR DESCRIPTION
This is a prerequisite for selecting CPUs so that sharing the same cache between many memory-bandwidth hungry workloads could be avoided.