### PR TITLE
github: explicitly ensure contents-only copying

### DIFF
--- a/.github/workflows/publish-olm-bundle.yaml
+++ b/.github/workflows/publish-olm-bundle.yaml
@@ -133,7 +133,7 @@ jobs:
       - name: Copy the bundle to the community-operators repo
         run: |
           mkdir -p community-operators/operators/nri-plugins-operator/${{ env.TAG }}
-          cp -r deployment/operator/bundle/ community-operators/operators/nri-plugins-operator/${{ env.TAG }}
+          cp -r deployment/operator/bundle/* community-operators/operators/nri-plugins-operator/${{ env.TAG }}
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
Even though `bundle/` is specified with a trailing `/`, the directory itself is copied into the target `nri-plugins-operator/.` in https://github.com/k8s-operatorhub/community-operators/pull/5958. Let's be explicit to ensure contents-only copying.