### PR TITLE
e2e: fix CNI directory in recent containerd versions

### DIFF
--- a/test/e2e/playbook/provision.yaml
+++ b/test/e2e/playbook/provision.yaml
@@ -310,10 +310,10 @@
 
         - name: Update CNI plugin directory on Fedora
           when: ansible_facts['distribution'] == "Fedora"
-          ansible.builtin.lineinfile:
+          ansible.builtin.replace:
             path: /etc/containerd/config.toml
-            regexp: ' *bin_dir *= *./opt/cni/bin. *'
-            line: 'bin_dir = "/usr/libexec/cni"'
+            regexp: '/opt/cni/bin'
+            replace: '/usr/libexec/cni'
 
     - name: Configure bridge CNI plugin
       when: cni_plugin == "bridge"


### PR DESCRIPTION
Due to containerd configuration change in recent versions, that is switching from bin_dir to bin_dirs, our configuration modification for Fedora stopped working. This patch makes the CNI location fix more robust, and it works with old and new containerd versions.