### PR TITLE
fix(operator): clear kubeconfig env vars to bypass ansible-operator proxy

### DIFF
--- a/config/crd/bases/config.nri_nriplugindeployments.yaml
+++ b/config/crd/bases/config.nri_nriplugindeployments.yaml
@@ -41,6 +41,7 @@ spec:
                 - message: pluginName is immutable
                   rule: self == oldSelf
                 enum:
+                - template
                 - topology-aware
                 - balloons
                 - memtierd

--- a/deployment/operator/config/rbac/role.yaml
+++ b/deployment/operator/config/rbac/role.yaml
@@ -1,29 +1,24 @@
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: manager-role
 rules:
   ##
-  ## Rules for the operator
+  ## Core Operator Permissions
   ##
   - apiGroups:
-      - config.nri
+    - config.nri
     resources:
-      - nriplugindeployments
+    - templatepolicies
+    - templatepolicies/status
+    - balloonspolicies
+    - balloonspolicies/status
+    - topologyawarepolicies
+    - topologyawarepolicies/status
+    - nriplugindeployments
+    - nriplugindeployments/status
     verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - config.nri
-    resources:
-      - nriplugindeployments/status
-    verbs:
-      - get
-      - update
-      - patch
+    - "*"
   - apiGroups:
     - topology.node.k8s.io
     resources:
@@ -33,11 +28,27 @@ rules:
     - get
     - update
   ##
-  ## Rules for config.nri/v1alpha1, Kind: NriPluginDeployment
+  ## Permissions for Helm Release Management
+  ## Helm needs these to create/get/update the release state secrets.
   ##
-  - verbs:
-    - "*"
-    apiGroups:
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    - events
+    verbs:
+    - create
+    - get
+    - list
+    - watch
+    - update
+    - patch
+    - delete
+  ##
+  ## Rules for config.nri/v1alpha1, Kind: NriPluginDeployment
+  ## (Resources the Helm chart will actually deploy)
+  ##
+  - apiGroups:
     - "rbac.authorization.k8s.io"
     - "apps"
     - ""
@@ -50,5 +61,6 @@ rules:
     - "configmaps"
     - "serviceaccounts"
     - "namespaces"
-    - "secrets"
- #+kubebuilder:scaffold:rules
+    verbs:
+    - "*"
+  #+kubebuilder:scaffold:rules

--- a/deployment/operator/roles/plugin-deployment/tasks/main.yml
+++ b/deployment/operator/roles/plugin-deployment/tasks/main.yml
@@ -8,7 +8,7 @@
   block:
     - name: Set plugin chart reference
       set_fact:
-        chart_ref: "nri-plugins/nri-{{ 'resource-policy-' if pluginName in ['topology-aware', 'balloons'] else '' }}{{ pluginName }}"
+        chart_ref: "nri-plugins/nri-{{ 'resource-policy-' if pluginName in ['template', 'topology-aware', 'balloons'] else '' }}{{ pluginName }}"
 
     - name: Deploy {{ pluginName }} plugin
       kubernetes.core.helm:
@@ -16,17 +16,23 @@
         chart_ref: "{{ chart_ref }}"
         release_namespace: "{{ ansible_operator_meta.namespace }}"
         chart_version: "{{ pluginVersion }}"
-        wait: True
-        create_namespace: True
+        wait: true
+        create_namespace: true
         values: "{{ values | default({}) }}"
-        skip_crds: True
+        skip_crds: true
+      environment:
+        KUBECONFIG: ""
+        K8S_AUTH_KUBECONFIG: ""
   when:
-  - state == "present"
-  - pluginName in ["topology-aware", "balloons", "memory-qos", "memtierd", "sgx-epc"]
+    - state == "present"
+    - pluginName in ["template", "topology-aware", "balloons", "memory-qos", "memtierd", "sgx-epc"]
 
 - name: Uninstall {{ pluginName }} plugin
   kubernetes.core.helm:
     name: "{{ pluginName }}"
-    namespace: "{{ ansible_operator_meta.namespace }}"
+    release_namespace: "{{ ansible_operator_meta.namespace }}"
     state: absent
+  environment:
+    KUBECONFIG: ""
+    K8S_AUTH_KUBECONFIG: ""
   when: state == "absent" or state == "revoked"


### PR DESCRIPTION
This is a clone of PR #633 which is in a strange state and can't be merged, failing with 'Head branch is out of date', both for merge commits and rebases.
