### PR TITLE
e2e: EFI BIOS support for e2e test VMs.

### DIFF
--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -37,6 +37,7 @@ export TEST_OUTPUT_DIR=${test_outdir:-"$OUTPUT_DIR"}
 export COMMAND_OUTPUT_DIR="$TEST_OUTPUT_DIR"/commands
 
 distro=${distro:-$DEFAULT_DISTRO}
+efi=${efi:-}
 
 export k8scri=${k8scri:-"containerd"}
 export cni_plugin=${cni_plugin:-bridge}
@@ -244,6 +245,7 @@ fi
 
 echo
 echo "    VM              = $vm_name"
+echo "    EFI boot        = ${efi:-no}"
 echo "    Distro          = $distro"
 echo "    Distro image    = ${distro_img:-vagrant default}"
 echo "    Kubernetes"

--- a/test/e2e/run_tests.sh
+++ b/test/e2e/run_tests.sh
@@ -7,6 +7,7 @@ RUN_SH="${0%/*}/run.sh"
 DEFAULT_DISTRO=${DEFAULT_DISTRO:-"fedora/42"}
 
 k8scri=${k8scri:="containerd"}
+efi=${efi:-}
 
 proxy=${proxy:=$https_proxy}
 proxy=${proxy:=$HTTPS_PROXY}


### PR DESCRIPTION
Add EFI BIOS support for our e2e test VMs.
- use `efi=/usr/share/OVMF`, if `efi=1` is set
- create/boot VM using `$efi/OVMF_{CODE,VARS}[_4M].fd` if `$efi` is set
- dump extra `vm-setup()` info, if `vagrant_debug=1` is set