### PR TITLE
sysfs: add a helper for gathering whatever IDs related to CPUs

### DIFF
--- a/cmd/plugins/topology-aware/policy/mocks_test.go
+++ b/cmd/plugins/topology-aware/policy/mocks_test.go
@@ -261,6 +261,9 @@ func (fake *mockSystem) CoreKindCPUs(sysfs.CoreKind) cpuset.CPUSet {
 func (fake *mockSystem) CoreKinds() []sysfs.CoreKind {
 	return nil
 }
+func (fake *mockSystem) IDSetForCPUs(cpus cpuset.CPUSet, f func(cpu system.CPU) idset.ID) idset.IDSet {
+	panic("unimplemented")
+}
 func (fake *mockSystem) AllThreadsForCPUs(cpuset.CPUSet) cpuset.CPUSet {
 	return cpuset.New()
 }

--- a/pkg/sysfs/system.go
+++ b/pkg/sysfs/system.go
@@ -125,6 +125,7 @@ type System interface {
 	OfflineCPUs() cpuset.CPUSet
 	CoreKindCPUs(CoreKind) cpuset.CPUSet
 	CoreKinds() []CoreKind
+	IDSetForCPUs(cpuset.CPUSet, func(CPU) idset.ID) idset.IDSet
 	AllThreadsForCPUs(cpuset.CPUSet) cpuset.CPUSet
 	SingleThreadForCPUs(cpuset.CPUSet) cpuset.CPUSet
 	AllCPUsSharingNthLevelCacheWithCPUs(int, cpuset.CPUSet) cpuset.CPUSet
@@ -783,6 +784,17 @@ func (sys *system) CoreKinds() []CoreKind {
 		kinds = append(kinds, kind)
 	}
 	return kinds
+}
+
+// IDSetForCPUs returns a set of IDs for the given CPUs.
+func (sys *system) IDSetForCPUs(cpus cpuset.CPUSet, idForCPU func(cpu CPU) idset.ID) idset.IDSet {
+	ids := idset.NewIDSet()
+	for _, id := range cpus.UnsortedList() {
+		if cpu, ok := sys.cpus[id]; ok {
+			ids.Add(idForCPU(cpu))
+		}
+	}
+	return ids
 }
 
 func (sys *system) AllThreadsForCPUs(cpus cpuset.CPUSet) cpuset.CPUSet {


### PR DESCRIPTION
This helper gathers package, die, node, etc. ids from a set of CPUs. The helper takes care of checking validity/existence of each CPU in the set.