### PR TITLE
operator: replace deprecated gcr.io/kubebuilder/kube-rbac-proxy

### DIFF
--- a/deployment/operator/config/default/manager_auth_proxy_patch.yaml
+++ b/deployment/operator/config/default/manager_auth_proxy_patch.yaml
@@ -31,7 +31,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.21.2
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
The `gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1` image is deprecated. 
Switch to the actively maintained https://github.com/kube-rbac-proxy/kube-rbac-proxy (which was also mirrored by the deprecated image). No functional changes expected, this just updates to a supported source.

Ref: https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/issues/318