### PR TITLE
sysfs: fix CPU.GetCaches() to not return empty slice.

### DIFF
--- a/pkg/sysfs/system.go
+++ b/pkg/sysfs/system.go
@@ -1210,7 +1210,7 @@ func (c *cpu) CacheCount() int {
 
 // GetCaches returns the caches for this CPU.
 func (c *cpu) GetCaches() []*Cache {
-	caches := make([]*Cache, 0, len(c.caches))
+	caches := make([]*Cache, len(c.caches))
 	copy(caches, c.caches)
 	return caches
 }


### PR DESCRIPTION
Fix `pkg/cache.GetCaches()` always incorrectly returning an empty slice. 