### PR TITLE
image-build: switch to bookworm for image building.

### DIFF
--- a/cmd/config-manager/Dockerfile
+++ b/cmd/config-manager/Dockerfile
@@ -1,7 +1,7 @@
 # Build Stage
 ARG GO_VERSION=1.25
 
-FROM golang:${GO_VERSION}-bullseye AS build
+FROM golang:${GO_VERSION}-bookworm AS build
 WORKDIR /go/builder
 
 # Fetch go dependencies in a separate layer for caching

--- a/cmd/mpolset/Dockerfile
+++ b/cmd/mpolset/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.25
 
-FROM golang:${GO_VERSION}-bullseye AS builder
+FROM golang:${GO_VERSION}-bookworm AS builder
 
 ARG IMAGE_VERSION
 ARG BUILD_VERSION

--- a/cmd/plugins/balloons/Dockerfile
+++ b/cmd/plugins/balloons/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.25
 
-FROM golang:${GO_VERSION}-bullseye AS builder
+FROM golang:${GO_VERSION}-bookworm AS builder
 
 ARG IMAGE_VERSION
 ARG BUILD_VERSION

--- a/cmd/plugins/memory-policy/Dockerfile
+++ b/cmd/plugins/memory-policy/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.25
 
-FROM golang:${GO_VERSION}-bullseye AS builder
+FROM golang:${GO_VERSION}-bookworm AS builder
 
 ARG IMAGE_VERSION
 ARG BUILD_VERSION

--- a/cmd/plugins/memory-qos/Dockerfile
+++ b/cmd/plugins/memory-qos/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.25
 
-FROM golang:${GO_VERSION}-bullseye AS builder
+FROM golang:${GO_VERSION}-bookworm AS builder
 
 ARG IMAGE_VERSION
 ARG BUILD_VERSION

--- a/cmd/plugins/memtierd/Dockerfile
+++ b/cmd/plugins/memtierd/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.25
 
-FROM golang:${GO_VERSION}-bullseye AS builder
+FROM golang:${GO_VERSION}-bookworm AS builder
 
 ARG IMAGE_VERSION
 ARG BUILD_VERSION

--- a/cmd/plugins/sgx-epc/Dockerfile
+++ b/cmd/plugins/sgx-epc/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.25
 
-FROM golang:${GO_VERSION}-bullseye AS builder
+FROM golang:${GO_VERSION}-bookworm AS builder
 
 ARG IMAGE_VERSION
 ARG BUILD_VERSION

--- a/cmd/plugins/template/Dockerfile
+++ b/cmd/plugins/template/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.25
 
-FROM golang:${GO_VERSION}-bullseye AS builder
+FROM golang:${GO_VERSION}-bookworm AS builder
 
 ARG IMAGE_VERSION
 ARG BUILD_VERSION

--- a/cmd/plugins/topology-aware/Dockerfile
+++ b/cmd/plugins/topology-aware/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.25
 
-FROM golang:${GO_VERSION}-bullseye AS builder
+FROM golang:${GO_VERSION}-bookworm AS builder
 
 ARG IMAGE_VERSION
 ARG BUILD_VERSION


### PR DESCRIPTION
We need to switch our image building to bookworm from bullseye. There are no golang-1.25.x images for bullseye.