### PR TITLE
memory-policy: use NRI memory policy adjustments

### DIFF
--- a/cmd/plugins/memory-policy/main.go
+++ b/cmd/plugins/memory-policy/main.go
@@ -442,25 +442,23 @@ func (policy *LinuxMemoryPolicy) ToMemoryPolicyAdjustment() (*api.ContainerAdjus
 	if policy == nil {
 		return nil, nil
 	}
-	return nil, fmt.Errorf("memory policy adjustment is not implemented yet")
 
-	// // Uncomment this to use memory policy in NRI API
-	// ca := &api.ContainerAdjustment{}
-	// mode, ok := api.MpolMode_value[policy.Mode]
-	// if !ok {
-	// 	return nil, fmt.Errorf("invalid memory policy mode %q", policy.Mode)
-	// }
-	//
-	// flags := []api.MpolFlag{}
-	// for _, flag := range policy.Flags {
-	// 	if flagValue, ok := api.MpolFlag_value[flag]; ok {
-	// 		flags = append(flags, api.MpolFlag(flagValue))
-	// 	} else {
-	// 		return nil, fmt.Errorf("invalid memory policy flag %q", flag)
-	// 	}
-	// }
-	// ca.SetLinuxMemoryPolicy(api.MpolMode(mode), policy.Nodes, flags...)
-	// return ca, nil
+	ca := &api.ContainerAdjustment{}
+	mode, ok := api.MpolMode_value[policy.Mode]
+	if !ok {
+		return nil, fmt.Errorf("invalid memory policy mode %q", policy.Mode)
+	}
+
+	flags := []api.MpolFlag{}
+	for _, flag := range policy.Flags {
+		if flagValue, ok := api.MpolFlag_value[flag]; ok {
+			flags = append(flags, api.MpolFlag(flagValue))
+		} else {
+			return nil, fmt.Errorf("invalid memory policy flag %q", flag)
+		}
+	}
+	ca.SetLinuxMemoryPolicy(api.MpolMode(mode), policy.Nodes, flags...)
+	return ca, nil
 }
 
 // ToCommandInjectionAdjustment() converts the memory policy into a

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/containers/nri-plugins
 
