### PR TITLE
topology-aware: fix format of container-exported memsets.

### DIFF
--- a/cmd/plugins/topology-aware/policy/topology-aware-policy.go
+++ b/cmd/plugins/topology-aware/policy/topology-aware-policy.go
@@ -410,15 +410,15 @@ func (p *policy) ExportResourceData(c cache.Container) map[string]string {
 	dram := mems.And(p.memAllocator.Masks().NodesByTypes(libmem.TypeMaskDRAM))
 	pmem := mems.And(p.memAllocator.Masks().NodesByTypes(libmem.TypeMaskPMEM))
 	hbm := mems.And(p.memAllocator.Masks().NodesByTypes(libmem.TypeMaskHBM))
-	data["ALL_MEMS"] = mems.String()
+	data["ALL_MEMS"] = mems.MemsetString()
 	if dram.Size() > 0 {
-		data["DRAM_MEMS"] = dram.String()
+		data["DRAM_MEMS"] = dram.MemsetString()
 	}
 	if pmem.Size() > 0 {
-		data["PMEM_MEMS"] = pmem.String()
+		data["PMEM_MEMS"] = pmem.MemsetString()
 	}
 	if hbm.Size() > 0 {
-		data["HBM_MEMS"] = hbm.String()
+		data["HBM_MEMS"] = hbm.MemsetString()
 	}
 
 	return data


### PR DESCRIPTION
The format of container exported memsets (exposed to containers through the policy injected `/.nri-resource-policy/resources.sh` downward API file) was accidentally altered when we switched to libmem. This patch restores the original format.