### PR TITLE
e2e: fix helm-launch when error is expected

### DIFF
--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test05-reserved-resources/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test05-reserved-resources/code.var.sh
@@ -19,7 +19,7 @@ cleanup-kube-system
 helm-terminate
 RESERVED_CPU="cpuset:3,7,11,15"
 helm_config=$(instantiate helm-config.yaml)
-( launch_timeout=5s helm-launch topology-aware ) && error "unexpected success" || {
+( expect_error=1 launch_timeout=5s helm-launch topology-aware ) && error "unexpected success" || {
     echo "Launch failed as expected"
     get-config-node-status-error topologyawarepolicies/default || :
 }
@@ -28,7 +28,7 @@ helm_config=$(instantiate helm-config.yaml)
 helm-terminate
 RESERVED_CPU='"11"'
 helm_config=$(instantiate helm-config.yaml)
-( launch_timeout=5s helm-launch topology-aware ) && error "unexpected success" || {
+( expect_error=1 launch_timeout=5s helm-launch topology-aware ) && error "unexpected success" || {
     echo "Launch failed as expected"
     get-config-node-status-error topologyawarepolicies/default || :
 }

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test13-reject-symlink/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test13-reject-symlink/code.var.sh
@@ -26,7 +26,7 @@ symlink_cache
 # Try to re-launch nri-resource-policy, check whether and how it fails.
 (
   trap 'restore_cache' 0
-  if (launch_timeout=5s helm-launch topology-aware); then
+  if (expect_error=1 launch_timeout=5s helm-launch topology-aware); then
       exit 1
   else
       vm-command "kubectl -n kube-system logs ds/nri-resource-policy-topology-aware"


### PR DESCRIPTION
- helm install --rollback-on-failure causes long delays when container crashes. Drop the parameter when expecting failures. (Negative tests do not expect rollbacks.)

- Add expect_error=1 on negative test helm-launches where missing.

- More deterministic return 1 from helm-launch when expecting errors.

Fixes failing topology-aware/test12 and random failures in test05 and test13.