### PR TITLE
build: explicitly use docker buildx for image building.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ E2E_TESTS     ?= $(E2E_DIR)/policies.test-suite
 E2E_WORKDIR   ?= $(TOP_DIR)/e2e-results
 
 DOCKER       := docker
-DOCKER_BUILD := $(DOCKER) build
+DOCKER_BUILD := $(DOCKER) buildx build
 
 # Plugins and other binaries we build.
 #


### PR DESCRIPTION
Use docker buildx for image building to ensure we always build with buildkit.