### PR TITLE
docs: fix and improve reset (allow all) affinity

### DIFF
--- a/docs/resource-policy/policy/balloons.md
+++ b/docs/resource-policy/policy/balloons.md
@@ -657,8 +657,9 @@ spec:
     namespaces:
     - "*"
     shareIdleCPUsInSame: system
+    # preferIsolCpus: true # uncomment to use kernel isolcpus, too
   reservedResources:
-    cpu: 1
+    cpu: 1000m
   pinCPU: true
   pinMemory: true
 ```


### PR DESCRIPTION
- "cpu: 1" is an error because a string is expected
- add option for handling isolcpus in reset