### PR TITLE
docs: fix golang version.

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,6 +1,6 @@
 FROM sphinxdoc/sphinx:7.4.7
 
-ARG GO_VERSION=1.24
+ARG GO_VERSION=1.24.3
 
 RUN apt-get update && apt-get install -y wget git
 


### PR DESCRIPTION
Fix the golang version used in the doc-/site-building image. It can't be a plain 1.24, must be 1.24.X, since it is must resolve to a downloadable release tarball.