### PR TITLE
e2e: support custom image URLs, use fedora 42 by default.

### DIFF
--- a/test/e2e/files/Vagrantfile.in
+++ b/test/e2e/files/Vagrantfile.in
@@ -57,6 +57,7 @@ Vagrant.configure("2") do |config|
   config.vm.define HOSTNAME
   config.vm.hostname = HOSTNAME
   config.vm.box = IMAGE_NAME
+# config.vm.box_url =
   config.vm.box_check_update = false
   config.nfs.functional = false
   config.vm.network "forwarded_port", id: "ssh", host: SSH_PORT, guest: 22

--- a/test/e2e/lib/vm.bash
+++ b/test/e2e/lib/vm.bash
@@ -124,6 +124,13 @@ vm-setup() {
 	echo "CPU: $CPU"
 	echo "MEM: $MEM"
 	echo "EXTRA: $EXTRA_ARGS"
+        echo "image: ${distro_img:-vagrant default}"
+    fi
+
+    if [ -n "$distro_img" ]; then
+        CUSTOM_IMAGE="config.vm.box_url = \"$distro_img\""
+    else
+        CUSTOM_IMAGE="# config.vm.box_url = vagrant default image"
     fi
 
     if [ ! -f "$vagrantdir/Vagrantfile" ]; then
@@ -134,6 +141,7 @@ vm-setup() {
 	    -e "s/QEMU_SMP/$CPU/" \
 	    -e "s/QEMU_EXTRA_ARGS/$EXTRA_ARGS/" \
             -e "s:QEMU_DIR:$qemu_dir:" \
+            -e "s|^.*config.vm.box_url.*$|$CUSTOM_IMAGE|g" \
 	    "$files/Vagrantfile.in" > "$vagrantdir/Vagrantfile.erb"
     fi
 

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -1,11 +1,19 @@
 #!/bin/bash
 
 TITLE="NRI Resource Policy End-to-End Testing"
-DEFAULT_DISTRO=${DEFAULT_DISTRO:-"fedora/40-cloud-base"}
+DEFAULT_DISTRO=${DEFAULT_DISTRO:-"fedora-42/cloud-base"}
 
 # Other tested distros
 #    generic/ubuntu2204
-#    fedora/37-cloud-base
+#    fedora-40/cloud-base
+#    fedora-41/cloud-base
+
+declare -A distro_images=(
+        ["generic/ubuntu2204"]=""
+        ["fedora-40/cloud-base"]=""
+        ["fedora-41/cloud-base"]="https://mirror.karneval.cz/pub/linux/fedora/linux/releases/41/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-libvirt-41-1.4.x86_64.vagrant.libvirt.box"
+        ["fedora-42/cloud-base"]="https://download.fedoraproject.org/pub/fedora/linux/releases/42/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-libvirt-42-1.1.x86_64.vagrant.libvirt.box"
+)
 
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 SRC_DIR=$(realpath "$SCRIPT_DIR/../..")
@@ -19,6 +27,11 @@ export TEST_OUTPUT_DIR=${test_outdir:-"$OUTPUT_DIR"}
 export COMMAND_OUTPUT_DIR="$TEST_OUTPUT_DIR"/commands
 
 distro=${distro:-$DEFAULT_DISTRO}
+image_url=${distro_images[$distro]}
+if [ -n "$image_url" ]; then
+    export distro_img="$image_url"
+fi
+
 export k8scri=${k8scri:-"containerd"}
 export cni_plugin=${cni_plugin:-bridge}
 export cni_release=${cni_release:-latest}
@@ -194,6 +207,7 @@ fi
 echo
 echo "    VM              = $vm_name"
 echo "    Distro          = $distro"
+echo "    Distro image    = ${distro_img:-vagrant default}"
 echo "    Kubernetes"
 echo "      - release     = $k8s_release"
 echo "      - version     = $k8s_version"

--- a/test/e2e/run_tests.sh
+++ b/test/e2e/run_tests.sh
@@ -4,7 +4,7 @@ TESTS_DIR="$1"
 SKIP_LONG_TESTS="${skip_long_tests:-yes}"
 RUN_SH="${0%/*}/run.sh"
 
-DEFAULT_DISTRO=${DEFAULT_DISTRO:-"fedora/40-cloud-base"}
+DEFAULT_DISTRO=${DEFAULT_DISTRO:-"fedora-42/cloud-base"}
 
 k8scri=${k8scri:="containerd"}
 


### PR DESCRIPTION
Add support for pulling vagrant images from custom URLs or URLs from default vagrant image locations which are not hosted by Hashicorp. Use fedora 42 cloud base image by default.