### PR TITLE
scripts: fix Helm release artifact checker.

### DIFF
--- a/scripts/release/check-artifacts.sh
+++ b/scripts/release/check-artifacts.sh
@@ -65,7 +65,7 @@ check-helm-charts() {
     info "Checking Helm charts for version $VERSION..."
     for pkg in $CHECK_CHARTS; do
         info "  $pkg:$VERSION..."
-        if [ $(cat helm-index | yq ".entries.$pkg[] | select(.version == \"$VERSION\") | length > 0") != "true" ]; then
+        if [ "$(cat helm-index | yq ".entries.$pkg[] | select(.version == \"$VERSION\") | length > 0")" != "true" ]; then
             info "  FAIL: Helm chart $pkg:$VERSION NOT FOUND"
             status=1
         else


### PR DESCRIPTION
Don't report success, with only a printed bash error weakly hinting failure, when we don't find a Helm chart version in the index.