### PR TITLE
.github: fix unstable chart publishing with Helm v4.x.

### DIFF
--- a/.github/workflows/package-helm.yaml
+++ b/.github/workflows/package-helm.yaml
@@ -144,7 +144,7 @@ jobs:
       - name: Log In To Registry
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | \
-              helm registry login ${{ env.REGISTRY }}/${{ env.REGISTRY_PATH }} -u ${{ env.REGISTRY_USER }} --password-stdin
+              helm registry login ${{ env.REGISTRY }} -u ${{ env.REGISTRY_USER }} --password-stdin
 
       - name: Push Unstable Helm Charts To Registry
         shell: bash


### PR DESCRIPTION
Unstable Helm chart publishing has been broken since Helm 4.x came out. This is due to our questionable practice to install and use the latest Helm release in CI, combined with Helm 4.x refusing to parse a registry URL with a path suffix in login. Fix the latter of these in our workflow.