### PR TITLE
balloons: allow allocation of online CPUs only

### DIFF
--- a/cmd/plugins/balloons/policy/balloons-policy.go
+++ b/cmd/plugins/balloons/policy/balloons-policy.go
@@ -1532,10 +1532,11 @@ func (p *balloons) setConfig(bpoptions *BalloonsOptions) error {
 	case cfgapi.AmountQuantity:
 		return balloonsError("can't handle CPU resources given as resource.Quantity (%v)", amount)
 	case cfgapi.AmountAbsent:
-		// Available CPUs not specified, default to all on-line CPUs.
-		availableCpus = p.options.System.CPUSet().Difference(p.options.System.Offlined())
+		// Available CPUs not specified, default to system CPUs.
+		availableCpus = p.options.System.CPUSet()
 	}
-	p.allowed = availableCpus
+	// Allocation of only online CPUs is allowed.
+	p.allowed = availableCpus.Intersection(p.options.System.OnlineCPUs())
 
 	setOmittedDefaults(bpoptions)
 

--- a/cmd/plugins/topology-aware/policy/topology-aware-policy.go
+++ b/cmd/plugins/topology-aware/policy/topology-aware-policy.go
@@ -536,9 +536,11 @@ func (p *policy) checkConstraints() error {
 	case cfgapi.AmountQuantity:
 		return fmt.Errorf("can't handle CPU resources given as resource.Quantity (%v)", amount)
 	case cfgapi.AmountAbsent:
-		// default to all online cpus
-		p.allowed = p.sys.CPUSet().Difference(p.sys.Offlined())
+		// Available CPUs not specified, default to system CPUs.
+		p.allowed = p.sys.CPUSet()
 	}
+	// Allocation of only online CPUs is allowed.
+	p.allowed = p.allowed.Intersection(p.sys.OnlineCPUs())
 
 	p.isolated = p.sys.Isolated().Intersection(p.allowed)
 


### PR DESCRIPTION
Fixes balloons NRT report and internal behavior when user-specified allowed resources cpuset contains CPUs that are not online. Previously used difference with OfflineCPUs() does not work in this context anymore because it contains only present CPUs not online, while user-specified set may extend even beyond all possible CPUs.