### PR TITLE
resmgr: purge cached pod resource list upon pod stop/removal.

### DIFF
--- a/pkg/agent/pod-resource-api.go
+++ b/pkg/agent/pod-resource-api.go
@@ -79,7 +79,7 @@ func (a *Agent) GoListPodResources(timeout time.Duration) <-chan *podresapi.PodR
 	return ch
 }
 
-// PurgePodResources()
+// PurgePodResources removes any cached resources for the given pod.
 func (a *Agent) PurgePodResources(ns, pod string) {
 	if !a.podResCli.HasClient() {
 		return

--- a/pkg/agent/pod-resource-api.go
+++ b/pkg/agent/pod-resource-api.go
@@ -78,3 +78,12 @@ func (a *Agent) GoListPodResources(timeout time.Duration) <-chan *podresapi.PodR
 
 	return ch
 }
+
+// PurgePodResources()
+func (a *Agent) PurgePodResources(ns, pod string) {
+	if !a.podResCli.HasClient() {
+		return
+	}
+
+	a.podResCli.PurgePodResources(ns, pod)
+}

--- a/pkg/agent/podresapi/client.go
+++ b/pkg/agent/podresapi/client.go
@@ -159,6 +159,7 @@ func (c *Client) Get(ctx context.Context, namespace, pod string) (*PodResources,
 	return l.GetPodResources(namespace, pod), nil
 }
 
+// PurgePodResources removes any cached resources for the given pod.
 func (c *Client) PurgePodResources(namespace, pod string) {
 	if c.cached != nil {
 		c.cached.PurgePodResources(namespace, pod)

--- a/pkg/agent/podresapi/client.go
+++ b/pkg/agent/podresapi/client.go
@@ -158,3 +158,9 @@ func (c *Client) Get(ctx context.Context, namespace, pod string) (*PodResources,
 
 	return l.GetPodResources(namespace, pod), nil
 }
+
+func (c *Client) PurgePodResources(namespace, pod string) {
+	if c.cached != nil {
+		c.cached.PurgePodResources(namespace, pod)
+	}
+}

--- a/pkg/agent/podresapi/resources.go
+++ b/pkg/agent/podresapi/resources.go
@@ -114,6 +114,16 @@ func (l *PodResourcesList) GetContainer(ns, pod, ctr string) *ContainerResources
 	return l.GetPodResources(ns, pod).GetContainer(ctr)
 }
 
+func (l *PodResourcesList) PurgePodResources(ns, pod string) {
+	if l == nil {
+		return
+	}
+
+	if podMap, ok := l.m[ns]; ok {
+		delete(podMap, pod)
+	}
+}
+
 // GetDeviceTopologyHints returns topology hints for the given container. checkDenied
 // is used to filter out hints that are disallowed.
 func (r *ContainerResources) GetDeviceTopologyHints(checkDenied func(string) bool) topology.Hints {

--- a/pkg/resmgr/nri.go
+++ b/pkg/resmgr/nri.go
@@ -335,6 +335,7 @@ func (p *nriPlugin) StopPodSandbox(ctx context.Context, podSandbox *api.PodSandb
 
 	pod, _ := m.cache.LookupPod(podSandbox.GetId())
 	released := slices.Clone(pod.GetContainers())
+	m.agent.PurgePodResources(pod.GetNamespace(), pod.GetName())
 
 	if err := p.runPostReleaseHooks(event, released...); err != nil {
 		nri.Error("%s: failed to run post-release hooks for pod %s: %v",
@@ -370,6 +371,7 @@ func (p *nriPlugin) RemovePodSandbox(ctx context.Context, podSandbox *api.PodSan
 
 	pod, _ := m.cache.LookupPod(podSandbox.GetId())
 	released := slices.Clone(pod.GetContainers())
+	m.agent.PurgePodResources(pod.GetNamespace(), pod.GetName())
 
 	if err := p.runPostReleaseHooks(event, released...); err != nil {
 		nri.Error("%s: failed to run post-release hooks for pod %s: %v",


### PR DESCRIPTION
This patch set fixes a problem which occurs if the Pod Resource API Get() is feature-gated off and one creates subsequently two identical pods with identical containers but with slightly different resources which then have different (NUMA node) locality. Currently, when podresapi.Get() is unavailable we emulate it with a List, followed by a lookup, caching any parsed per pod/container resources and the remaining unparsed slice of the resource list. However, since we miss purging cached items (when a pod is removed), case we fail to refresh the cached list in the aforementioned case.

This patch set adds support for purging cached entries and actively purge pod entries when a pod is stopped or removed.