### PR TITLE
config/blockio: fix typo, clarify block I/O setup.

### DIFF
--- a/config/crd/bases/config.nri_balloonspolicies.yaml
+++ b/config/crd/bases/config.nri_balloonspolicies.yaml
@@ -342,7 +342,9 @@ spec:
                         description: |-
                           Enable class based block I/O prioritization and throttling. When
                           enabled, policy implementations can adjust block I/O priority by
-                          by assigning containers to block I/O priority classes.
+                          assigning containers to block I/O priority classes. Additionally
+                          you need to set up your cluster nodes' runtimes with the desired
+                          block I/O class configuration.
                         type: boolean
                       usePodQoSAsDefaultClass:
                         description: |-

--- a/config/crd/bases/config.nri_templatepolicies.yaml
+++ b/config/crd/bases/config.nri_templatepolicies.yaml
@@ -71,7 +71,9 @@ spec:
                         description: |-
                           Enable class based block I/O prioritization and throttling. When
                           enabled, policy implementations can adjust block I/O priority by
-                          by assigning containers to block I/O priority classes.
+                          assigning containers to block I/O priority classes. Additionally
+                          you need to set up your cluster nodes' runtimes with the desired
+                          block I/O class configuration.
                         type: boolean
                       usePodQoSAsDefaultClass:
                         description: |-

--- a/config/crd/bases/config.nri_topologyawarepolicies.yaml
+++ b/config/crd/bases/config.nri_topologyawarepolicies.yaml
@@ -85,7 +85,9 @@ spec:
                         description: |-
                           Enable class based block I/O prioritization and throttling. When
                           enabled, policy implementations can adjust block I/O priority by
-                          by assigning containers to block I/O priority classes.
+                          assigning containers to block I/O priority classes. Additionally
+                          you need to set up your cluster nodes' runtimes with the desired
+                          block I/O class configuration.
                         type: boolean
                       usePodQoSAsDefaultClass:
                         description: |-

--- a/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
+++ b/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
@@ -342,7 +342,9 @@ spec:
                         description: |-
                           Enable class based block I/O prioritization and throttling. When
                           enabled, policy implementations can adjust block I/O priority by
-                          by assigning containers to block I/O priority classes.
+                          assigning containers to block I/O priority classes. Additionally
+                          you need to set up your cluster nodes' runtimes with the desired
+                          block I/O class configuration.
                         type: boolean
                       usePodQoSAsDefaultClass:
                         description: |-

--- a/deployment/helm/template/crds/config.nri_templatepolicies.yaml
+++ b/deployment/helm/template/crds/config.nri_templatepolicies.yaml
@@ -71,7 +71,9 @@ spec:
                         description: |-
                           Enable class based block I/O prioritization and throttling. When
                           enabled, policy implementations can adjust block I/O priority by
-                          by assigning containers to block I/O priority classes.
+                          assigning containers to block I/O priority classes. Additionally
+                          you need to set up your cluster nodes' runtimes with the desired
+                          block I/O class configuration.
                         type: boolean
                       usePodQoSAsDefaultClass:
                         description: |-

--- a/deployment/helm/topology-aware/crds/config.nri_topologyawarepolicies.yaml
+++ b/deployment/helm/topology-aware/crds/config.nri_topologyawarepolicies.yaml
@@ -85,7 +85,9 @@ spec:
                         description: |-
                           Enable class based block I/O prioritization and throttling. When
                           enabled, policy implementations can adjust block I/O priority by
-                          by assigning containers to block I/O priority classes.
+                          assigning containers to block I/O priority classes. Additionally
+                          you need to set up your cluster nodes' runtimes with the desired
+                          block I/O class configuration.
                         type: boolean
                       usePodQoSAsDefaultClass:
                         description: |-

--- a/pkg/apis/config/v1alpha1/resmgr/control/blockio/config.go
+++ b/pkg/apis/config/v1alpha1/resmgr/control/blockio/config.go
@@ -20,7 +20,9 @@ package blockio
 type Config struct {
 	// Enable class based block I/O prioritization and throttling. When
 	// enabled, policy implementations can adjust block I/O priority by
-	// by assigning containers to block I/O priority classes.
+	// assigning containers to block I/O priority classes. Additionally
+	// you need to set up your cluster nodes' runtimes with the desired
+	// block I/O class configuration.
 	// +optional
 	Enable bool `json:"enable,omitempty"`
 	// usePodQoSAsDefaultClass controls whether a container's Pod QoS


### PR DESCRIPTION
Fix a small typo and add a minor clarification about block I/O class configuration to the comments/CRD schemas.