### PR TITLE
e2e: try harder in vm-reboot.

### DIFF
--- a/test/e2e/lib/vm.bash
+++ b/test/e2e/lib/vm.bash
@@ -330,6 +330,7 @@ vm-reboot() { # script API
 
     local _deadline=${deadline:-}
     local _vagrantdir=${1:-$OUTPUT_DIR}
+    local _pid
 
     if [ -z "$deadline" ]; then
         _deadline=$(( $(date +%s) + ${timeout:-60} ))
@@ -341,6 +342,14 @@ vm-reboot() { # script API
             vagrant halt
             sleep 5
             vagrant halt --force
+            sleep 3
+            for _pid in $(lsof -Fp monitor.sock 2>/dev/null); do
+                kill ${_pid#p} || :
+            done
+            sleep 3
+            for _pid in $(lsof -Fp monitor.sock 2>/dev/null); do
+                kill -9 ${_pid#p} || :
+            done
             sleep 3
             vagrant up --no-provision
             if [ $? = 0 ]; then


### PR DESCRIPTION
If we fail to halt our vagrant/qemu instance in vm-reboot, try harder by killing the processes that keep open the monitor socket.