### PR TITLE
e2e: adjust cloud image URLs, allow image override, fix ssh connectivity problems.

### DIFF
--- a/test/e2e/playbook/provision.yaml
+++ b/test/e2e/playbook/provision.yaml
@@ -113,6 +113,12 @@
         path: /tmp/get_helm.sh
         state: absent
 
+    - name: Install ansible.builtin.dnf dependencies
+      ansible.builtin.shell: |
+        dnf install -y python3-libdnf5
+      when: (ansible_facts['distribution'] == "Fedora") and
+            (ansible_facts['distribution_major_version'] | int == 41)
+
     - name: Install common packages
       ansible.builtin.package:
         name:

--- a/test/e2e/playbook/provision.yaml
+++ b/test/e2e/playbook/provision.yaml
@@ -76,6 +76,21 @@
         state: absent
       when: ansible_facts['distribution'] == "Ubuntu"
 
+    - name: Disable ssh daemon per source penalties
+      block:
+        - name: Disable ssh daemon per source penalties
+          ansible.builtin.copy:
+            dest: /etc/ssh/sshd_config.d/90-disable-persource-penalties.conf
+            content: |
+              PerSourcePenalties no
+            mode: '0644'
+        - name: Restart ssh daemon
+          ansible.builtin.systemd:
+            name: sshd
+            state: restarted
+      when: (ansible_facts['distribution'] == "Fedora") and
+            (ansible_facts['distribution_major_version'] | int >= 41)
+
     - name: Update APT package index
       ansible.builtin.apt:
         update_cache: yes

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -8,12 +8,22 @@ DEFAULT_DISTRO=${DEFAULT_DISTRO:-"fedora/42"}
 #    fedora/40
 #    fedora/41
 
-declare -A distro_images=(
+if [ -z "${!distro_images[*]}" ]; then
+    echo "Using stock distro images"
+    declare -A distro_images=(
         ["generic/ubuntu2204"]=""
         ["fedora/40"]="https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-libvirt.x86_64-40-1.14.vagrant.libvirt.box"
         ["fedora/41"]="https://dl.fedoraproject.org/pub/fedora/linux/releases/41/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-libvirt-41-1.4.x86_64.vagrant.libvirt.box"
         ["fedora/42"]="https://dl.fedoraproject.org/pub/fedora/linux/releases/42/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-libvirt-42-1.1.x86_64.vagrant.libvirt.box"
-)
+    )
+else
+    echo "WARNING: using overridden distro images"
+fi
+
+for d in ${distro_images[*]}; do
+    img=${distro_images[$d]}
+    echo "  - $d: ${img:-vagrant resolved default}"
+done
 
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 SRC_DIR=$(realpath "$SCRIPT_DIR/../..")

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 
 TITLE="NRI Resource Policy End-to-End Testing"
-DEFAULT_DISTRO=${DEFAULT_DISTRO:-"fedora-42/cloud-base"}
+DEFAULT_DISTRO=${DEFAULT_DISTRO:-"fedora/42"}
 
 # Other tested distros
 #    generic/ubuntu2204
-#    fedora-40/cloud-base
-#    fedora-41/cloud-base
+#    fedora/40
+#    fedora/41
 
 declare -A distro_images=(
         ["generic/ubuntu2204"]=""
-        ["fedora-40/cloud-base"]=""
-        ["fedora-41/cloud-base"]="https://mirror.karneval.cz/pub/linux/fedora/linux/releases/41/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-libvirt-41-1.4.x86_64.vagrant.libvirt.box"
-        ["fedora-42/cloud-base"]="https://download.fedoraproject.org/pub/fedora/linux/releases/42/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-libvirt-42-1.1.x86_64.vagrant.libvirt.box"
+        ["fedora/40"]="https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-libvirt.x86_64-40-1.14.vagrant.libvirt.box"
+        ["fedora/41"]="https://dl.fedoraproject.org/pub/fedora/linux/releases/41/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-libvirt-41-1.4.x86_64.vagrant.libvirt.box"
+        ["fedora/42"]="https://dl.fedoraproject.org/pub/fedora/linux/releases/42/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-libvirt-42-1.1.x86_64.vagrant.libvirt.box"
 )
 
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"

--- a/test/e2e/run_tests.sh
+++ b/test/e2e/run_tests.sh
@@ -4,7 +4,7 @@ TESTS_DIR="$1"
 SKIP_LONG_TESTS="${skip_long_tests:-yes}"
 RUN_SH="${0%/*}/run.sh"
 
-DEFAULT_DISTRO=${DEFAULT_DISTRO:-"fedora-42/cloud-base"}
+DEFAULT_DISTRO=${DEFAULT_DISTRO:-"fedora/42"}
 
 k8scri=${k8scri:="containerd"}
 


### PR DESCRIPTION
This PR fixes a number recent/remaining problems with vagrant images in e2e tests. In particular,

- adjusts fat-fingered or otherwise wrong cloud image URLs
- allows overriding distro images (for instance to local caches for environments behind proxies)
- fixes post-provisioning ssh connectivity problems with Fedora >= 41 images
- changes default distro consistently to fedora/42.