### PR TITLE
resmgr: expose RDT metrics.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/containers/nri-plugins/pkg/topology v0.0.0
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/fsnotify/fsnotify v1.6.0
-	github.com/intel/goresctrl v0.8.0
+	github.com/intel/goresctrl v0.8.1-0.20250628124214-579664119777
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.2
 	github.com/onsi/ginkgo/v2 v2.21.0
 	github.com/onsi/gomega v1.35.1

--- a/go.sum
+++ b/go.sum
@@ -838,8 +838,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
-github.com/intel/goresctrl v0.8.0 h1:N3shVbS3kA1Hk2AmcbHv8805Hjbv+zqsCIZCGktxx50=
-github.com/intel/goresctrl v0.8.0/go.mod h1:T3ZZnuHSNouwELB5wvOoUJaB7l/4Rm23rJy/wuWJlr0=
+github.com/intel/goresctrl v0.8.1-0.20250628124214-579664119777 h1:bmFeqbOhPIFBdWb4Wi80vvFmE5WvqQRO5xYUJcDwPqQ=
+github.com/intel/goresctrl v0.8.1-0.20250628124214-579664119777/go.mod h1:1S8GDqL46GuKb525bxNhIEEkhf4rhVcbSf9DuKhp7mw=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/pkg/apis/config/v1alpha1/resmgr/control/rdt/config.go
+++ b/pkg/apis/config/v1alpha1/resmgr/control/rdt/config.go
@@ -17,8 +17,8 @@ package rdt
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 
-	grclog "github.com/intel/goresctrl/pkg/log"
 	grcpath "github.com/intel/goresctrl/pkg/path"
 	"github.com/intel/goresctrl/pkg/rdt"
 )
@@ -33,7 +33,7 @@ var (
 	// Expose goresctrl/rdt functions for configuration via this package.
 	SetPrefix  func(string)                  = grcpath.SetPrefix
 	Initialize func(string) error            = rdt.Initialize
-	SetLogger  func(grclog.Logger)           = rdt.SetLogger
+	SetLogger  func(*slog.Logger)            = rdt.SetLogger
 	SetConfig  func(*rdt.Config, bool) error = rdt.SetConfig
 )
 

--- a/pkg/apis/config/v1alpha1/resmgr/control/rdt/config.go
+++ b/pkg/apis/config/v1alpha1/resmgr/control/rdt/config.go
@@ -35,6 +35,9 @@ var (
 	Initialize func(string) error            = rdt.Initialize
 	SetLogger  func(*slog.Logger)            = rdt.SetLogger
 	SetConfig  func(*rdt.Config, bool) error = rdt.SetConfig
+
+	// And some that we need for other plumbing.
+	NewCollector = rdt.NewCollector
 )
 
 // Config provides runtime configuration for class based cache allocation

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -16,6 +16,7 @@ package log
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 
@@ -96,6 +97,9 @@ type Logger interface {
 
 	// Source returns the source name of this Logger.
 	Source() string
+
+	// SlogHandler returns an slog.Handler for this logger.
+	SlogHandler() slog.Handler
 }
 
 // logger implements Logger.

--- a/pkg/log/slog-logger.go
+++ b/pkg/log/slog-logger.go
@@ -1,0 +1,80 @@
+// Copyright The NRI Plugins Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+)
+
+type slogger struct {
+	l Logger
+}
+
+var _ slog.Handler = &slogger{}
+
+// SetSlogLogger sets up the default logger for the slog package.
+func SetSlogLogger(source string) {
+	var l Logger
+
+	if source == "" {
+		l = Default()
+	} else {
+		l = log.get(source)
+	}
+
+	slog.SetDefault(slog.New(l.SlogHandler()))
+}
+
+func (l logger) SlogHandler() slog.Handler {
+	return &slogger{l: l}
+}
+
+func (s *slogger) Enabled(_ context.Context, level slog.Level) bool {
+	switch level {
+	case slog.LevelDebug:
+		return log.level <= LevelDebug
+	case slog.LevelInfo:
+		return log.level <= LevelInfo
+	case slog.LevelWarn:
+		return log.level <= LevelWarn
+	case slog.LevelError:
+		return log.level <= LevelError
+	}
+	return level >= slog.LevelInfo
+}
+
+func (s *slogger) Handle(_ context.Context, r slog.Record) error {
+	switch r.Level {
+	case slog.LevelDebug:
+		s.l.Debug("%s", strings.TrimPrefix(r.Message, r.Level.String()+" "))
+	case slog.LevelInfo:
+		s.l.Info("%s", strings.TrimPrefix(r.Message, r.Level.String()+" "))
+	case slog.LevelWarn:
+		s.l.Warn("%s", strings.TrimPrefix(r.Message, r.Level.String()+" "))
+	case slog.LevelError:
+		s.l.Error("%s", strings.TrimPrefix(r.Message, r.Level.String()+" "))
+	}
+	return nil
+}
+
+func (s *slogger) WithAttrs(_ []slog.Attr) slog.Handler {
+	return s
+}
+
+func (s *slogger) WithGroup(_ string) slog.Handler {
+	return s
+}

