### PR TITLE
 e2e: support "cxl" in hardware topology (CXL-1)

### DIFF
--- a/test/e2e/files/Vagrantfile.in
+++ b/test/e2e/files/Vagrantfile.in
@@ -89,12 +89,16 @@ Vagrant.configure("2") do |config|
     qemu.arch = "x86_64"
     qemu.machine = "QEMU_MACHINE"
     qemu.cpu = "QEMU_CPU"
+    qemu.drive_interface = "none,id=disk0" # qemu.extra_drive_args may not work, piggyback id to interface
     qemu.net_device = "virtio-net-pci"
     qemu.extra_netdev_args = "net=192.168.76.0/24,dhcpstart=192.168.76.9"
     qemu.ssh_port = SSH_PORT
     qemu.qemu_dir = "QEMU_DIR"
     qemu.smp = "QEMU_SMP"
-    qemu.extra_qemu_args = ["-enable-kvm",QEMU_EXTRA_ARGS]
+    qemu.extra_qemu_args = [
+      "-device", "pcie-root-port,id=rp_disk,bus=pcie.0,port=0x9,chassis=5",
+      "-device", "virtio-blk-pci,drive=disk0,id=virtio_disk0,bus=rp_disk",
+      QEMU_EXTRA_ARGS]
     qemu.disk_resize = "#{ENV['VM_DISK_SIZE']}"
   end
 

--- a/test/e2e/lib/vm.bash
+++ b/test/e2e/lib/vm.bash
@@ -439,6 +439,74 @@ vm-cpu-hotremove() { # script API
     vm-monitor "device_del ${deviceid}"
 }
 
+_vm_cxl_hotplug_count=""
+
+vm-cxl-hw() { # script API
+    # Usage: vm-cxl-hw
+    #
+    # List hotpluggable and removable cxl memory devices
+    # See also: vm-cxl-hotplug, vm-cxl-hotremove
+    local plugged plugged_id
+    declare -A plugged
+    for plugged_id in $(vm-monitor "info qtree -b" | awk -F\" '/dev: cxl-type3/{print $2}' | sed 's/\.hp.*//g'); do
+        plugged[$plugged_id]=1
+    done
+    vm-monitor "info memdev" | awk '/ beram_cxl_memdev/{print $3}' | while read beram_id; do
+        read dev bus sn <<< "$(sed -e 's/^beram_\(cxl_memdev[0-9]\+\)__bus_\(.*\)__sn_\(.*\)$/\1 \2 \3/g' <<< "$beram_id")"
+        echo -n "$dev"
+        [ "$show_bus" = 1 ] && echo -n " bus=$bus"
+        [ "$show_sn" = 1 ] && echo -n " sn=$sn"
+        [ "$show_be" = 1 ] && echo -n " volatile-memdev=$beram_id"
+        [ "${plugged[$dev]}" = 1 ] && echo -n " plugged"
+        echo
+    done
+}
+
+vm-cxl-hotplug() { # script API
+    # Usage: vm-cxl-hotplug
+    #
+    # Hotplug CXL memory device.
+    #
+    # Example: vm-cxl-hotplug cxl_memdev1
+    local memmatch memline devadd
+    memmatch=$1
+    if [ -z "$memmatch" ]; then
+        error "missing CXL_MEMDEV"
+        return 1
+    fi
+    memline="$(show_bus=1 show_sn=1 show_be=1 vm-cxl-hw | grep "${memmatch}__bus")"
+    if [ -z "$memline" ]; then
+        error "no cxl memory devices matching '$memmatch'"
+        return 1
+    fi
+    while read dev bus sn be dontcare; do
+        # Qemu does not allow hotplugging a device with same ID twice,
+        # even if it would be deleted. Workaround by adding a hotplug
+        # counter as device ID suffix
+        _vm_cxl_hotplug_count=$(( _vm_cxl_hotplug_count + 1 ))
+        dev=${dev}.hp${_vm_cxl_hotplug_count}
+        vm-monitor "device_add cxl-type3,$bus,$be,id=$dev,$sn"
+    done <<< "$memline"
+}
+
+vm-cxl-hotremove() { # script API
+    # Usage: vm-cxl-remove
+    #
+    # Hotremove CXL memory device.
+    #
+    # Example: vm-cxl-remove cxl_memdev1
+    local memmatch memline devadd
+    memmatch=$1
+    if [ -z "$memmatch" ]; then
+        error "missing CXL_MEMDEV"
+        return 1
+    fi
+    memline="$(vm-monitor "info qtree -b" | awk -F\" '/dev: cxl-type3/{print $2}' | grep "$memmatch")"
+    echo "$memline" | while read dev dontcare; do
+        vm-monitor "device_del $dev"
+    done
+}
+
 vm-mem-hotplug() { # script API
     # Usage: vm-mem-hotplug MEMORY
     #


### PR DESCRIPTION
    - topology2qemuopts converts CXL structures to Qemu PCIe devices
      and memory backend objects.
    
    - Add functions to e2e script API for listing, hotplugging
      and hotremoving CXL devices.
    
    - Move hardcoded Qemu accelerator from Vagrantfile template to
      topology2qemuopts that already generates Qemu machine parameters.
      There is no functional change: keep using kvm. However, this enables
      switching back and forth between "accel=kvm" with "accel=tcg" in
      generated Vagrantfile more cleanly than between "-enable-kvm" and
      "". While "accel=tcg" is needed to actually use CXL memory in vm, it
      is most likely faster to do test setup first with kvm, and finally
      reboot to tcg once the vm has been fully prepared for such a test.
    
    - Use explicitly specified PCIe root port for Qemu disk in
      Vagrantfile to avoid errors when CXL PCIe devices are added.
    
    - Fix a bug in SEPARATED_OUTPUT_VARS=1 output, where an empty
      deviceparams or objectparams list caused extra ", ," in output
      leading to errors in Vagrantfile.


Stacked on top of #587.