### PR TITLE
topology-aware: more consistent setup error handling.

### DIFF
--- a/cmd/plugins/topology-aware/policy/topology-aware-policy.go
+++ b/cmd/plugins/topology-aware/policy/topology-aware-policy.go
@@ -583,7 +583,7 @@ func (p *policy) checkConstraints() error {
 		from := p.allowed.Difference(p.isolated)
 		cset, err := p.cpuAllocator.AllocateCpus(&from, p.reserveCnt, normalPrio.Option())
 		if err != nil {
-			log.Fatal("cannot reserve %dm CPUs for ReservedResources from AvailableResources: %s", qty.MilliValue(), err)
+			return policyError("cannot reserve %dm CPUs for ReservedResources from AvailableResources: %s", qty.MilliValue(), err)
 		}
 		p.reserved = cset
 	}


### PR DESCRIPTION
Don't log as fatal (and abort) when we fail to allocate reserved cpuset. Try to propagate the error back to the source config CR as with the rest of the errors.