### PR TITLE
resctrl-mon: revert CRI-O pidfile fallback due to security concerns

### DIFF
--- a/cmd/plugins/resctrl-mon/plugin.go
+++ b/cmd/plugins/resctrl-mon/plugin.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -72,6 +74,9 @@ func newPlugin() *plugin {
 // Configure handles connecting to container runtime's NRI server.
 func (p *plugin) Configure(ctx context.Context, config, runtime, version string) (stub.EventMask, error) {
 	log.Infof("Connected to %s %s...", runtime, version)
+	if err := checkRuntimeVersion(runtime, version); err != nil {
+		return 0, err
+	}
 	if config != "" {
 		log.Debugf("loading configuration from NRI server")
 		if err := p.setConfig([]byte(config)); err != nil {
@@ -270,15 +275,14 @@ func (p *plugin) PostStartContainer(ctx context.Context, pod *api.PodSandbox, ct
 		return nil
 	}
 
-	// Fallback: write the init PID if StartContainer didn't.
 	if pid > 0 {
 		if err := p.rdt.writeTaskPID(monGroupDir, pid); err != nil {
 			log.Warnf("PostStartContainer %s: failed to write PID %d to tasks: %v", ctrName, pid, err)
 		} else {
-			log.Infof("PostStartContainer %s: fallback assigned pid %d to mon_group %s", ctrName, pid, monGroupDir)
+			log.Infof("PostStartContainer %s: assigned pid %d to mon_group %s", ctrName, pid, monGroupDir)
 		}
 	} else {
-		log.Warnf("PostStartContainer %s: PID still 0 after start, unexpected", ctrName)
+		log.Warnf("PostStartContainer %s: PID=0, cannot assign to mon_group (runtime did not provide PID via NRI)", ctrName)
 	}
 
 	return nil
@@ -381,4 +385,34 @@ func getRDTClass(ctr *api.Container) string {
 // pprintCtr returns a human-readable container identifier.
 func pprintCtr(pod *api.PodSandbox, ctr *api.Container) string {
 	return fmt.Sprintf("%s/%s:%s", pod.GetNamespace(), pod.GetName(), ctr.GetName())
+}
+
+// checkRuntimeVersion verifies that the container runtime provides PIDs via NRI.
+// CRI-O versions before 1.36 do not populate Container.Pid in NRI events,
+// making the plugin unable to assign tasks to monitoring groups.
+func checkRuntimeVersion(runtime, version string) error {
+	if !strings.EqualFold(runtime, "cri-o") {
+		return nil
+	}
+	// Normalize: strip leading "v" and any pre-release/build suffix.
+	version = strings.TrimPrefix(version, "v")
+	if idx := strings.IndexAny(version, "-+"); idx != -1 {
+		version = version[:idx]
+	}
+	parts := strings.SplitN(version, ".", 3)
+	if len(parts) < 2 {
+		return fmt.Errorf("CRI-O version %q: unable to parse; require >= 1.36 for NRI PID support", version)
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return fmt.Errorf("CRI-O version %q: unable to parse major version: %w", version, err)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return fmt.Errorf("CRI-O version %q: unable to parse minor version: %w", version, err)
+	}
+	if major < 1 || (major == 1 && minor < 36) {
+		return fmt.Errorf("CRI-O %s does not provide container PIDs via NRI (requires >= 1.36)", version)
+	}
+	return nil
 }

--- a/cmd/plugins/resctrl-mon/plugin.go
+++ b/cmd/plugins/resctrl-mon/plugin.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -143,9 +141,6 @@ func (p *plugin) Synchronize(ctx context.Context, pods []*api.PodSandbox, contai
 			continue
 		}
 		pid := int(ctr.GetPid())
-		if pid == 0 {
-			pid = readContainerPID(ctr.GetId())
-		}
 		if pid > 0 {
 			monGroupDir := p.state.getMonGroupDir(podUID)
 			if err := p.rdt.writeTaskPID(monGroupDir, pid); err != nil {
@@ -275,23 +270,15 @@ func (p *plugin) PostStartContainer(ctx context.Context, pod *api.PodSandbox, ct
 		return nil
 	}
 
-	// Fallback: if the NRI event has no PID (CRI-O <= 1.35 does not
-	// populate Container.Pid), read it from the CRI-O pidfile.
-	if pid == 0 {
-		pid = readContainerPID(ctr.GetId())
-		if pid > 0 {
-			log.Debugf("PostStartContainer %s: read pid %d from pidfile", ctrName, pid)
-		}
-	}
-
+	// Fallback: write the init PID if StartContainer didn't.
 	if pid > 0 {
 		if err := p.rdt.writeTaskPID(monGroupDir, pid); err != nil {
 			log.Warnf("PostStartContainer %s: failed to write PID %d to tasks: %v", ctrName, pid, err)
 		} else {
-			log.Infof("PostStartContainer %s: assigned pid %d to mon_group %s", ctrName, pid, monGroupDir)
+			log.Infof("PostStartContainer %s: fallback assigned pid %d to mon_group %s", ctrName, pid, monGroupDir)
 		}
 	} else {
-		log.Warnf("PostStartContainer %s: PID not available from NRI or pidfile", ctrName)
+		log.Warnf("PostStartContainer %s: PID still 0 after start, unexpected", ctrName)
 	}
 
 	return nil
@@ -394,24 +381,4 @@ func getRDTClass(ctr *api.Container) string {
 // pprintCtr returns a human-readable container identifier.
 func pprintCtr(pod *api.PodSandbox, ctr *api.Container) string {
 	return fmt.Sprintf("%s/%s:%s", pod.GetNamespace(), pod.GetName(), ctr.GetName())
-}
-
-// readContainerPID reads the container init PID from the CRI-O pidfile.
-// CRI-O versions <= 1.35 do not populate Container.Pid in NRI events.
-// As a fallback, we read the PID from the container's pidfile at
-// /run/containers/storage/overlay-containers/<id>/userdata/pidfile.
-// Returns 0 if the PID cannot be read (e.g., running under containerd).
-func readContainerPID(containerID string) int {
-	pidfile := filepath.Join("/run/containers/storage/overlay-containers", containerID, "userdata/pidfile")
-	data, err := os.ReadFile(pidfile)
-	if err != nil {
-		log.Debugf("readContainerPID: cannot read %s: %v", pidfile, err)
-		return 0
-	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
-	if err != nil {
-		log.Debugf("readContainerPID: invalid pid in %s: %v", pidfile, err)
-		return 0
-	}
-	return pid
 }

--- a/cmd/plugins/resctrl-mon/plugin_test.go
+++ b/cmd/plugins/resctrl-mon/plugin_test.go
@@ -367,3 +367,40 @@ func TestStopContainer_RemovesStateOnRmdirFailure(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, p.state.podCount())
 }
+
+func TestCheckRuntimeVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		runtime string
+		version string
+		wantErr bool
+	}{
+		{"containerd any version", "containerd", "2.0.0", false},
+		{"cri-o 1.36.0", "cri-o", "1.36.0", false},
+		{"cri-o 1.37.0", "cri-o", "1.37.0", false},
+		{"cri-o 2.0.0", "cri-o", "2.0.0", false},
+		{"cri-o 1.35.0 rejected", "cri-o", "1.35.0", true},
+		{"cri-o 1.35.2 rejected", "cri-o", "1.35.2", true},
+		{"cri-o 1.31.5 rejected", "cri-o", "1.31.5", true},
+		{"cri-o 0.99.0 rejected", "cri-o", "0.99.0", true},
+		{"CRI-O case insensitive", "CRI-O", "1.35.0", true},
+		{"cri-o no patch", "cri-o", "1.36", false},
+		{"cri-o unparsable", "cri-o", "latest", true},
+		{"cri-o v prefix accepted", "cri-o", "v1.36.0", false},
+		{"cri-o v prefix rejected", "cri-o", "v1.35.0", true},
+		{"cri-o strips pre-release suffix", "cri-o", "1.36.0-rc1", false},
+		{"cri-o strips pre-release old version", "cri-o", "1.35.0-beta.1", true},
+		{"cri-o strips build metadata", "cri-o", "1.36.0+build123", false},
+		{"cri-o strips v prefix and pre-release", "cri-o", "v1.35.0-alpha.0", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkRuntimeVersion(tt.runtime, tt.version)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/deployment/helm/resctrl-mon/README.md
+++ b/deployment/helm/resctrl-mon/README.md
@@ -30,8 +30,10 @@ to support Application Energy Telemetry (AET) via Kepler passive mode.
       installation.
 
   - CRI-O
-    - At least [v1.26.0](https://github.com/cri-o/cri-o/releases/tag/v1.26.0)
-      release version to use the NRI feature
+    - At least [v1.36.0](https://github.com/cri-o/cri-o/releases/tag/v1.36.0)
+      release version. CRI-O >= 1.36 is required because earlier versions do
+      not provide container PIDs via NRI, which prevents the plugin from
+      assigning tasks to monitoring groups.
     - Enable NRI feature by following
       [these](https://github.com/cri-o/cri-o/blob/main/docs/crio.conf.5.md#crionri-table)
       detailed instructions.  You can optionally enable the NRI in CRI-O using

--- a/docs/monitoring/resctrl-mon.md
+++ b/docs/monitoring/resctrl-mon.md
@@ -86,8 +86,10 @@ RMID allocation is delegated entirely to the Linux kernel:
 
 ### Prerequisites
 
-- Containerd v1.7+ or CRI-O v1.26+
-- Enable NRI in /etc/containerd/config.toml:
+- Containerd v1.7+ or CRI-O v1.36+
+- Enable NRI in the container runtime:
+
+  **containerd** — in `/etc/containerd/config.toml`:
 
   ```toml
   [plugins."io.containerd.nri.v1.nri"]
@@ -99,6 +101,16 @@ RMID allocation is delegated entirely to the Linux kernel:
     plugin_request_timeout = "2s"
     socket_path = "/var/run/nri/nri.sock"
   ```
+
+  **CRI-O** — in `/etc/crio/crio.conf.d/10-nri.conf` (or equivalent):
+
+  ```toml
+  [crio.nri]
+  enable_nri = true
+  ```
+
+  See the [CRI-O NRI documentation](https://github.com/cri-o/cri-o/blob/main/docs/crio.conf.5.md#crionri-table)
+  for additional options.
 
 - Intel CPU with RDT monitoring support
 - resctrl filesystem mounted at `/sys/fs/resctrl`


### PR DESCRIPTION
### Summary

Revert the CRI-O pidfile fallback added in f7883b9e, and add a runtime
version check that rejects CRI-O < 1.36 at startup.

### Context

CRI-O <= 1.35 does not populate `Container.Pid` in NRI events. The
reverted commit attempted to work around this by reading PID from
CRI-O's internal pidfile. However, enabling this requires a host mount
that violates the principle of least privilege.

The upstream fix (CRI-O commit 19d319695) populates the PID field
directly in NRI and is available in CRI-O >= 1.36.

### Impact

| Runtime | Effect |
|---------|--------|
| containerd | No impact — PID is always provided via NRI |
| CRI-O >= 1.36 | No impact — PID is provided via NRI |
| CRI-O < 1.36 | **Plugin refuses to start** with a clear error message; DaemonSet enters CrashLoopBackOff |

The hard fail is intentional: without PIDs, mon_groups are created but
remain empty, silently reporting zeros for all metrics. This is worse
than a crash because it produces data indistinguishable from "this pod
uses no LLC/bandwidth," leading to incorrect capacity decisions. A loud
crash with a clear log message ("CRI-O 1.35.x does not provide
container PIDs via NRI, requires >= 1.36") gives the admin immediate
actionable feedback.

### Security analysis

The current deployment in `origin/main` is **not actively insecure**.
The default Helm daemonset template mounts only:

- `/var/run/nri` (NRI socket)
- `/sys/fs/resctrl` (resctrl filesystem)

There is no volume or volumeMount for `/run/containers/storage` in the
shipped template. Without that mount, `readContainerPID()` calls
`os.ReadFile` on a path that does not exist inside the container, gets
`ENOENT`, and returns 0. The fallback is a complete no-op in the
default deployment — no information is leaked and no error is raised.

However, the code **cannot function** without the insecure mount, and
the only way to make it function is to add a hostPath volume for
`/run/containers/storage`. That directory contains:

- `/run/containers/storage/overlay-containers/<id>/userdata/pidfile`
  (the target file)
- `/run/containers/storage/overlay-containers/<id>/userdata/config.json`
  (full OCI runtime spec including process environment variables)

Mounting this path grants the monitoring plugin read access to secrets
and environment variables of **every container on the node**. This is
an unacceptable privilege escalation for a read-only monitoring plugin.

**In summary:** the upstream code is dead code that can only be
activated via an insecure deployment modification. Rather than ship
non-functional code whose only activation path is insecure, we remove
it entirely.