### PR TITLE
e2e: drop old shims from custom-build containerd

### DIFF
--- a/test/e2e/playbook/provision.yaml
+++ b/test/e2e/playbook/provision.yaml
@@ -200,8 +200,6 @@
       with_items:
         - "{{ containerd_src }}/bin/ctr"
         - "{{ containerd_src }}/bin/containerd"
-        - "{{ containerd_src }}/bin/containerd-shim"
-        - "{{ containerd_src }}/bin/containerd-shim-runc-v1"
         - "{{ containerd_src }}/bin/containerd-shim-runc-v2"
       when: is_containerd and containerd_src != ""
 


### PR DESCRIPTION
Recent versions of containerd do not build dropped shims. It is realistic to assume that we are building and testing with most recent containerd versions rather than old ones, so let's support that case in our default e2e workflow, too.

This change affects only testing with containerd_src set to a local containerd build.