### PR TITLE
.github: allow building and publishing per-topic test images and Helm charts.

### DIFF
--- a/.github/workflows/package-helm.yaml
+++ b/.github/workflows/package-helm.yaml
@@ -114,7 +114,11 @@ jobs:
           # Package charts
           find "$CHARTS_DIR" -name values.yaml | xargs -I '{}' \
               sed -e s"/pullPolicy:.*/pullPolicy: Always/" -i '{}'
-          helm package --version "$CHART_VERSION" --app-version $APP_VERSION "$CHARTS_DIR"/*
+          orig="ghcr.io/containers/nri-plugins"
+          repo="${{ env.REGISTRY }}/${{ env.REGISTRY_PATH }}"
+          find "$CHARTS_DIR" -name values.yaml | xargs -I '{}' \
+              sed -e s"|  name: $orig/|  name: $repo/|g" -i '{}'
+          helm package --version "$CHART_VERSION" --app-version "$APP_VERSION" "$CHARTS_DIR"/*
           find "$CHARTS_DIR" -name values.yaml | xargs -I '{}' \
               git checkout '{}'
           mkdir ../$UNSTABLE_CHARTS

--- a/.github/workflows/package-helm.yaml
+++ b/.github/workflows/package-helm.yaml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
       - release-*
+      - test/build/*
 
 env:
   CHARTS_DIR: deployment/helm/
@@ -106,11 +107,24 @@ jobs:
           #   - image version: 'unstable'.
           majmin="$(git describe --tags | sed -E 's/(v[0-9]*\.[0-9]*).*$/\1/')"
           CHART_VERSION="${majmin}-unstable"
-          if [  $GITHUB_REF_NAME = "main" ]; then
-              APP_VERSION=unstable
-          else
-              APP_VERSION="${majmin}-unstable"
-          fi
+          variant=""
+          case $GITHUB_REF_NAME in
+              main)
+                  APP_VERSION=unstable
+                  ;;
+              release-*)
+                  APP_VERSION="${majmin}-unstable"
+                  ;;
+              test/build/*)
+                  variant="${GITHUB_REF_NAME#test/build/}"
+                  variant="${variant//\//-}"
+                  tag="${majmin}-${variant}-unstable"
+                  APP_VERSION="${majmin}-${variant}-unstable"
+                  CHART_VERSION="${majmin}-${variant}-unstable"
+                  ;;
+          esac
+          echo "- Using APP_VERSION=$APP_VERSION"
+          echo "        CHART_VERSION=$CHART_VERSION"
           # Package charts
           find "$CHARTS_DIR" -name values.yaml | xargs -I '{}' \
               sed -e s"/pullPolicy:.*/pullPolicy: Always/" -i '{}'

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - release-*
+      - test/build/*
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
 
@@ -47,6 +48,7 @@ jobs:
               echo "  - image:  $img"
               echo "  - digest: $sha"
               echo "  - digging out tag from git ref $GITREF..."
+              variant=""
               case $GITREF in
                   refs/tags/v*)
                       tag="${GITREF#refs/tags/}"
@@ -56,6 +58,12 @@ jobs:
                       ;;
                   refs/heads/release-*)
                       tag="v${GITREF#refs/heads/release-}-unstable"
+                      ;;
+                  refs/heads/test/build/*)
+                      variant="${GITREF#refs/heads/test/build/}"
+                      variant="${variant//\//-}"
+                      majmin="$(git describe --tags | sed -E 's/(v[0-9]*\.[0-9]*).*$/\1/')"
+                      tag="${majmin}-${variant}-unstable"
                       ;;
                   *)
                       echo "error: can't determine tag."


### PR DESCRIPTION
This patch set updates the github workflows to allow publishing images and Helm charts for topic-specific test builds. These builds are triggered by pushing to a branch matching test/build/$TOPIC. Images and charts will be named after $TOPIC taken from the test branch name.

For instance, pushing a v0.9 development tree to a branch named `test/build/dra-driver` in the `klihub` fork of the main github repository builds and publishes (among others) this image and chart to the OCI repo `ghcr.io/klihub/nri-plugins`:

- nri-plugins/nri-resource-policy-topology-aware v0.9-dra-driver-unstable
- helm-charts/nri-resource-policy-topology-aware v0.9-dra-driver-unstable

The built chart references the image by default. IOW, once such a build is ready, it can be installed with a single command like this:

```bash
$ helm install --devel -n kube-system test \
    oci://ghcr.io/klihub/nri-plugins/helm-charts/nri-resource-policy-topology-aware \
    --version v0.9-dra-driver-unstable
```
