### PR TITLE
resmgr,helm: nuke obsolete metrics-interval command line flag.

### DIFF
--- a/deployment/helm/balloons/templates/daemonset.yaml
+++ b/deployment/helm/balloons/templates/daemonset.yaml
@@ -67,8 +67,6 @@ spec:
             - {{ .Release.Namespace }}
             - --pid-file
             - /tmp/nri-resource-policy.pid
-            - -metrics-interval
-            - 5s
             - --nri-plugin-index
             - "{{ .Values.nri.plugin.index | int | printf "%02d"  }}"
             {{- if .Values.configGroupLabel }}

--- a/deployment/helm/template/templates/daemonset.yaml
+++ b/deployment/helm/template/templates/daemonset.yaml
@@ -60,8 +60,6 @@ spec:
             - {{ .Release.Namespace }}
             - --pid-file
             - /tmp/nri-resource-policy.pid
-            - -metrics-interval
-            - 5s
             - --nri-plugin-index
             - "{{ .Values.nri.plugin.index | int | printf "%02d"  }}"
             {{- if .Values.configGroupLabel }}

--- a/deployment/helm/topology-aware/templates/daemonset.yaml
+++ b/deployment/helm/topology-aware/templates/daemonset.yaml
@@ -67,8 +67,6 @@ spec:
             - {{ .Release.Namespace }}
             - --pid-file
             - /tmp/nri-resource-policy.pid
-            - -metrics-interval
-            - 5s
             - --nri-plugin-index
             - "{{ .Values.nri.plugin.index | int | printf "%02d"  }}"
             {{- if .Values.configGroupLabel }}

--- a/pkg/resmgr/flags.go
+++ b/pkg/resmgr/flags.go
@@ -16,7 +16,6 @@ package resmgr
 
 import (
 	"flag"
-	"time"
 
 	"github.com/containerd/nri/pkg/api"
 	"github.com/containers/nri-plugins/pkg/pidfile"
@@ -32,7 +31,6 @@ type options struct {
 	HostRoot      string
 	StateDir      string
 	PidFile       string
-	MetricsTimer  time.Duration
 	NriPluginName string
 	NriPluginIdx  string
 	NriSocket     string
@@ -54,9 +52,6 @@ func init() {
 
 	flag.StringVar(&opt.PidFile, "pid-file", pidfile.GetPath(),
 		"PID file to write daemon PID to")
-	flag.DurationVar(&opt.MetricsTimer, "metrics-interval", 0,
-		"Obsolete way to set interval for polling/gathering runtime metrics data.\n"+
-			"Use the instrumentation section of the CR-based configuration interface instead.")
 	flag.StringVar(&opt.StateDir, "state-dir", "/var/lib/nri-resource-policy",
 		"Permanent storage directory path for the resource manager to store its state in.")
 }

--- a/pkg/resmgr/resource-manager.go
+++ b/pkg/resmgr/resource-manager.go
@@ -80,12 +80,6 @@ func NewResourceManager(backend policy.Backend, agt *agent.Agent) (ResourceManag
 		topology.SetSysRoot(opt.HostRoot)
 	}
 
-	if opt.MetricsTimer != 0 {
-		log.Warn("WARNING: obsolete metrics-interval flag given, ignoring...")
-		log.Warn("WARNING: use the CR-based configuration interface instead")
-		log.Warn("WARNING: this flag will be removed in a future release")
-	}
-
 	m := &resmgr{
 		agent: agt,
 	}


### PR DESCRIPTION
Nuke and stop using the obsolete `--metrics-interval` command line flag, to get rid of this warning in the startup logs:

```
W1014 05:10:36.579221       1 resource-manager.go:84] WARNING: obsolete metrics-interval flag given, ignoring...
W1014 05:10:36.579243       1 resource-manager.go:85] WARNING: use the CR-based configuration interface instead
W1014 05:10:36.579251       1 resource-manager.go:86] WARNING: this flag will be removed in a future release
```