-go 1.24.0
+go 1.24.3
+
+toolchain go1.24.4
 
 require (
 	github.com/askervin/gofmbt v0.0.0-20250119175120-506d925f666f
@@ -62,12 +64,12 @@ require (
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/knqyf263/go-plugin v0.8.1-0.20240827022226-114c6257e441 // indirect
+	github.com/knqyf263/go-plugin v0.9.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/opencontainers/runtime-spec v1.1.0 // indirect
+	github.com/opencontainers/runtime-spec v1.2.2-0.20250804081626-bfdffd548aa6 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
@@ -100,8 +102,9 @@ require (
 )
 
 replace (
+	github.com/containerd/nri => github.com/askervin/nri v0.1.1-0.20250805132206-a9827f7d8b9a
 	github.com/containers/nri-plugins/pkg/topology v0.0.0 => ./pkg/topology
-	github.com/opencontainers/runtime-tools => github.com/opencontainers/runtime-tools v0.0.0-20221026201742-946c877fa809
+	github.com/opencontainers/runtime-tools => github.com/askervin/runtime-tools v0.0.0-20250805113549-904c7269e2a7
 )
 
 tool k8s.io/code-generator

--- a/go.sum
+++ b/go.sum
@@ -610,6 +610,8 @@ github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4x
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/askervin/gofmbt v0.0.0-20250119175120-506d925f666f h1:AKRIaPPDqBRhpWnvxhvtdbVtkV/3XrboabuFaLyp1kw=
 github.com/askervin/gofmbt v0.0.0-20250119175120-506d925f666f/go.mod h1:1rWH2fCHPoGz1ApWyGyEV9YhZ2ZHeeCPaHcicW3b6uk=
+github.com/askervin/nri v0.1.1-0.20250805132206-a9827f7d8b9a h1:1MlnYAVGwd9Em/3DRA4VLRO+ImSZS1LxGXli/mpBzJs=
+github.com/askervin/nri v0.1.1-0.20250805132206-a9827f7d8b9a/go.mod h1:Ej7TxkHmzXcTmlgOkycncvLzi54rwi1nV/ScEapghLk=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
@@ -643,8 +645,6 @@ github.com/cncf/xds/go v0.0.0-20230105202645-06c439db220b/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
-github.com/containerd/nri v0.9.1-0.20250530003506-6120e633d4ad h1:FiRhXzn9B9ToI30hX/2i4dRUKUoVELTc7PlEqvFLwGE=
-github.com/containerd/nri v0.9.1-0.20250530003506-6120e633d4ad/go.mod h1:zA1mhuTD3Frj9fyyIp+1+H2AXS/IueLvxRpkAzmP6RQ=
 github.com/containerd/otelttrpc v0.0.0-20240305015340-ea5083fda723 h1:swk9KxrmARZjSMrHc1Lzb39XhcDwAhYpqkBhinCFLCQ=
 github.com/containerd/otelttrpc v0.0.0-20240305015340-ea5083fda723/go.mod h1:ZKzztepTSz/LKtbUSzfBNVwgqBEPABVZV9PQF/l53+Q=
 github.com/containerd/ttrpc v1.2.2/go.mod h1:sIT6l32Ph/H9cvnJsfXM5drIVzTr5A2flTf1G5tYZak=
@@ -856,8 +856,8 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/asmfmt v1.3.2/go.mod h1:AG8TuvYojzulgDAMCnYn50l/5QV3Bs/tp6j0HLHbNSE=
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
-github.com/knqyf263/go-plugin v0.8.1-0.20240827022226-114c6257e441 h1:Q/sZeuWkXprbKJSs7AwXryuZKSEL/a8ltC7e7xSspN0=
-github.com/knqyf263/go-plugin v0.8.1-0.20240827022226-114c6257e441/go.mod h1:CvCrNDMiKFlAlLFLmcoEfsTROEfNKbEZAMMrwQnLXCM=
+github.com/knqyf263/go-plugin v0.9.0 h1:CQs2+lOPIlkZVtcb835ZYDEoyyWJWLbSTWeCs0EwTwI=
+github.com/knqyf263/go-plugin v0.9.0/go.mod h1:2z5lCO1/pez6qGo8CvCxSlBFSEat4MEp1DrnA+f7w8Q=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -889,8 +889,8 @@ github.com/onsi/ginkgo/v2 v2.21.0 h1:7rg/4f3rB88pb5obDgNZrNHrQ4e6WpjonchcpuBRnZM
 github.com/onsi/ginkgo/v2 v2.21.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/onsi/gomega v1.35.1 h1:Cwbd75ZBPxFSuZ6T+rN/WCb/gOc6YgFBXLlZLhC7Ds4=
 github.com/onsi/gomega v1.35.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
-github.com/opencontainers/runtime-spec v1.1.0 h1:HHUyrt9mwHUjtasSbXSMvs4cyFxh+Bll4AjJ9odEGpg=
-github.com/opencontainers/runtime-spec v1.1.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/opencontainers/runtime-spec v1.2.2-0.20250804081626-bfdffd548aa6 h1:6S6r1L8VO9b1UfgIQi+nteqlElma9KDlzZw/nM3ctI0=
+github.com/opencontainers/runtime-spec v1.2.2-0.20250804081626-bfdffd548aa6/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/phpdave11/gofpdf v1.4.2/go.mod h1:zpO6xFn9yxo3YLyMvW8HcKWVdbNqgIfOOp2dXMnm1mY=


### PR DESCRIPTION
Dependencies:
- https://github.com/opencontainers/runtime-spec/pull/1282 (merged)
- https://github.com/opencontainers/runtime-tools/pull/786 (not merged, use from the PR)
- https://github.com/containerd/nri/pull/166 (not merged, use from the PR)

Keeping as Draft until all dependencies are merged and used from upstream in go.mod.