### PR TITLE
sysfs: only discover topology of online cpus

### DIFF
--- a/pkg/sysfs/system.go
+++ b/pkg/sysfs/system.go
@@ -1486,6 +1486,10 @@ func (sys *system) discoverPackages() error {
 	sys.packages = make(map[idset.ID]*cpuPackage)
 
 	for _, cpu := range sys.cpus {
+		if !cpu.Online() {
+			continue
+		}
+
 		pkg, found := sys.packages[cpu.pkg]
 		if !found {
 			pkg = &cpuPackage{


### PR DESCRIPTION
Fix a bug where all offline cpus were listed under package/die/cluster 0. The Linux kernel hides the topology information of offline cpus so we do not know where they belong.