### PR TITLE
resmgr: update topology change on reconfigure

### DIFF
--- a/pkg/resmgr/resource-manager.go
+++ b/pkg/resmgr/resource-manager.go
@@ -158,7 +158,9 @@ func (m *resmgr) updateConfig(newCfg interface{}) (bool, error) {
 	log.Infof("configuration update %s (generation %d):", meta.GetName(), meta.GetGeneration())
 	log.InfoBlock("  <updated config> ", "%s", dump)
 
-	return false, m.reconfigure(cfg)
+	reconfErr := m.reconfigure(cfg)
+	m.updateTopologyZones()
+	return false, reconfErr
 }
 
 // Start resource management once we acquired initial configuration.


### PR DESCRIPTION
Policy configuration is likely to change balloon structure on nodes in the balloons policy. CPU pools in the topology-aware policy may change, too, for instance when available or reserved resources are modified. Therefore NodeResourceTopology should be updated on configuration update. This includes also failed configuration updates where old configuration is restored, but if things do not go well, CPU affinities might get changed.