--- a/pkg/resmgr/rdt.go
+++ b/pkg/resmgr/rdt.go
@@ -16,6 +16,7 @@ package resmgr
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/containers/nri-plugins/pkg/apis/config/v1alpha1/resmgr/control/rdt"
 	logger "github.com/containers/nri-plugins/pkg/log"
@@ -27,7 +28,7 @@ type rdtControl struct {
 }
 
 func newRdtControl(resmgr *resmgr, hostRoot string) *rdtControl {
-	rdt.SetLogger(logger.Get("goresctrl"))
+	slog.SetDefault(slog.New(logger.Get("goresctrl").SlogHandler()))
 
 	if hostRoot != "" {
 		rdt.SetPrefix(opt.HostRoot)

--- a/pkg/resmgr/rdt.go
+++ b/pkg/resmgr/rdt.go
@@ -20,23 +20,36 @@ import (
 
 	"github.com/containers/nri-plugins/pkg/apis/config/v1alpha1/resmgr/control/rdt"
 	logger "github.com/containers/nri-plugins/pkg/log"
+	"github.com/containers/nri-plugins/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	rdtlog = logger.Get("goresctrl")
 )
 
 type rdtControl struct {
-	resmgr   *resmgr
-	hostRoot string
+	hostRoot  string
+	resmgr    *resmgr
+	collector *rdtCollector
 }
 
 func newRdtControl(resmgr *resmgr, hostRoot string) *rdtControl {
-	slog.SetDefault(slog.New(logger.Get("goresctrl").SlogHandler()))
+	slog.SetDefault(slog.New(rdtlog.SlogHandler()))
 
 	if hostRoot != "" {
 		rdt.SetPrefix(opt.HostRoot)
 	}
 
+	collector, err := registerRdtCollector()
+	if err != nil {
+		log.Error("failed to register RDT metrics collector: %v", err)
+	}
+
 	return &rdtControl{
-		resmgr:   resmgr,
-		hostRoot: hostRoot,
+		resmgr:    resmgr,
+		hostRoot:  hostRoot,
+		collector: collector,
 	}
 }
 
@@ -65,6 +78,43 @@ func (c *rdtControl) configure(cfg *rdt.Config) error {
 	}
 
 	c.resmgr.cache.ConfigureRDTControl(cfg.Enable)
+	c.collector.enable(cfg.Enable)
 
 	return nil
+}
+
+type rdtCollector struct {
+	prometheus.Collector
+	enabled bool
+}
+
+func registerRdtCollector() (*rdtCollector, error) {
+	options := []metrics.RegisterOption{
+		metrics.WithGroup("policy"),
+		metrics.WithCollectorOptions(
+			metrics.WithoutSubsystem(),
+		),
+	}
+
+	c := &rdtCollector{Collector: rdt.NewCollector()}
+
+	if err := metrics.Register("rdt", c, options...); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+func (c *rdtCollector) enable(enabled bool) {
+	c.enabled = enabled
+}
+
+func (c *rdtCollector) Describe(ch chan<- *prometheus.Desc) {
+	rdtlog.Debug("describing RDT metrics")
+	c.Collector.Describe(ch)
+}
+
+func (c *rdtCollector) Collect(ch chan<- prometheus.Metric) {
+	rdtlog.Debug("collecting RDT metrics")
+	c.Collector.Collect(ch)
 }


### PR DESCRIPTION
This PR exposes RDT metrics provided by `goresctrl`. These new metrics are available as `rdt` within the `policy` metrics group.
