### PR TITLE
helm,resource-annotator: add chart support for cert-manager.

### DIFF
--- a/cmd/resource-annotator/config.go
+++ b/cmd/resource-annotator/config.go
@@ -32,9 +32,9 @@ const (
 	// DefaultPort is the default port our HTTPS server listens on.
 	DefaultPort = 8443
 	// DefaultCertFile is the default path to our TLS certificate file.
-	DefaultCertFile = "/etc/resource-annotator/certs.d/svc.crt"
+	DefaultCertFile = "/etc/resource-annotator/certs.d/tls.crt"
 	// DefaultKeyFile is the default path to our TLS private key file.
-	DefaultKeyFile = "/etc/resource-annotator/certs.d/svc.key"
+	DefaultKeyFile = "/etc/resource-annotator/certs.d/tls.key"
 
 	// EnvPort is the environment variable used to override the default port.
 	EnvPort = "RESOURCE_ANNOTATOR_PORT"

--- a/cmd/resource-annotator/webhook.go
+++ b/cmd/resource-annotator/webhook.go
@@ -65,7 +65,8 @@ type Webhook struct {
 }
 
 func NewWebhook(cfg *Config) (*Webhook, error) {
-	cert, err := tls.LoadX509KeyPair(cfg.CertFile, cfg.KeyFile)
+	// test loading the certificate/key pair
+	_, err := tls.LoadX509KeyPair(cfg.CertFile, cfg.KeyFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load certificate: %w", err)
 	}
@@ -74,9 +75,8 @@ func NewWebhook(cfg *Config) (*Webhook, error) {
 		Logger: logger.Get("webhook"),
 		cfg:    cfg,
 		srv: &http.Server{
-			Addr:      ":" + strconv.FormatUint(uint64(cfg.Port), 10),
-			TLSConfig: &tls.Config{Certificates: []tls.Certificate{cert}},
-			Handler:   http.NewServeMux(),
+			Addr:    ":" + strconv.FormatUint(uint64(cfg.Port), 10),
+			Handler: http.NewServeMux(),
 		},
 	}
 
@@ -86,7 +86,7 @@ func NewWebhook(cfg *Config) (*Webhook, error) {
 }
 
 func (w *Webhook) Run() error {
-	return w.srv.ListenAndServeTLS("", "")
+	return w.srv.ListenAndServeTLS(w.cfg.CertFile, w.cfg.KeyFile)
 }
 
 func (w *Webhook) handler(rw http.ResponseWriter, r *http.Request) {

--- a/deployment/helm/resource-annotator/README.md
+++ b/deployment/helm/resource-annotator/README.md
@@ -15,15 +15,22 @@ to discover container resource requirements instead of estimating them.
 
 ## Installing the Chart
 
+### Manually Generated HTTPS Certificate
+
 Path to the chart: `resource-annotator`
 
-At the moment the webhook does not you cert-manager. Instead you need
-to generate a certificate for the webhook before instantiating it and
-pass the certificate and its related key to helm. The below example
-demonstrates how this can be done.
+For setting up HTTPS access to the webhook, you can either provide a
+certificate and private key yourself, or you can reference a cert-
+manager certificate issuer. In the latter case the chart will submit
+a certificate request to the issuer and set up annotations for cert-
+manager to inject the resulting certificate.
+
+To install the chart with a manually created certificate using the
+following commands:
 
 ```shell
 $ helm repo add nri-plugins https://containers.github.io/nri-plugins
+# Create certificate manually.
 $ mkdir cert
 $ SVC=nri-resource-annotator; NS=kube-system
 $ openssl req -x509 -newkey rsa:2048 -sha256 -days 365 -nodes \
@@ -31,12 +38,69 @@ $ openssl req -x509 -newkey rsa:2048 -sha256 -days 365 -nodes \
       -out ./cert/server-crt.pem \
       -subj "/CN=$SVC.$NS.svc" \
       -addext "subjectAltName=DNS:$SVC,DNS:$SVC.$NS,DNS:$SVC.$NS.svc"
+
+# Install chart injecting the generated certificate.
 $ helm -n $NS install nri-webhook nri-plugins/nri-resource-annotator \
       --set service.secret.crt=$(base64 -w0 < ./cert/server-crt.pem) \
       --set service.secret.key=$(base64 -w0 < ./cert/server-key.pem)
 ```
 
-This will set up everything for the resource annotator webhook.
+This will set up everything for the resource annotator webhook using the
+locally generated certificate for HTTPS access.
+
+### Using cert-manager for HTTPS Certificate Injection
+
+Alternatively, you use cert-manager to generate a certificate using
+these commands:
+
+```shell
+# Install cert-manager, if you don't have it yet.
+$ helm install cert-manager oci://quay.io/jetstack/charts/cert-manager \
+       --version v1.19.2 --namespace cert-manager --create-namespace \
+       --set crds.enabled=true --set crds.keep=false
+
+# Bootstrap a local issuer for cert-manager if you don't have one yet.
+$ kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-cluster-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: internal-root-ca
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: internal-root-ca
+  secretName: internal-root-ca-secret
+  issuerRef:
+    name: selfsigned-cluster-issuer
+    kind: ClusterIssuer
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: console-ca-issuer
+  namespace: cert-manager
+spec:
+  ca:
+    secretName: internal-root-ca-secret
+EOF
+$ kubectl apply -f ca-bootstrap.yaml
+$ kubectl wait --for=condition=Ready=True clusterissuer/console-ca-issuer
+
+# Install the chart referring it to the certificate issuer.
+$ helm install -n kube-system nri-webhook nri-plugins/nri-resource-annotator \
+      --set image.tag=v0.12.0 --set image.pullPolicy=IfNotPresent \
+      --set service.certificateIssuer=console-ca-issuer
+```
+
+This should set up the resource annotator with a cert-manager issued
+certificate.
 
 ## Uninstalling the Chart
 

--- a/deployment/helm/resource-annotator/templates/secret.yaml
+++ b/deployment/helm/resource-annotator/templates/secret.yaml
@@ -3,7 +3,19 @@ kind: Secret
 metadata:
   name: nri-resource-annotator-secret
   namespace: {{ .Release.Namespace }}
+{{- if (not (or (eq .Values.service.certificateIssuer nil)
+                (eq .Values.service.certificateIssuer ""))) }}
+  annotations:
+    cert-manager.io/allow-direct-injection: "true"
+{{- end }}
+type: kubernetes.io/tls
 data:
-  svc.crt: {{ .Values.service.base64Crt }}
-  svc.key: {{ .Values.service.base64Key }}
+{{- if (or (eq .Values.service.certificateIssuer nil)
+           (eq .Values.service.certificateIssuer "")) }}
+  tls.crt: {{ .Values.service.base64Crt }}
+  tls.key: {{ .Values.service.base64Key }}
+{{- else }}
+  tls.crt: ""
+  tls.key: ""
+{{- end }}
 type: Opaque

--- a/deployment/helm/resource-annotator/templates/webhook-config.yaml
+++ b/deployment/helm/resource-annotator/templates/webhook-config.yaml
@@ -2,6 +2,11 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: nri-resource-annotator
+{{ if (not (or (eq .Values.service.certificateIssuer nil)
+               (eq .Values.service.certificateIssuer ""))) }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/nri-resource-annotator
+{{ end }}
 webhooks:
 - name: nri-resource-annotator.noderesource.dev
   sideEffects: None
@@ -26,4 +31,7 @@ webhooks:
     service:
       namespace: {{ .Release.Namespace }}
       name: nri-resource-annotator
+    {{- if (or (eq .Values.service.certificateIssuer nil)
+               (eq .Values.service.certificateIssuer "")) }}
     caBundle: {{ .Values.service.base64Crt }}
+    {{- end }}

--- a/deployment/helm/resource-annotator/templates/webhook-deployment.yaml
+++ b/deployment/helm/resource-annotator/templates/webhook-deployment.yaml
@@ -1,3 +1,21 @@
+{{- if (not (or (eq .Values.service.certificateIssuer nil)
+                (eq .Values.service.certificateIssuer ""))) }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: nri-resource-annotator
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: nri-resource-annotator-secret
+  dnsNames:
+  - nri-resource-annotator.{{ .Release.Namespace }}.svc
+  - nri-resource-annotator.{{ .Release.Namespace }}
+  - nri-resource-annotator
+  issuerRef:
+    name: {{ .Values.service.certificateIssuer }}
+    kind: {{ .Values.service.certificateIssuerKind | default "ClusterIssuer" }}
+{{- end }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -24,8 +42,8 @@ spec:
           mountPath: /etc/resource-annotator/certs.d/
           readOnly: true
         args:
-         - "-cert-file=/etc/resource-annotator/certs.d/svc.crt"
-         - "-key-file=/etc/resource-annotator/certs.d/svc.key"
+         - "-cert-file=/etc/resource-annotator/certs.d/tls.crt"
+         - "-key-file=/etc/resource-annotator/certs.d/tls.key"
          - "-port=8443"
         {{- if .Values.extraEnv }}
         env:

--- a/deployment/helm/resource-annotator/values.yaml
+++ b/deployment/helm/resource-annotator/values.yaml
@@ -8,9 +8,16 @@ image:
   #tag: unstable
   pullPolicy: Always
 
+# For HTTP access to the webhook, either provide a base64
+# encoded certificate and private key, or refer to a cert-
+# manager certificate issuer.
 service:
+  # Existing certificate and private key.
   base64Crt: UHV0IGhlcmUgeW91ciBjZXJ0aWZpY2F0ZSAoUEVNKQo=
   base64Key: QW5kIGhlcmUgeW91ciBjZXJ0aWZpY2F0ZSBrZXkgKFBFTSkK
+  # Or alternatively name of the issuer to request certificate from.
+  #certificateIssuer:
+  #certificateIssuerKind: # defaults to ClusterIssuer
 
 resources:
   requests:


### PR DESCRIPTION
Add support for HTTPS certificate generation and injection by cert-manager. Also, update default key and certificate names to match the ones injected by cert-manager. Finally, let the stock golang HTTP implementation know about the certificate and key file location and take them into use on its own accord, in the hope that it will also watch and reload certificates when cert-manager rotates/renews them.