### PR TITLE
e2e: run_tests.sh accepts user overrides for vars read from files

### DIFF
--- a/test/e2e/run_tests.sh
+++ b/test/e2e/run_tests.sh
@@ -6,6 +6,8 @@ RUN_SH="${0%/*}/run.sh"
 
 DEFAULT_DISTRO=${DEFAULT_DISTRO:-"fedora/42"}
 
+allow_var_override=""
+
 k8scri=${k8scri:="containerd"}
 efi=${efi:-}
 
@@ -52,8 +54,12 @@ $(< "$var_filepath")"
             # creating / replace other variables
             if [ -z "${!var_name}" ]; then
                 echo "exporting $var_name - creating from $var_filepath"
-            else
+                allow_var_override+=" $var_name "
+            elif grep -q " $var_name " <<< "$allow_var_override"; then
                 echo "exporting $var_name - overriding from $var_filepath"
+            else
+                echo "not overriding $var_name - variable is not created from *.var.* files"
+                continue
             fi
             if [[ "$var_file_name" == *.var.in.* ]]; then
                 export "$var_name"="$(eval "echo -e \"$(<"${var_filepath}")\"")"


### PR DESCRIPTION
run_tests.sh exports "kernel_getsource" variable from contents of a kernel_getsource.var.sh file, if the file is in a (parent) directory of a test. A file closer to a test in the directory hierarchy overrides files in its parent directories. This patch enables user to override all files by setting

kernel_getsource='git clone ...' ./run_tests.sh path/to/test