### PR TITLE
helm: set defaults for agent config in values.

### DIFF
--- a/deployment/helm/balloons/values.yaml
+++ b/deployment/helm/balloons/values.yaml
@@ -12,6 +12,10 @@ config:
   reservedResources:
     cpu: 1000m
 
+  agent:
+    nodeResourceTopology: true
+    podResourceAPI: false
+
   allocatorTopologyBalancing: true
 
   balloonTypes:

--- a/deployment/helm/template/values.yaml
+++ b/deployment/helm/template/values.yaml
@@ -11,6 +11,9 @@ image:
 config:
   reservedResources:
     cpu: 750m
+  agent:
+    nodeResourceTopology: true
+    podResourceAPI: false
   control:
     rdt:
       enable: false

--- a/deployment/helm/topology-aware/values.yaml
+++ b/deployment/helm/topology-aware/values.yaml
@@ -11,6 +11,9 @@ image:
 config:
   reservedResources:
     cpu: 750m
+  agent:
+    nodeResourceTopology: true
+    podResourceAPI: false
   control:
     rdt:
       enable: false


### PR DESCRIPTION
Set defaults for agent config in values. This makes it easy to enable pod resource API by passing this to helm install

   --set config.agent.podResourceAPI=true