### PR TITLE
buildx: load the images to local docker daemon.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ E2E_TESTS     ?= $(E2E_DIR)/policies.test-suite
 E2E_WORKDIR   ?= $(TOP_DIR)/e2e-results
 
 DOCKER       := docker
-DOCKER_BUILD := $(DOCKER) buildx build
+DOCKER_BUILD := $(DOCKER) buildx build --load
 
 # Plugins and other binaries we build.
 #


### PR DESCRIPTION
Shutdown the docker image save warnings as below:

```
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
```
In theory, this should also allow listing images with docker daemon. Because by default, buildx leaves final images in the build cache without exporting it anywhere (like for docker images).