### PR TITLE
Bump golangci-lint and fix linter errors

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.64.5
+          version: v2.4.0
           args: --timeout=10m

--- a/cmd/config-manager/main.go
+++ b/cmd/config-manager/main.go
@@ -125,7 +125,11 @@ func configureNriForCrio(cfg *nriConfig) error {
 	if err != nil {
 		return fmt.Errorf("error creating a drop-in file for CRI-O: %w", err)
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
 
 	_, err = f.WriteString("[crio.nri]\nenable_nri = true\n")
 	if err != nil {
@@ -152,7 +156,11 @@ func writeToContainerdConfig(file string, config map[string]interface{}) error {
 	if err != nil {
 		return fmt.Errorf("error truncating file: %w", err)
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
 
 	w := bufio.NewWriter(f)
 	_, err = w.WriteString(buf.String())

--- a/cmd/plugins/balloons/policy/balloons-policy.go
+++ b/cmd/plugins/balloons/policy/balloons-policy.go
@@ -30,7 +30,6 @@ import (
 	"github.com/containers/nri-plugins/pkg/resmgr/events"
 	libmem "github.com/containers/nri-plugins/pkg/resmgr/lib/memory"
 	policy "github.com/containers/nri-plugins/pkg/resmgr/policy"
-	policyapi "github.com/containers/nri-plugins/pkg/resmgr/policy"
 	"github.com/containers/nri-plugins/pkg/utils"
 	"github.com/containers/nri-plugins/pkg/utils/cpuset"
 	idset "github.com/intel/goresctrl/pkg/utils"
@@ -369,17 +368,17 @@ func (p *balloons) GetTopologyZones() []*policy.TopologyZone {
 		showContainers = *p.bpoptions.ShowContainersInNrt
 	}
 
-	zones := []*policyapi.TopologyZone{}
+	zones := []*policy.TopologyZone{}
 	sysmCpu := 1000 * p.cpuTree.cpus.Size()
 	for _, bln := range p.balloons {
 		// Expose every balloon as a separate zone.
-		zone := &policyapi.TopologyZone{
+		zone := &policy.TopologyZone{
 			Name: bln.PrettyName(),
 			Type: "balloon",
 		}
 
-		cpu := &policyapi.ZoneResource{
-			Name: policyapi.CPUResource,
+		cpu := &policy.ZoneResource{
+			Name: policy.CPUResource,
 		}
 
 		// "Capacity" is the total number of CPUs available in
@@ -424,11 +423,11 @@ func (p *balloons) GetTopologyZones() []*policy.TopologyZone {
 
 		zone.Resources = append(zone.Resources, cpu)
 
-		attributes := []*policyapi.ZoneAttribute{
+		attributes := []*policy.ZoneAttribute{
 			{
 				// "cpuset" are CPUs allowed only to
 				// containers in this balloon.
-				Name:  policyapi.CPUsAttribute,
+				Name:  policy.CPUsAttribute,
 				Value: bln.Cpus.String(),
 			},
 			{
@@ -436,7 +435,7 @@ func (p *balloons) GetTopologyZones() []*policy.TopologyZone {
 				// containers in this and other
 				// balloons that shareIdleCPUsInSame
 				// scope.
-				Name:  policyapi.SharedCPUsAttribute,
+				Name:  policy.SharedCPUsAttribute,
 				Value: bln.SharedIdleCpus.String(),
 			},
 			{
@@ -444,7 +443,7 @@ func (p *balloons) GetTopologyZones() []*policy.TopologyZone {
 				// request of a container that fits
 				// into this balloon without inflating
 				// it.
-				Name:  policyapi.ExcessCPUsAttribute,
+				Name:  policy.ExcessCPUsAttribute,
 				Value: fmt.Sprintf("%dm", bln.AvailMilliCpus()-blnReqmCpu),
 			},
 		}
@@ -460,8 +459,8 @@ func (p *balloons) GetTopologyZones() []*policy.TopologyZone {
 				}
 				return fmt.Sprintf("{%s}", strings.Join(res, ", "))
 			}
-			attributes = append(attributes, &policyapi.ZoneAttribute{
-				Name:  policyapi.ComponentCPUsAttribute,
+			attributes = append(attributes, &policy.ZoneAttribute{
+				Name:  policy.ComponentCPUsAttribute,
 				Value: compCpusString(bln),
 			})
 		}
@@ -514,9 +513,9 @@ func (p *balloons) GetTopologyZones() []*policy.TopologyZone {
 				if !ok {
 					continue
 				}
-				czone := &policyapi.TopologyZone{
+				czone := &policy.TopologyZone{
 					Name: c.PrettyName(),
-					Type: policyapi.ContainerAllocationZoneType,
+					Type: policy.ContainerAllocationZoneType,
 				}
 				ctrLimitmCpu := p.containerLimitedMilliCpus(ctrID)
 				ctrReqmCpu := p.containerRequestedMilliCpus(ctrID)
@@ -529,9 +528,9 @@ func (p *balloons) GetTopologyZones() []*policy.TopologyZone {
 				if ctrLimitmCpu == 0 || ctrLimitmCpu > ctrAllowedmCpu {
 					ctrCapacitymCpu = ctrAllowedmCpu
 				}
-				czone.Resources = []*policyapi.ZoneResource{
+				czone.Resources = []*policy.ZoneResource{
 					{
-						Name: policyapi.CPUResource,
+						Name: policy.CPUResource,
 						Capacity: *resource.NewMilliQuantity(
 							int64(ctrCapacitymCpu),
 							resource.DecimalSI),
@@ -541,13 +540,13 @@ func (p *balloons) GetTopologyZones() []*policy.TopologyZone {
 					},
 				}
 				czone.Parent = zone.Name
-				czone.Attributes = []*policyapi.ZoneAttribute{
+				czone.Attributes = []*policy.ZoneAttribute{
 					{
-						Name:  policyapi.CPUsAttribute,
+						Name:  policy.CPUsAttribute,
 						Value: ctrCpusetCpus,
 					},
 					{
-						Name:  policyapi.MemsetAttribute,
+						Name:  policy.MemsetAttribute,
 						Value: c.GetCpusetMems(),
 					},
 				}

--- a/cmd/plugins/balloons/policy/cputree.go
+++ b/cmd/plugins/balloons/policy/cputree.go
@@ -206,12 +206,12 @@ func (t *cpuTreeNode) FindLeafWithCpu(cpu int) *cpuTreeNode {
 // WalkSkipChildren error returned from a DepthFirstWalk handler
 // prevents walking deeper in the tree. The caller of the
 // DepthFirstWalk will get no error.
-var WalkSkipChildren error = errors.New("skip children")
+var WalkSkipChildren error = errors.New("skip children") // nolint:staticcheck
 
 // WalkStop error returned from a DepthFirstWalk handler stops the
 // walk altogether. The caller of the DepthFirstWalk will get the
 // WalkStop error.
-var WalkStop error = errors.New("stop")
+var WalkStop error = errors.New("stop") // nolint:staticcheck
 
 // DepthFirstWalk walks through nodes in a CPU tree. Every node is
 // passed to the handler callback that controls next step by

--- a/cmd/plugins/memtierd/main.go
+++ b/cmd/plugins/memtierd/main.go
@@ -340,7 +340,7 @@ func (p *plugin) detectCgroupsDir() error {
 	if err != nil {
 		return fmt.Errorf("failed to open /proc/mounts: %v", err)
 	}
-	defer file.Close()
+	defer file.Close() // nolint:errcheck
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
@@ -404,7 +404,7 @@ func newMemtierdEnv(fullCgroupPath string, namespace string, podName string, con
 	}
 	memtierdConfigOut := string(memtierdConfigIn)
 	for key, value := range replace {
-		memtierdConfigOut = strings.Replace(memtierdConfigOut, key, value, -1)
+		memtierdConfigOut = strings.ReplaceAll(memtierdConfigOut, key, value)
 	}
 
 	configFilePath := fmt.Sprintf("%s/memtierd.config.yaml", ctrDir)

--- a/cmd/plugins/topology-aware/policy/mocks_test.go
+++ b/cmd/plugins/topology-aware/policy/mocks_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/containers/nri-plugins/pkg/resmgr/cache"
 	libmem "github.com/containers/nri-plugins/pkg/resmgr/lib/memory"
 	"github.com/containers/nri-plugins/pkg/sysfs"
-	system "github.com/containers/nri-plugins/pkg/sysfs"
 	"github.com/containers/nri-plugins/pkg/topology"
 	"github.com/containers/nri-plugins/pkg/utils/cpuset"
 	"github.com/intel/goresctrl/pkg/sst"
@@ -37,12 +36,12 @@ type mockSystemNode struct {
 	id       idset.ID // node id
 	memFree  uint64
 	memTotal uint64
-	memType  system.MemoryType
+	memType  sysfs.MemoryType
 	distance []int
 }
 
-func (fake *mockSystemNode) MemoryInfo() (*system.MemInfo, error) {
-	return &system.MemInfo{MemFree: fake.memFree, MemTotal: fake.memTotal}, nil
+func (fake *mockSystemNode) MemoryInfo() (*sysfs.MemInfo, error) {
+	return &sysfs.MemInfo{MemFree: fake.memFree, MemTotal: fake.memTotal}, nil
 }
 
 func (fake *mockSystemNode) PackageID() idset.ID {
@@ -57,7 +56,7 @@ func (fake *mockSystemNode) ID() idset.ID {
 	return fake.id
 }
 
-func (fake *mockSystemNode) GetMemoryType() system.MemoryType {
+func (fake *mockSystemNode) GetMemoryType() sysfs.MemoryType {
 	return fake.memType
 }
 
@@ -140,8 +139,8 @@ type mockCPU struct {
 func (c *mockCPU) BaseFrequency() uint64 {
 	return 0
 }
-func (c *mockCPU) EPP() system.EPP {
-	return system.EPPUnknown
+func (c *mockCPU) EPP() sysfs.EPP {
+	return sysfs.EPPUnknown
 }
 func (c *mockCPU) ID() idset.ID {
 	return idset.ID(0)
@@ -161,8 +160,8 @@ func (c *mockCPU) CoreID() idset.ID {
 func (c *mockCPU) ThreadCPUSet() cpuset.CPUSet {
 	return cpuset.New()
 }
-func (c *mockCPU) FrequencyRange() system.CPUFreq {
-	return system.CPUFreq{}
+func (c *mockCPU) FrequencyRange() sysfs.CPUFreq {
+	return sysfs.CPUFreq{}
 }
 func (c *mockCPU) Online() bool {
 	return true
@@ -210,13 +209,13 @@ func (c *mockCPU) CoreKind() sysfs.CoreKind {
 
 type mockSystem struct {
 	isolatedCPU  int
-	nodes        []system.Node
+	nodes        []sysfs.Node
 	cpuCount     int
 	packageCount int
 	socketCount  int
 }
 
-func (fake *mockSystem) Node(id idset.ID) system.Node {
+func (fake *mockSystem) Node(id idset.ID) sysfs.Node {
 	for _, node := range fake.nodes {
 		if node.ID() == id {
 			return node
@@ -225,7 +224,7 @@ func (fake *mockSystem) Node(id idset.ID) system.Node {
 	return &mockSystemNode{}
 }
 
-func (fake *mockSystem) CPU(idset.ID) system.CPU {
+func (fake *mockSystem) CPU(idset.ID) sysfs.CPU {
 	return &mockCPU{}
 }
 func (fake *mockSystem) CPUCount() int {
@@ -234,10 +233,10 @@ func (fake *mockSystem) CPUCount() int {
 	}
 	return fake.cpuCount
 }
-func (fake *mockSystem) Discover(flags system.DiscoveryFlag) error {
+func (fake *mockSystem) Discover(flags sysfs.DiscoveryFlag) error {
 	return nil
 }
-func (fake *mockSystem) Package(idset.ID) system.CPUPackage {
+func (fake *mockSystem) Package(idset.ID) sysfs.CPUPackage {
 	return &mockCPUPackage{}
 }
 func (fake *mockSystem) PossibleCPUs() cpuset.CPUSet {
@@ -261,7 +260,7 @@ func (fake *mockSystem) CoreKindCPUs(sysfs.CoreKind) cpuset.CPUSet {
 func (fake *mockSystem) CoreKinds() []sysfs.CoreKind {
 	return nil
 }
-func (fake *mockSystem) IDSetForCPUs(cpus cpuset.CPUSet, f func(cpu system.CPU) idset.ID) idset.IDSet {
+func (fake *mockSystem) IDSetForCPUs(cpus cpuset.CPUSet, f func(cpu sysfs.CPU) idset.ID) idset.IDSet {
 	panic("unimplemented")
 }
 func (fake *mockSystem) AllThreadsForCPUs(cpuset.CPUSet) cpuset.CPUSet {

--- a/cmd/plugins/topology-aware/policy/node.go
+++ b/cmd/plugins/topology-aware/policy/node.go
@@ -422,7 +422,7 @@ func (n *node) HasMemoryType(reqType memoryType) bool {
 func (p *policy) NewNumaNode(id idset.ID, parent Node) *numanode {
 	n := &numanode{}
 	n.self.node = n
-	n.node.init(p, fmt.Sprintf("NUMA node #%v", id), NumaNode, parent)
+	n.init(p, fmt.Sprintf("NUMA node #%v", id), NumaNode, parent)
 	n.id = id
 	n.sysnode = p.sys.Node(id)
 
@@ -487,7 +487,7 @@ func (p *policy) NewDieNode(id idset.ID, parent Node) *dienode {
 	pkg := parent.(*socketnode)
 	n := &dienode{}
 	n.self.node = n
-	n.node.init(p, fmt.Sprintf("die #%v/%v", pkg.id, id), DieNode, parent)
+	n.init(p, fmt.Sprintf("die #%v/%v", pkg.id, id), DieNode, parent)
 	n.id = id
 	n.syspkg = p.sys.Package(pkg.id)
 
@@ -556,7 +556,7 @@ func (n *dienode) HintScore(hint topology.Hint) float64 {
 func (p *policy) NewSocketNode(id idset.ID, parent Node) *socketnode {
 	n := &socketnode{}
 	n.self.node = n
-	n.node.init(p, fmt.Sprintf("socket #%v", id), SocketNode, parent)
+	n.init(p, fmt.Sprintf("socket #%v", id), SocketNode, parent)
 	n.id = id
 	n.syspkg = p.sys.Package(id)
 
@@ -620,7 +620,7 @@ func (n *socketnode) HintScore(hint topology.Hint) float64 {
 func (p *policy) NewVirtualNode(name string, parent Node) *virtualnode {
 	n := &virtualnode{}
 	n.self.node = n
-	n.node.init(p, name, VirtualNode, parent)
+	n.init(p, name, VirtualNode, parent)
 
 	return n
 }

--- a/cmd/plugins/topology-aware/policy/pod-preferences_test.go
+++ b/cmd/plugins/topology-aware/policy/pod-preferences_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	resapi "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -316,8 +315,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 		{
 			name: "cpuAllocationPreferences() should handle nil pod arg gracefully",
 			container: &mockContainer{
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("1"),
 					},
 				},
@@ -327,8 +326,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 		{
 			name: "return defaults",
 			container: &mockContainer{
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("1"),
 					},
 				},
@@ -343,8 +342,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 			name: "return request's value for system container",
 			container: &mockContainer{
 				namespace: metav1.NamespaceSystem,
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("2"),
 					},
 				},
@@ -358,8 +357,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 		{
 			name: "return request's value for burstable QoS",
 			container: &mockContainer{
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("2"),
 					},
 				},
@@ -372,8 +371,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 		{
 			name: "guaranteed QoS with sub-core request",
 			container: &mockContainer{
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("750m"),
 					},
 				},
@@ -388,8 +387,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 		{
 			name: "guaranteed QoS with sub-core request, prefer isolated",
 			container: &mockContainer{
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("750m"),
 					},
 				},
@@ -405,8 +404,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 		{
 			name: "guaranteed QoS with sub-core request, prefer shared",
 			container: &mockContainer{
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("750m"),
 					},
 				},
@@ -422,8 +421,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 		{
 			name: "guaranteed QoS with sub-core request, prefer isolated & shared",
 			container: &mockContainer{
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("750m"),
 					},
 				},
@@ -441,8 +440,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 		{
 			name: "guaranteed QoS with single full core request, prefer isolated",
 			container: &mockContainer{
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("1"),
 					},
 				},
@@ -457,8 +456,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 		{
 			name: "guaranteed QoS with single full core request, prefer no isolated",
 			container: &mockContainer{
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("1"),
 					},
 				},
@@ -473,8 +472,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 		{
 			name: "guaranteed QoS with single full core request, prefer shared",
 			container: &mockContainer{
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("1"),
 					},
 				},
@@ -490,8 +489,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 		{
 			name: "guaranteed QoS with single full core request, prefer isolated & shared",
 			container: &mockContainer{
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("1"),
 					},
 				},
@@ -509,8 +508,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 			name: "guaranteed QoS with single full core request, annotated shared",
 			container: &mockContainer{
 				name: "testcontainer",
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("1"),
 					},
 				},
@@ -531,8 +530,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 			name: "guaranteed QoS with single full core request, annotated no isolated",
 			container: &mockContainer{
 				name: "testcontainer",
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("1"),
 					},
 				},
@@ -552,8 +551,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 		{
 			name: "guaranteed QoS with potential mixed request",
 			container: &mockContainer{
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("1500m"),
 					},
 				},
@@ -568,8 +567,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 		{
 			name: "guaranteed QoS with potential mixed request, prefer isolated",
 			container: &mockContainer{
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("1500m"),
 					},
 				},
@@ -585,8 +584,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 		{
 			name: "guaranteed QoS with potential mixed request, prefer shared",
 			container: &mockContainer{
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("1500m"),
 					},
 				},
@@ -602,8 +601,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 		{
 			name: "guaranteed QoS with potential mixed request, prefer isolated & shared",
 			container: &mockContainer{
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("1500m"),
 					},
 				},
@@ -620,8 +619,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 		{
 			name: "guaranteed QoS with multi-core full request",
 			container: &mockContainer{
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("2"),
 					},
 				},
@@ -635,8 +634,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 		{
 			name: "guaranteed QoS with multi-core full request, prefer isolated",
 			container: &mockContainer{
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("2"),
 					},
 				},
@@ -651,8 +650,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 		{
 			name: "guaranteed QoS with multi-core full request, prefer shared",
 			container: &mockContainer{
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("2"),
 					},
 				},
@@ -668,8 +667,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 		{
 			name: "guaranteed QoS with multi-core full request, prefer isolated & shared",
 			container: &mockContainer{
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("2"),
 					},
 				},
@@ -687,8 +686,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 			name: "guaranteed QoS with multi-core full request, annotate isolated",
 			container: &mockContainer{
 				name: "testcontainer",
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("2"),
 					},
 				},
@@ -706,8 +705,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 			name: "guaranteed QoS with multi-core full request, annotate shared",
 			container: &mockContainer{
 				name: "testcontainer",
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("2"),
 					},
 				},
@@ -726,8 +725,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 			name: "guaranteed QoS with multi-core full request, annotate isolated & shared",
 			container: &mockContainer{
 				name: "testcontainer",
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("2"),
 					},
 				},
@@ -746,8 +745,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 		{
 			name: "guaranteed QoS with multi-core mixed request",
 			container: &mockContainer{
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("2500m"),
 					},
 				},
@@ -762,8 +761,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 		{
 			name: "guaranteed QoS with multi-core mixed request, prefer isolated",
 			container: &mockContainer{
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("2500m"),
 					},
 				},
@@ -778,8 +777,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 		{
 			name: "guaranteed QoS with multi-core mixed request, prefer shared",
 			container: &mockContainer{
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("2500m"),
 					},
 				},
@@ -794,8 +793,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 		{
 			name: "guaranteed QoS with multi-core mixed request, prefer isolated & shared",
 			container: &mockContainer{
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("2500m"),
 					},
 				},
@@ -811,8 +810,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 			name: "guaranteed QoS with multi-core mixed request, annotate isolated",
 			container: &mockContainer{
 				name: "testcontainer",
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("2500m"),
 					},
 				},
@@ -831,8 +830,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 			name: "guaranteed QoS with multi-core mixed request, annotate shared",
 			container: &mockContainer{
 				name: "testcontainer",
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("2500m"),
 					},
 				},
@@ -851,8 +850,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 			name: "guaranteed QoS with multi-core mixed request, annotate isolated & shared",
 			container: &mockContainer{
 				name: "testcontainer",
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("2500m"),
 					},
 				},
@@ -872,8 +871,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 			name: "guaranteed QoS with multi-core mixed request, annotate no shared",
 			container: &mockContainer{
 				name: "testcontainer",
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("2500m"),
 					},
 				},
@@ -892,8 +891,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 			name: "guaranteed QoS with multi-core mixed request, annotate isolated, no shared",
 			container: &mockContainer{
 				name: "testcontainer",
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("2500m"),
 					},
 				},
@@ -913,8 +912,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 			name: "return request's value for reserved pool namespace container",
 			container: &mockContainer{
 				namespace: "foobar",
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("2"),
 					},
 				},
@@ -930,8 +929,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 			name: "return request's value for reserved pool namespace container using a glob 1",
 			container: &mockContainer{
 				namespace: "foobar2",
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("2"),
 					},
 				},
@@ -947,8 +946,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 			name: "return request's value for reserved pool namespace container using a glob 2",
 			container: &mockContainer{
 				namespace: "foobar-testing",
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("2"),
 					},
 				},
@@ -964,8 +963,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 			name: "return request's value for reserved pool namespace container using a glob 3",
 			container: &mockContainer{
 				namespace: "testing",
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("2"),
 					},
 				},
@@ -981,8 +980,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 			name: "return request's value for reserved pool namespace container using a glob 4",
 			container: &mockContainer{
 				namespace: "1foobar2",
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("2"),
 					},
 				},
@@ -998,8 +997,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 			name: "return request's value for reserved pool namespace container using a glob 5",
 			container: &mockContainer{
 				namespace: "foobar12",
-				returnValueForGetResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
+				returnValueForGetResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resapi.MustParse("2"),
 					},
 				},

--- a/cmd/plugins/topology-aware/policy/pools.go
+++ b/cmd/plugins/topology-aware/policy/pools.go
@@ -80,7 +80,7 @@ func (p *policy) enumeratePools() {
 
 func (p *policy) buildRootPool() {
 	var (
-		root  Node = nilnode
+		root  = nilnode
 		vroot *virtualnode
 	)
 
@@ -94,8 +94,8 @@ func (p *policy) buildRootPool() {
 		log.Info("+ created pool %s", vroot.Name())
 
 		cpus := p.sys.CPUSet()
-		vroot.node.noderes, vroot.node.freeres = p.getCpuSupply(vroot, cpus)
-		vroot.node.mem, vroot.node.pMem, vroot.node.hbm = p.getMemSupply(vroot, cpus)
+		vroot.noderes, vroot.freeres = p.getCpuSupply(vroot, cpus)
+		vroot.mem, vroot.pMem, vroot.hbm = p.getMemSupply(vroot, cpus)
 	} else {
 		log.Info("- omitted virtual root pool (single socket HW)")
 	}
@@ -117,8 +117,8 @@ func (p *policy) buildSocketPool(socketID idset.ID, root Node) {
 	log.Info("+ created pool %s", socket.Name())
 
 	cpus := p.sys.Package(socketID).CPUSet()
-	socket.node.noderes, socket.node.freeres = p.getCpuSupply(socket, cpus)
-	socket.node.mem, socket.node.pMem, socket.node.hbm = p.getMemSupply(socket, cpus)
+	socket.noderes, socket.freeres = p.getCpuSupply(socket, cpus)
+	socket.mem, socket.pMem, socket.hbm = p.getMemSupply(socket, cpus)
 
 	if dieIDs := p.sys.Package(socketID).DieIDs(); len(dieIDs) > 1 {
 		for _, dieID := range dieIDs {
@@ -141,8 +141,8 @@ func (p *policy) buildDiePool(socketID, dieID idset.ID, socket Node) {
 	log.Info("+ created pool %s", die.Name())
 
 	cpus := p.sys.Package(socketID).DieCPUSet(dieID)
-	die.node.noderes, die.node.freeres = p.getCpuSupply(die, cpus)
-	die.node.mem, die.node.pMem, die.node.hbm = p.getMemSupply(die, cpus)
+	die.noderes, die.freeres = p.getCpuSupply(die, cpus)
+	die.mem, die.pMem, die.hbm = p.getMemSupply(die, cpus)
 
 	if nodeIDs := p.sys.Package(socketID).DieNodeIDs(dieID); len(nodeIDs) > 1 {
 		for _, nodeID := range nodeIDs {
@@ -171,8 +171,8 @@ func (p *policy) buildNumaNodePool(socketID, nodeID idset.ID, parent Node) {
 	log.Info("+ created pool %s", node.Name())
 
 	cpus := p.sys.Node(nodeID).CPUSet()
-	node.node.noderes, node.node.freeres = p.getCpuSupply(node, cpus)
-	node.node.mem, node.node.pMem, node.node.hbm = p.getMemSupply(node, cpus)
+	node.noderes, node.freeres = p.getCpuSupply(node, cpus)
+	node.mem, node.pMem, node.hbm = p.getMemSupply(node, cpus)
 }
 
 func (p *policy) getCpuSupply(node Node, cpus cpuset.CPUSet) (Supply, Supply) {

--- a/cmd/plugins/topology-aware/policy/pools_test.go
+++ b/cmd/plugins/topology-aware/policy/pools_test.go
@@ -36,6 +36,11 @@ func findNodeWithName(name string, nodes []Node) Node {
 	panic("No node found with name " + name)
 }
 
+func removeAll(t *testing.T, path string) {
+	if err := os.RemoveAll(path); err != nil {
+		t.Fatalf("failed to remove %q: %v", path, err)
+	}
+}
 func TestPoolCreation(t *testing.T) {
 
 	// Test pool creation with "real" sysfs data.
@@ -45,7 +50,7 @@ func TestPoolCreation(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	defer os.RemoveAll(dir)
+	defer removeAll(t, dir)
 
 	// Uncompress the test data to the directory.
 	err = utils.UncompressTbz2(path.Join("testdata", "sysfs.tar.bz2"), dir)
@@ -200,7 +205,7 @@ func TestWorkloadPlacement(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	defer os.RemoveAll(dir)
+	defer removeAll(t, dir)
 
 	// Uncompress the test data to the directory.
 	err = utils.UncompressTbz2(path.Join("testdata", "sysfs.tar.bz2"), dir)
@@ -306,7 +311,7 @@ func TestAffinities(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	defer os.RemoveAll(dir)
+	defer removeAll(t, dir)
 
 	// Uncompress the test data to the directory.
 	err = utils.UncompressTbz2(path.Join("testdata", "sysfs.tar.bz2"), dir)

--- a/cmd/plugins/topology-aware/policy/resources.go
+++ b/cmd/plugins/topology-aware/policy/resources.go
@@ -454,7 +454,8 @@ func (cs *supply) AllocateCPU(r Request) (Grant, error) {
 	grant.AccountAllocateCPU()
 
 	if fraction > 0 {
-		if cpuType == cpuNormal {
+		switch cpuType {
+		case cpuNormal:
 			// allocate requested portion of shared CPUs
 			if cs.AllocatableSharedCPU() < fraction {
 				cs.ReleaseCPU(grant)
@@ -463,7 +464,7 @@ func (cs *supply) AllocateCPU(r Request) (Grant, error) {
 					cs.node.Name(), fraction, cs.sharable, cs.AllocatableSharedCPU())
 			}
 			cs.grantedShared += fraction
-		} else if cpuType == cpuReserved {
+		case cpuReserved:
 			// allocate requested portion of reserved CPUs
 			if cs.AllocatableReservedCPU() < fraction {
 				cs.ReleaseCPU(grant)
@@ -967,7 +968,7 @@ func (cs *supply) AllocatableReservedCPU() int {
 
 // AllocatableSharedCPU calculates the allocatable amount of shared CPU of this supply.
 func (cs *supply) AllocatableSharedCPU(quiet ...bool) int {
-	verbose := !(len(quiet) > 0 && quiet[0])
+	verbose := len(quiet) == 0 || !quiet[0]
 
 	// Notes:
 	//   Take into account the supplies/grants in all ancestors, making sure

--- a/pkg/agent/podresapi/client.go
+++ b/pkg/agent/podresapi/client.go
@@ -94,7 +94,7 @@ func NewClient(options ...ClientOption) (*Client, error) {
 // Close closes the client.
 func (c *Client) Close() {
 	if c != nil && c.conn != nil {
-		c.conn.Close()
+		c.conn.Close() // nolint:errcheck
 		c.conn = nil
 	}
 	c.cli = nil

--- a/pkg/agent/watch/file.go
+++ b/pkg/agent/watch/file.go
@@ -109,7 +109,7 @@ func (w *FileWatch) run() error {
 		for {
 			select {
 			case <-w.stopC:
-				w.fsw.Close()
+				w.fsw.Close() // nolint:errcheck
 				close(w.resultC)
 				close(w.doneC)
 				return

--- a/pkg/apis/config/v1alpha1/balloons-policy.go
+++ b/pkg/apis/config/v1alpha1/balloons-policy.go
@@ -55,7 +55,7 @@ func (c *BalloonsPolicy) Validate() error {
 		return err
 	}
 
-	if err := c.Spec.Config.Validate(); err != nil {
+	if err := c.Spec.Validate(); err != nil {
 		return err
 	}
 

--- a/pkg/cgroups/cgroupblkio.go
+++ b/pkg/cgroups/cgroupblkio.go
@@ -350,7 +350,12 @@ func (dpm defaultPlatform) writeToFile(filename string, content string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		cerr := f.Close()
+		if cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
 	_, err = fmt.Fprintf(f, "%s", content)
 	return err
 }

--- a/pkg/cgroups/cgroupcontrol.go
+++ b/pkg/cgroups/cgroupcontrol.go
@@ -159,7 +159,11 @@ func (g Group) Write(entry, format string, args ...interface{}) error {
 	if err != nil {
 		return g.errorf("%q: failed to open: %v", entry, err)
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
 
 	data := fmt.Sprintf(format, args...)
 	if _, err := f.Write([]byte(data)); err != nil {
@@ -179,7 +183,7 @@ func (g Group) readPids(entry string) ([]string, error) {
 	if err != nil {
 		return nil, g.errorf("failed to open %q: %v", entry, err)
 	}
-	defer f.Close()
+	defer f.Close() // nolint:errcheck
 
 	s := bufio.NewScanner(f)
 	for s.Scan() {
@@ -200,7 +204,11 @@ func (g Group) writePids(entry string, pids ...string) error {
 	if err != nil {
 		return g.errorf("failed to write pids to %q: %v", pidFile, err)
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
 
 	for _, pid := range pids {
 		if _, err := f.Write([]byte(pid)); err != nil {

--- a/pkg/cgroups/cgroupstats.go
+++ b/pkg/cgroups/cgroupstats.go
@@ -278,9 +278,10 @@ func GetCPUSetMemoryMigrate(cgroupPath string) (bool, error) {
 		return false, err
 	}
 
-	if number == 0 {
+	switch number {
+	case 0:
 		return false, nil
-	} else if number == 1 {
+	case 1:
 		return true, nil
 	}
 

--- a/pkg/cpuallocator/cpuallocator_test.go
+++ b/pkg/cpuallocator/cpuallocator_test.go
@@ -33,7 +33,7 @@ func TestAllocatorHelper(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create tmpdir: %v", err)
 	}
-	defer os.RemoveAll(tmpdir)
+	defer removeAll(t, tmpdir)
 
 	if err := utils.UncompressTbz2(path.Join("testdata", "sysfs.tar.bz2"), tmpdir); err != nil {
 		t.Fatalf("failed to decompress testdata: %v", err)
@@ -111,7 +111,7 @@ func TestClusteredAllocation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create tmpdir: %v", err)
 	}
-	defer os.RemoveAll(tmpdir)
+	defer removeAll(t, tmpdir)
 
 	if err := utils.UncompressTbz2(path.Join("testdata", "sysfs.tar.bz2"), tmpdir); err != nil {
 		t.Fatalf("failed to decompress testdata: %v", err)
@@ -327,7 +327,7 @@ func TestClusteredCoreKindAllocation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create tmpdir: %v", err)
 	}
-	defer os.RemoveAll(tmpdir)
+	defer removeAll(t, tmpdir)
 
 	if err := utils.UncompressTbz2(path.Join("testdata", "sysfs.tar.bz2"), tmpdir); err != nil {
 		t.Fatalf("failed to decompress testdata: %v", err)
@@ -744,5 +744,11 @@ func TestClusteredCoreKindAllocation(t *testing.T) {
 				t.Errorf("expected %q, result was %q", tc.expected, result)
 			}
 		})
+	}
+}
+
+func removeAll(t *testing.T, path string) {
+	if err := os.RemoveAll(path); err != nil {
+		t.Fatalf("failed to remove %q: %v", path, err)
 	}
 }

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -182,7 +182,7 @@ func (s *Server) Stop() {
 		return
 	}
 
-	s.server.Close()
+	s.server.Close() // nolint:errcheck
 	s.server = nil
 }
 

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -75,7 +75,7 @@ type testHandler struct {
 }
 
 func (h *testHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, "%s", h.response)
+	fmt.Fprintf(w, "%s", h.response) // nolint:errcheck
 }
 
 func TestPatternsp(t *testing.T) {

--- a/pkg/instrumentation/instrumentation_test.go
+++ b/pkg/instrumentation/instrumentation_test.go
@@ -76,7 +76,7 @@ func checkPrometheus(t *testing.T, server string, shouldFail bool) {
 		}
 
 		_, err = io.ReadAll(rpl.Body)
-		rpl.Body.Close()
+		rpl.Body.Close() // nolint:errcheck
 		if err != nil {
 			t.Errorf("failed to read Prometheus response: %v", err)
 		}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -403,7 +403,7 @@ func (srv *testServer) collect(t *testing.T) (described, collected) {
 	resp, err := http.Get("http://localhost" + srv.srv.Addr + "/metrics")
 	require.NoError(t, err)
 
-	defer resp.Body.Close()
+	defer resp.Body.Close() // nolint:errcheck
 
 	var (
 		types   []string

--- a/pkg/pidfile/pidfile.go
+++ b/pkg/pidfile/pidfile.go
@@ -59,7 +59,7 @@ func Write() error {
 		return fmt.Errorf("failed to create PID file: %w", err)
 	}
 
-	_, err = pidFile.Write([]byte(fmt.Sprintf("%d\n", os.Getpid())))
+	_, err = fmt.Fprintf(pidFile, "%d\n", os.Getpid())
 	if err != nil {
 		close()
 		return fmt.Errorf("failed to write PID file: %w", err)
@@ -98,7 +98,9 @@ func close() {
 		if err := pidFile.Truncate(0); err != nil {
 			logger.Default().Warnf("failed to truncate PID file: %v\n", err)
 		}
-		pidFile.Close()
+		if err := pidFile.Close(); err != nil {
+			logger.Default().Warnf("failed to close PID file: %v\n", err)
+		}
 		pidFile = nil
 	}
 }

--- a/pkg/pidfile/pidfile_test.go
+++ b/pkg/pidfile/pidfile_test.go
@@ -247,7 +247,9 @@ func mkTestDir(t *testing.T) (string, error) {
 	}
 
 	t.Cleanup(func() {
-		os.RemoveAll(tmp)
+		if err := os.RemoveAll(tmp); err != nil {
+			t.Errorf("failed to remove test directory %s: %v", tmp, err)
+		}
 	})
 
 	return tmp, nil

--- a/pkg/resmgr/cache/cache.go
+++ b/pkg/resmgr/cache/cache.go
@@ -1231,7 +1231,11 @@ func (cch *cache) WriteFile(id string, name string, perm os.FileMode, data []byt
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() {
+		if cerr := file.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
 	_, err = file.Write(data)
 
 	return err

--- a/pkg/resmgr/cache/container_test.go
+++ b/pkg/resmgr/cache/container_test.go
@@ -859,7 +859,9 @@ func createSysFsDevice(devType string, major, minor int64) error {
 	if _, err := f.Write([]byte(cpulist)); err != nil {
 		log.Get("cache").Errorf("unable to write to %s: %v", realDevPath+"/local_cpulist", err)
 	}
-	f.Close()
+	if err := f.Close(); err != nil {
+		return err
+	}
 
 	f, err = os.Create(realDevPath + "/numa_node")
 	if err != nil {
@@ -869,7 +871,9 @@ func createSysFsDevice(devType string, major, minor int64) error {
 	if _, err := f.Write([]byte(numanode)); err != nil {
 		log.Get("cache").Errorf("unable to write to %s: %v", realDevPath+"/numa_node", err)
 	}
-	f.Close()
+	if err := f.Close(); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/pkg/resmgr/control/cpu/cpu.go
+++ b/pkg/resmgr/control/cpu/cpu.go
@@ -132,14 +132,14 @@ func (ctl *cpuctl) enforceCpufreq(class string, cpus ...int) error {
 	if min := int(c.MinFreq); min > 0 {
 		log.Debug("enforcing cpu frequency min %d from class %q on %v", min, class, cpus)
 		if err := utils.SetCPUsScalingMinFreq(cpus, min); err != nil {
-			return fmt.Errorf("Cannot set min freq %d: %w", min, err)
+			return fmt.Errorf("cannot set min freq %d: %w", min, err)
 		}
 	}
 
 	if max := int(c.MaxFreq); max > 0 {
 		log.Debug("enforcing cpu frequency max %d from class %q on %v", max, class, cpus)
 		if err := utils.SetCPUsScalingMaxFreq(cpus, max); err != nil {
-			return fmt.Errorf("Cannot set max freq %d: %w", max, err)
+			return fmt.Errorf("cannot set max freq %d: %w", max, err)
 		}
 	}
 

--- a/pkg/resmgr/control/e2e-test/e2e-test.go
+++ b/pkg/resmgr/control/e2e-test/e2e-test.go
@@ -140,7 +140,7 @@ func (ctl *testctl) dumpE2ETestControllerState(w http.ResponseWriter, req *http.
 		return
 	}
 
-	fmt.Fprintf(w, "%s\r\n", data)
+	fmt.Fprintf(w, "%s\r\n", data) // nolint:errcheck
 }
 
 func (ctl *testctl) registerHandler() {

--- a/pkg/resmgr/resource-manager.go
+++ b/pkg/resmgr/resource-manager.go
@@ -133,7 +133,7 @@ func (m *resmgr) Start() error {
 
 func (m *resmgr) updateConfig(newCfg interface{}) (bool, error) {
 	if newCfg == nil {
-		return false, fmt.Errorf("can't run without effective configuration...")
+		return false, fmt.Errorf("can't run without effective configuration")
 	}
 
 	cfg, ok := newCfg.(cfgapi.ResmgrConfig)

--- a/pkg/sysfs/system.go
+++ b/pkg/sysfs/system.go
@@ -1397,9 +1397,9 @@ func (sys *system) discoverNodes() error {
 	}
 	cpuNodes := cpuset.New(cpuNodesSlice...)
 
-	sys.Logger.Info("NUMA nodes with CPUs: %s", cpuNodes.String())
-	sys.Logger.Info("NUMA nodes with (any) memory: %s", memoryNodes.String())
-	sys.Logger.Info("NUMA nodes with normal memory: %s", normalMemNodes.String())
+	sys.Info("NUMA nodes with CPUs: %s", cpuNodes.String())
+	sys.Info("NUMA nodes with (any) memory: %s", memoryNodes.String())
+	sys.Info("NUMA nodes with normal memory: %s", normalMemNodes.String())
 
 	noMemNodes := onlineNodes.Difference(memoryNodes)
 	dramNodes := cpuNodes.Clone()
@@ -1446,17 +1446,17 @@ func (sys *system) discoverNodes() error {
 				return fmt.Errorf("not able to determine system special memory types")
 			}
 			if mem.MemTotal < dramAvg {
-				sys.Logger.Info("node %d has HBM memory", node.id)
+				sys.Info("node %d has HBM memory", node.id)
 				node.memoryType = MemoryTypeHBM
 			} else {
-				sys.Logger.Info("node %d has PMEM memory", node.id)
+				sys.Info("node %d has PMEM memory", node.id)
 				node.memoryType = MemoryTypePMEM
 			}
 		} else if _, ok := dramNodeIds[node.id]; ok {
-			sys.Logger.Info("node %d has DRAM memory", node.id)
+			sys.Info("node %d has DRAM memory", node.id)
 			node.memoryType = MemoryTypeDRAM
 		} else {
-			return fmt.Errorf("Unknown memory type for node %v (pmem nodes: %s, dram nodes: %s)", node, pmemOrHbmNodes, dramNodes)
+			return fmt.Errorf("unknown memory type for node %v (pmem nodes: %s, dram nodes: %s)", node, pmemOrHbmNodes, dramNodes)
 		}
 	}
 

--- a/pkg/sysfs/utils.go
+++ b/pkg/sysfs/utils.go
@@ -127,7 +127,11 @@ func writeSysfsEntry(base, entry string, val, oldp interface{}, args ...interfac
 	if err != nil {
 		return "", sysfsError(path, "cannot open: %w", err)
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = sysfsError(path, "failed to close: %w", cerr)
+		}
+	}()
 
 	if _, err = f.Write([]byte(buf + "\n")); err != nil {
 		return "", sysfsError(path, "cannot write: %w", err)

--- a/pkg/udev/monitor.go
+++ b/pkg/udev/monitor.go
@@ -88,7 +88,7 @@ func (m *Monitor) reader(events chan<- *Event) {
 		evt, err := m.r.Read()
 		if err != nil {
 			log.Errorf("failed to read udev event: %v", err)
-			m.r.Close()
+			m.r.Close() // nolint:errcheck
 			close(events)
 			return
 		}

--- a/pkg/udev/reader.go
+++ b/pkg/udev/reader.go
@@ -71,7 +71,7 @@ func NewReader() (*Reader, error) {
 	}
 
 	if err := syscall.Bind(fd, &addr); err != nil {
-		syscall.Close(fd)
+		syscall.Close(fd) // nolint:errcheck
 		return nil, fmt.Errorf("failed to bind udev reader: %w", err)
 	}
 

--- a/pkg/utils/net.go
+++ b/pkg/utils/net.go
@@ -25,7 +25,7 @@ import (
 func IsListeningSocket(socket string) (bool, error) {
 	conn, err := net.Dial("unix", socket)
 	if err == nil {
-		conn.Close()
+		conn.Close() // nolint:errcheck
 		return true, nil
 	}
 


### PR DESCRIPTION
Bump golangci-lint to v2.4.0

Fix errors found by this version of golangci-lint:

- unchecked errors (use nolint:errcheck where we're only reading)
- multiple imports of the same package
- nolint for error names that linter didn't like
- use strings.ReplaceAll
- remove unnecessary use of embedded fields of structs
- use switch-case instead of if/else
- apply De Morgan’s law
- use fmt.Fprintf instead of file.Write
- fix error strings (don't start with capital letter, don't end with
  punctuation)