### PR TITLE
e2e: fail reserved pool setup for the right reason.

### DIFF
--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test05-reserved-resources/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test05-reserved-resources/code.var.sh
@@ -21,14 +21,16 @@ RESERVED_CPU="cpuset:3,7,11,15"
 helm_config=$(instantiate helm-config.yaml)
 ( launch_timeout=5s helm-launch topology-aware ) && error "unexpected success" || {
     echo "Launch failed as expected"
+    get-config-node-status-error topologyawarepolicies/default || :
 }
 
 # Test launch failure, there are more reserved CPUs than available CPUs
 helm-terminate
-RESERVED_CPU="11"
+RESERVED_CPU='"11"'
 helm_config=$(instantiate helm-config.yaml)
 ( launch_timeout=5s helm-launch topology-aware ) && error "unexpected success" || {
     echo "Launch failed as expected"
+    get-config-node-status-error topologyawarepolicies/default || :
 }
 
 # Test that BestEffort containers are allowed to run on both Reserved


### PR DESCRIPTION
When we try to allocate too much reserved CPUs, don't fail startup due to passing an expected string value as an int. Alos, fetch node CR status error after expected failure.