### PR TITLE
e2e: alternate test runtimes in tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ GO_LICENSES_VERSION := v1.6.0
 SKIP_LICENSES       ?= 0
 
 E2E_DIR       := $(TOP_DIR)/test/e2e
-E2E_RUN       := $(E2E_DIR)/run_tests.sh
+E2E_RUN       := k8scri=$${k8scri:-containerd} $(E2E_DIR)/run_tests.sh
 E2E_TESTS     ?= $(E2E_DIR)/policies.test-suite
 E2E_WORKDIR   ?= $(TOP_DIR)/e2e-results
 

--- a/scripts/testing/e2e-runner
+++ b/scripts/testing/e2e-runner
@@ -192,12 +192,19 @@ run_e2e_tests() {
         k8scri=crio
     fi
 
+    # once per week build all binaries and images, otherwise just the bare minimal set
+    if [ $(( $(date +%j) % 7 )) != 0 ]; then
+       export PLUGINS="nri-resource-policy-balloons nri-resource-policy-topology-aware"
+       export BINARIES=""
+       export OTHER_IMAGE_TARGETS=""
+    fi
+
     info "running e2e tests ${E2E_TESTS:-with the default test set}..."
     must-cd "$WORKTREE"
     if [ -n "$E2E_TESTS" ]; then
-        make SKIP_LICENSES=1 k8scri=$k8scri E2E_TESTS="$E2E_TESTS" e2e-tests
+        make SKIP_LICENSES=1 k8scri=$k8scri $minimal E2E_TESTS="$E2E_TESTS" e2e-tests
     else
-        make SKIP_LICENSES=1 k8scri=$k8scri e2e-tests
+        make SKIP_LICENSES=1 k8scri=$k8scri $minimal e2e-tests
     fi
 }
 

--- a/scripts/testing/e2e-runner
+++ b/scripts/testing/e2e-runner
@@ -185,14 +185,19 @@ prepare_result_dir() {
 }
 
 run_e2e_tests() {
-    local tests
+    local k8scri=containerd
+
+    # test every other day with cri-o
+    if [ $(( $(date +%j) % 2 )) != 0 ]; then
+        k8scri=crio
+    fi
 
     info "running e2e tests ${E2E_TESTS:-with the default test set}..."
     must-cd "$WORKTREE"
     if [ -n "$E2E_TESTS" ]; then
-        make SKIP_LICENSES=1 E2E_TESTS="$E2E_TESTS" e2e-tests
+        make SKIP_LICENSES=1 k8scri=$k8scri E2E_TESTS="$E2E_TESTS" e2e-tests
     else
-        make SKIP_LICENSES=1 e2e-tests
+        make SKIP_LICENSES=1 k8scri=$k8scri e2e-tests
     fi
 }
 


### PR DESCRIPTION
- alternate the CRI runtime tests are being run on every other day
- only build the full set of binaries and images once per week, otherwise the minimal set we're going to test
