### PR TITLE
e2e: don't fail if partition resize fails.

### DIFF
--- a/test/e2e/playbook/provision.yaml
+++ b/test/e2e/playbook/provision.yaml
@@ -163,7 +163,13 @@
       ansible.builtin.shell: |
         fstype="$(stat -f -c %T /)"
         if [ "$fstype" == "btrfs" ]; then
-            growpart /dev/vda 4 && btrfs filesystem resize max /
+            growpart /dev/vda 4
+            status=$?
+            case $status in
+                 0) btrfs filesystem resize max /;;
+                 1) ;; # already at max size
+                 *) echo "***** WARNING: failed to grow partition";;
+            esac
         else
             echo "***** WARNING: Root filesystem type ($fstype) is not btrfs."
             echo "***** WARNING: resize of / to max possible size..."


### PR DESCRIPTION
Don't fail if partition is already maxed out. Also, if we fail to resize the partition for any other reason, print a warning instead of aborting all test runs.