### PR TITLE
e2e: fix isolcpu-resetting snippet in test.

### DIFF
--- a/test/e2e/lib/vm.bash
+++ b/test/e2e/lib/vm.bash
@@ -607,3 +607,61 @@ vm-pull-journal() {
     vm-command-q "journalctl $_service $_since" || \
         command-error "failed to pull journal logs (service: ${service:-all}, since: ${since:--}"
 }
+
+fedora-set-kernel-cmdline() {
+    local e2e_defaults="$*"
+    vm-command "mkdir -p /etc/default; touch /etc/default/grub; sed -i '/e2e:fedora-set-kernel-cmdline/d' /etc/default/grub"
+    vm-command "echo 'GRUB_CMDLINE_LINUX_DEFAULT=\"\${GRUB_CMDLINE_LINUX_DEFAULT} ${e2e_defaults}\" # by e2e:fedora-set-kernel-cmdline' >> /etc/default/grub" || {
+        command-error "writing new command line parameters failed"
+    }
+    vm-command "grub2-mkconfig -o /boot/grub2/grub.cfg" || {
+        command-error "updating grub failed"
+    }
+}
+
+ubuntu-set-kernel-cmdline() {
+    local e2e_defaults="$*"
+    vm-command "echo 'GRUB_CMDLINE_LINUX_DEFAULT=\"\${GRUB_CMDLINE_LINUX_DEFAULT} ${e2e_defaults}\"' > /etc/default/grub.d/60-e2e-defaults.cfg" || {
+        command-error "writing new command line parameters failed"
+    }
+    vm-command "update-grub" || {
+        command-error "updating grub failed"
+    }
+}
+
+vm-set-kernel-cmdline() {
+    if [[ "$distro" == *fedora* ]]; then
+        fedora-set-kernel-cmdline "$*"
+    else
+        ubuntu-set-kernel-cmdline "$*"
+    fi
+}
+
+fedora-set-kernel-cmdline() {
+    local e2e_defaults="$*"
+    vm-command "mkdir -p /etc/default; touch /etc/default/grub; sed -i '/e2e:fedora-set-kernel-cmdline/d' /etc/default/grub"
+    vm-command "echo 'GRUB_CMDLINE_LINUX_DEFAULT=\"\${GRUB_CMDLINE_LINUX_DEFAULT} ${e2e_defaults}\" # by e2e:fedora-set-kernel-cmdline' >> /etc/default/grub" || {
+        command-error "writing new command line parameters failed"
+    }
+    vm-command "grub2-mkconfig -o /boot/grub2/grub.cfg" || {
+        command-error "updating grub failed"
+    }
+}
+
+ubuntu-set-kernel-cmdline() {
+    local e2e_defaults="$*"
+    vm-command "echo 'GRUB_CMDLINE_LINUX_DEFAULT=\"\${GRUB_CMDLINE_LINUX_DEFAULT} ${e2e_defaults}\"' > /etc/default/grub.d/60-e2e-defaults.cfg" || {
+        command-error "writing new command line parameters failed"
+    }
+    vm-command "update-grub" || {
+        command-error "updating grub failed"
+    }
+}
+
+vm-set-kernel-cmdline() {
+    if [[ "$distro" == *fedora* ]]; then
+        fedora-set-kernel-cmdline "$*"
+    else
+        ubuntu-set-kernel-cmdline "$*"
+    fi
+}

--- a/test/e2e/policies.test-suite/balloons/n4c16/test22-isolcpus/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test22-isolcpus/code.var.sh
@@ -16,11 +16,7 @@ cleanup-pods() {
 
 cleanup() {
     cleanup-pods
-    if [[ "$distro" == *fedora* ]]; then
-        fedora-set-kernel-cmdline ""
-    else
-        ubuntu-set-kernel-cmdline ""
-    fi
+    vm-set-kernel-cmdline ""
     reboot-node
     vm-command "grep -v isolcpus /proc/cmdline"
     if [ $? -ne 0 ]; then
@@ -34,11 +30,7 @@ ns=isolcpus
 cleanup-pods
 
 vm-command "grep isolcpus=0,1 /proc/cmdline" || {
-    if [[ "$distro" == *fedora* ]]; then
-        fedora-set-kernel-cmdline "isolcpus=0,1"
-    else
-        ubuntu-set-kernel-cmdline "isolcpus=0,1"
-    fi
+    vm-set-kernel-cmdline "isolcpus=0,1"
     reboot-node
     vm-command "grep isolcpus=0,1 /proc/cmdline" || {
         error "failed to set isolcpus kernel commandline parameter"

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test00-basic-placement/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test00-basic-placement/code.var.sh
@@ -9,8 +9,8 @@ vm-command "kubectl delete pods pod0 pod1 pod2 pod3 pod4 pod5 --ignore-not-found
 # This can happen if test08-isolcpus failed and we are re-running
 # the tests from the start.
 vm-command "grep isolcpus /proc/cmdline" && {
-    vm-del-kernel-cmdline-arg "isolcpus=8,9"
-    vm-force-restart
+    vm-set-kernel-cmdline ""
+    timeout=120 vm-reboot
     vm-command "grep isolcpus /proc/cmdline" && {
 	error "failed to clean up isolcpus kernel commandline parameter"
     }

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -929,27 +929,6 @@ $py_assertion
     return 0
 }
 
-fedora-set-kernel-cmdline() {
-    local e2e_defaults="$*"
-    vm-command "mkdir -p /etc/default; touch /etc/default/grub; sed -i '/e2e:fedora-set-kernel-cmdline/d' /etc/default/grub"
-    vm-command "echo 'GRUB_CMDLINE_LINUX_DEFAULT=\"\${GRUB_CMDLINE_LINUX_DEFAULT} ${e2e_defaults}\" # by e2e:fedora-set-kernel-cmdline' >> /etc/default/grub" || {
-        command-error "writing new command line parameters failed"
-    }
-    vm-command "grub2-mkconfig -o /boot/grub2/grub.cfg" || {
-        command-error "updating grub failed"
-    }
-}
-
-ubuntu-set-kernel-cmdline() {
-    local e2e_defaults="$*"
-    vm-command "echo 'GRUB_CMDLINE_LINUX_DEFAULT=\"\${GRUB_CMDLINE_LINUX_DEFAULT} ${e2e_defaults}\"' > /etc/default/grub.d/60-e2e-defaults.cfg" || {
-        command-error "writing new command line parameters failed"
-    }
-    vm-command "update-grub" || {
-        command-error "updating grub failed"
-    }
-}
-
 # Defaults to use in case the test case does not define these values.
 yaml_in_defaults="CPU=1 MEM=100M ISO=true CPUREQ=1 CPULIM=2 MEMREQ=100M MEMLIM=200M CONTCOUNT=1"
 


### PR DESCRIPTION
This patch set
- adds a `vm-set-kernel-cmdline` frontend to the already existing `{fedora,ubuntu}-set-kernel-cmdline`
- moves all of these from `run.sh` to `lib/vm.bash`
- fixes isolcpus-resetting snippet in topology-aware test