### PR TITLE
build: ignore operator build failures for non releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,11 +299,33 @@ licenses.%:
 
 nri-plugins-operator-image:
 	$(Q)mkdir -p $(IMAGE_PATH); \
-	$(MAKE) -C deployment/operator image-save
+	if ! $(MAKE) -C deployment/operator image-save; then \
+	    case $(IMAGE_VERSION) in \
+	        *-[0-9]*-g[0-9a-f]*) \
+		   echo "ERROR: build of $@ failed"; \
+	           echo "WARNING: ignoring failure non-release build $(IMAGE_VERSION)"; \
+                   ;; \
+	        *) \
+                   echo "ERROR: $@ build failed"; \
+	           exit 1 \
+                   ;; \
+	    esac; \
+	fi
 
 nri-plugins-operator-bundle-image:
 	$(Q)mkdir -p $(IMAGE_PATH); \
-	$(MAKE) -C deployment/operator bundle-save
+	if ! $(MAKE) -C deployment/operator bundle-save; then \
+	    case $(IMAGE_VERSION) in \
+	        *-[0-9]*-g[0-9a-f]*) \
+		   echo "ERROR: build of $@ failed"; \
+	           echo "WARNING: ignoring failure non-release build $(IMAGE_VERSION)"; \
+                   ;; \
+	        *) \
+                   echo "ERROR: $@ build failed"; \
+	           exit 1 \
+                   ;; \
+	    esac; \
+	fi
 
 #
 # plugin build dependencies


### PR DESCRIPTION
Plugins operator image builds started failing recently. It looks like the reason might be external and out of our control (galaxy.ansible.com/api returning 500 Internal Error). As a first band-aid fix, ignore such failures for non-release builds. This should allow us to get other, successfully built unstable images published still published.