### PR TITLE
[release-0.10] scripts/build/update-gh-pages: fix parsing of latest release tag

### DIFF
--- a/scripts/build/update-gh-pages.sh
+++ b/scripts/build/update-gh-pages.sh
@@ -147,7 +147,7 @@ pushd "$build_dir"
 # Add "const" files we need in root dir
 touch .nojekyll
 
-_stable=`(ls -d1 v*/ || :) | sort -n | tail -n1`
+_stable=`(ls -d1 v*/ || :) | sort -V | tail -n1`
 if [ -n "$_stable" ]; then
     ln -sfT "$_stable" stable
     redirect_to="stable"


### PR DESCRIPTION
Use --version-sort when sorting versions. Fixes the stable/ symlink that is expected to point to the release with the highest version number.

(cherry picked from commit 5231242297c7cf00993ba54f18ef62f3115ade7c)

Backports #556 