### PR TITLE
e2e: report skipped tests with SKIP instead of PASS in the summary

### DIFF
--- a/test/e2e/run_tests.sh
+++ b/test/e2e/run_tests.sh
@@ -275,7 +275,9 @@ ${code}"
 			printf "\nTest duration: $test_time sec\n\n" >> "$test_outdir/run.sh.output"
 
                         test_name="$policy_name/$(basename "$TOPOLOGY_DIR")/$(basename "$TEST_DIR")"
-                        if grep -q "Test verdict: PASS" "$test_outdir/run.sh.output"; then
+                        if grep -q "Test verdict: SKIP" "$test_outdir/run.sh.output"; then
+                            echo "SKIP $test_name$(grep "Test verdict: SKIP" "$test_outdir/run.sh.output" | sed 's/Test verdict: SKIP//g')"
+                        elif grep -q "Test verdict: PASS" "$test_outdir/run.sh.output"; then
                             echo "PASS $test_name" >> "$summary_file"
                         elif grep -q "Test verdict: FAIL" "$test_outdir/run.sh.output"; then
                             echo "FAIL $test_name" >> "$summary_file"


### PR DESCRIPTION
If a test reported its own verdict to be SKIP, then use that verdict in the test result summary instead of exit status based verdict from the framework. If a test provides extra information for the SKIP (unsupported distro, too old kernel, ...), that will be included after the test name in the summary.