### PR TITLE
resctrl-mon: accept pod UIDs without dashes too

### DIFF
--- a/cmd/plugins/resctrl-mon/plugin.go
+++ b/cmd/plugins/resctrl-mon/plugin.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"sigs.k8s.io/yaml"
 
 	"github.com/containerd/nri/pkg/api"
@@ -142,12 +143,15 @@ func (p *plugin) Synchronize(ctx context.Context, pods []*api.PodSandbox, contai
 			log.Warnf("Synchronize: failed to create mon_group for pod %s: %v", podUID, err)
 			continue
 		}
+		// Use canonical form for state lookups (ensureMonGroup stores canonical).
+		u, _ := uuid.Parse(podUID)
+		canonicalUID := u.String()
 		pid := int(ctr.GetPid())
 		if pid == 0 {
 			pid = readContainerPID(ctr.GetId())
 		}
 		if pid > 0 {
-			monGroupDir := p.state.getMonGroupDir(podUID)
+			monGroupDir := p.state.getMonGroupDir(canonicalUID)
 			if err := p.rdt.writeTaskPID(monGroupDir, pid); err != nil {
 				log.Warnf("Synchronize: failed to write PID %d for pod %s: %v", pid, podUID, err)
 			} else {
@@ -227,6 +231,9 @@ func (p *plugin) PostCreateContainer(ctx context.Context, pod *api.PodSandbox, c
 // to PostStartContainer which will write PIDs after the process starts.
 func (p *plugin) StartContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) error {
 	podUID := pod.GetUid()
+	if u, err := uuid.Parse(podUID); err == nil {
+		podUID = u.String()
+	}
 	ctrName := pprintCtr(pod, ctr)
 	pid := int(ctr.GetPid())
 
@@ -261,6 +268,9 @@ func (p *plugin) StartContainer(ctx context.Context, pod *api.PodSandbox, ctr *a
 // the RMID.
 func (p *plugin) PostStartContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) error {
 	podUID := pod.GetUid()
+	if u, err := uuid.Parse(podUID); err == nil {
+		podUID = u.String()
+	}
 	ctrName := pprintCtr(pod, ctr)
 	pid := int(ctr.GetPid())
 
@@ -300,6 +310,9 @@ func (p *plugin) PostStartContainer(ctx context.Context, pod *api.PodSandbox, ct
 // StopContainer is called when a container is being stopped.
 func (p *plugin) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) ([]*api.ContainerUpdate, error) {
 	podUID := pod.GetUid()
+	if u, err := uuid.Parse(podUID); err == nil {
+		podUID = u.String()
+	}
 	ctrName := pprintCtr(pod, ctr)
 
 	log.Debugf("StopContainer %s", ctrName)
@@ -329,9 +342,11 @@ func (p *plugin) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr *ap
 // container's RDT class. If an allocation plugin assigns different classes to
 // containers in the same pod, subsequent containers use the first class.
 func (p *plugin) ensureMonGroup(podUID, containerID, rdtClass string) error {
-	if !looksLikePodUID(podUID) {
+	u, err := uuid.Parse(podUID)
+	if err != nil {
 		return fmt.Errorf("invalid pod UID %q", podUID)
 	}
+	podUID = u.String()
 
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/cmd/plugins/resctrl-mon/plugin_test.go
+++ b/cmd/plugins/resctrl-mon/plugin_test.go
@@ -343,6 +343,77 @@ func TestStartContainer_FilteredPod(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestCompactUID_EnsureMonGroupStoresCanonical(t *testing.T) {
+	tmpDir := t.TempDir()
+	p := newTestPlugin(tmpDir)
+
+	compactUID := "a1b2c3d4e5f678901234abcdef567890"
+	canonicalUID := "a1b2c3d4-e5f6-7890-1234-abcdef567890"
+
+	pod := makePod(compactUID, "default", "test-pod")
+	ctr := makeContainer("c1", "container1", compactUID, 0, "")
+
+	err := p.PostCreateContainer(context.Background(), pod, ctr)
+	require.NoError(t, err)
+
+	// State must be keyed under the canonical dashed form.
+	assert.True(t, p.state.hasPod(canonicalUID))
+	assert.False(t, p.state.hasPod(compactUID))
+
+	monDir := p.state.getMonGroupDir(canonicalUID)
+	assert.Contains(t, monDir, canonicalUID)
+}
+
+func TestCompactUID_StartContainerFindsMonGroup(t *testing.T) {
+	tmpDir := t.TempDir()
+	p := newTestPlugin(tmpDir)
+
+	compactUID := "a1b2c3d4e5f678901234abcdef567890"
+	canonicalUID := "a1b2c3d4-e5f6-7890-1234-abcdef567890"
+
+	pod := makePod(compactUID, "default", "test-pod")
+	ctr := makeContainer("c1", "container1", compactUID, 0, "")
+
+	// Create mon_group via compact UID.
+	err := p.PostCreateContainer(context.Background(), pod, ctr)
+	require.NoError(t, err)
+
+	monDir := p.state.getMonGroupDir(canonicalUID)
+	require.NotEmpty(t, monDir)
+	require.NoError(t, os.WriteFile(filepath.Join(monDir, "tasks"), nil, 0644))
+
+	// StartContainer also using compact UID must find and write to the same mon_group.
+	ctrWithPid := makeContainer("c1", "container1", compactUID, 77, "")
+	err = p.StartContainer(context.Background(), pod, ctrWithPid)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(monDir, "tasks"))
+	require.NoError(t, err)
+	assert.Equal(t, "77\n", string(data))
+}
+
+func TestCompactUID_StopContainerCleansUp(t *testing.T) {
+	tmpDir := t.TempDir()
+	p := newTestPlugin(tmpDir)
+
+	compactUID := "a1b2c3d4e5f678901234abcdef567890"
+	canonicalUID := "a1b2c3d4-e5f6-7890-1234-abcdef567890"
+
+	pod := makePod(compactUID, "default", "test-pod")
+	ctr := makeContainer("c1", "container1", compactUID, 0, "")
+
+	err := p.PostCreateContainer(context.Background(), pod, ctr)
+	require.NoError(t, err)
+	assert.Equal(t, 1, p.state.podCount())
+
+	_, err = p.StopContainer(context.Background(), pod, ctr)
+	require.NoError(t, err)
+
+	// Pod must be gone from state after stop.
+	assert.Equal(t, 0, p.state.podCount())
+	assert.False(t, p.state.hasPod(canonicalUID))
+}
+
 func TestStopContainer_RemovesStateOnRmdirFailure(t *testing.T) {
 	tmpDir := t.TempDir()
 	p := newTestPlugin(tmpDir)

--- a/cmd/plugins/resctrl-mon/resctrl.go
+++ b/cmd/plugins/resctrl-mon/resctrl.go
@@ -22,6 +22,8 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+
+	"github.com/google/uuid"
 )
 
 const (
@@ -158,12 +160,13 @@ func (r *resctrlOps) cleanOrphanedInDir(monGroupsPath string, state *podState) {
 			continue
 		}
 		name := entry.Name()
-		// Only clean directories that look like pod UIDs (contain dashes like UUIDs).
-		if !looksLikePodUID(name) {
+		// Only clean directories that look like pod UIDs.
+		u, err := uuid.Parse(name)
+		if err != nil {
 			continue
 		}
 		orphanDir := filepath.Join(monGroupsPath, name)
-		trackedDir := state.getMonGroupDir(name)
+		trackedDir := state.getMonGroupDir(u.String())
 		if trackedDir == orphanDir {
 			// This is the active mon_group for this pod.
 			continue
@@ -172,43 +175,6 @@ func (r *resctrlOps) cleanOrphanedInDir(monGroupsPath string, state *podState) {
 		if err := os.Remove(orphanDir); err != nil && !errors.Is(err, os.ErrNotExist) {
 			log.Warnf("failed to remove orphaned mon_group %s: %v", orphanDir, err)
 		}
-	}
-}
-
-// looksLikePodUID returns true if the name looks like a Kubernetes pod UID.
-// It accepts both the standard UUID format with dashes (e.g.,
-// a1b2c3d4-e5f6-7890-abcd-ef1234567890) and the compact 32-char hex format
-// without dashes (e.g., a1b2c3d4e5f678901234567890abcdef).
-func looksLikePodUID(name string) bool {
-	switch len(name) {
-	case 36:
-		// Check for UUID-like pattern: 8-4-4-4-12 hex chars.
-		parts := strings.Split(name, "-")
-		if len(parts) != 5 {
-			return false
-		}
-		expectedLens := []int{8, 4, 4, 4, 12}
-		for i, part := range parts {
-			if len(part) != expectedLens[i] {
-				return false
-			}
-			for _, c := range part {
-				if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
-					return false
-				}
-			}
-		}
-		return true
-	case 32:
-		// Compact hex format without dashes.
-		for _, c := range name {
-			if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
-				return false
-			}
-		}
-		return true
-	default:
-		return false
 	}
 }
 

--- a/cmd/plugins/resctrl-mon/resctrl.go
+++ b/cmd/plugins/resctrl-mon/resctrl.go
@@ -175,29 +175,41 @@ func (r *resctrlOps) cleanOrphanedInDir(monGroupsPath string, state *podState) {
 	}
 }
 
-// looksLikePodUID returns true if the name looks like a Kubernetes pod UID
-// (UUID format with dashes, e.g., a1b2c3d4-e5f6-7890-abcd-ef1234567890).
+// looksLikePodUID returns true if the name looks like a Kubernetes pod UID.
+// It accepts both the standard UUID format with dashes (e.g.,
+// a1b2c3d4-e5f6-7890-abcd-ef1234567890) and the compact 32-char hex format
+// without dashes (e.g., a1b2c3d4e5f678901234567890abcdef).
 func looksLikePodUID(name string) bool {
-	if len(name) != 36 {
-		return false
-	}
-	// Check for UUID-like pattern: 8-4-4-4-12 hex chars.
-	parts := strings.Split(name, "-")
-	if len(parts) != 5 {
-		return false
-	}
-	expectedLens := []int{8, 4, 4, 4, 12}
-	for i, part := range parts {
-		if len(part) != expectedLens[i] {
+	switch len(name) {
+	case 36:
+		// Check for UUID-like pattern: 8-4-4-4-12 hex chars.
+		parts := strings.Split(name, "-")
+		if len(parts) != 5 {
 			return false
 		}
-		for _, c := range part {
+		expectedLens := []int{8, 4, 4, 4, 12}
+		for i, part := range parts {
+			if len(part) != expectedLens[i] {
+				return false
+			}
+			for _, c := range part {
+				if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
+					return false
+				}
+			}
+		}
+		return true
+	case 32:
+		// Compact hex format without dashes.
+		for _, c := range name {
 			if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
 				return false
 			}
 		}
+		return true
+	default:
+		return false
 	}
-	return true
 }
 
 // isValidRDTClass returns true if the name is a safe resctrl ctrl_group name.

--- a/cmd/plugins/resctrl-mon/resctrl_test.go
+++ b/cmd/plugins/resctrl-mon/resctrl_test.go
@@ -193,15 +193,22 @@ func TestCleanOrphanedMonGroups_StaleLocation(t *testing.T) {
 }
 
 func TestLooksLikePodUID(t *testing.T) {
+	// Standard UUID format with dashes.
 	assert.True(t, looksLikePodUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890"))
 	assert.True(t, looksLikePodUID("DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF"))
 	assert.True(t, looksLikePodUID("00000000-0000-0000-0000-000000000000"))
+
+	// Compact 32-char hex format without dashes.
+	assert.True(t, looksLikePodUID("9d6530de59bb553c393de789dcfc6da7"))
+	assert.True(t, looksLikePodUID("00000000000000000000000000000000"))
+	assert.True(t, looksLikePodUID("DEADBEEFDEADBEEFDEADBEEFDEADBEEF"))
 
 	assert.False(t, looksLikePodUID("short"))
 	assert.False(t, looksLikePodUID("not-a-uuid-at-all-nope-notthisone!"))
 	assert.False(t, looksLikePodUID("a1b2c3d4-e5f6-7890-abcd-ef123456789"))   // too short last segment
 	assert.False(t, looksLikePodUID("g1b2c3d4-e5f6-7890-abcd-ef1234567890"))  // 'g' is not hex
 	assert.False(t, looksLikePodUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890x")) // too long
+	assert.False(t, looksLikePodUID("9d6530de59bb553c393de789dcfc6da!"))      // invalid char in 32-char form
 }
 
 func TestIsValidRDTClass(t *testing.T) {

--- a/cmd/plugins/resctrl-mon/resctrl_test.go
+++ b/cmd/plugins/resctrl-mon/resctrl_test.go
@@ -192,6 +192,33 @@ func TestCleanOrphanedMonGroups_StaleLocation(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
+func TestCleanOrphanedMonGroups_CompactUIDIsOrphaned(t *testing.T) {
+	tmpDir := t.TempDir()
+	r := newResctrlOps(tmpDir)
+	state := newPodState()
+
+	// Simulate: pod is tracked under the canonical dashed UID (as ensureMonGroup stores it).
+	canonicalUID := "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+	canonicalDir, err := r.createMonGroup("", canonicalUID)
+	require.NoError(t, err)
+	state.addPod(canonicalUID, canonicalDir)
+
+	// Simulate: a stale compact-form directory left by a previous run (e.g. CRI-O).
+	compactUID := "a1b2c3d4e5f678901234abcdef567890"
+	compactDir := filepath.Join(tmpDir, "mon_groups", compactUID)
+	require.NoError(t, os.Mkdir(compactDir, 0755))
+
+	r.cleanOrphanedMonGroups(state)
+
+	// Canonical mon_group (tracked) must survive.
+	_, err = os.Stat(canonicalDir)
+	assert.NoError(t, err)
+
+	// Compact-named directory is not tracked — must be removed as orphan.
+	_, err = os.Stat(compactDir)
+	assert.True(t, os.IsNotExist(err))
+}
+
 func TestIsValidRDTClass(t *testing.T) {
 	assert.True(t, isValidRDTClass("BestEffort"))
 	assert.True(t, isValidRDTClass("Guaranteed"))

--- a/cmd/plugins/resctrl-mon/resctrl_test.go
+++ b/cmd/plugins/resctrl-mon/resctrl_test.go
@@ -192,25 +192,6 @@ func TestCleanOrphanedMonGroups_StaleLocation(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
-func TestLooksLikePodUID(t *testing.T) {
-	// Standard UUID format with dashes.
-	assert.True(t, looksLikePodUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890"))
-	assert.True(t, looksLikePodUID("DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF"))
-	assert.True(t, looksLikePodUID("00000000-0000-0000-0000-000000000000"))
-
-	// Compact 32-char hex format without dashes.
-	assert.True(t, looksLikePodUID("9d6530de59bb553c393de789dcfc6da7"))
-	assert.True(t, looksLikePodUID("00000000000000000000000000000000"))
-	assert.True(t, looksLikePodUID("DEADBEEFDEADBEEFDEADBEEFDEADBEEF"))
-
-	assert.False(t, looksLikePodUID("short"))
-	assert.False(t, looksLikePodUID("not-a-uuid-at-all-nope-notthisone!"))
-	assert.False(t, looksLikePodUID("a1b2c3d4-e5f6-7890-abcd-ef123456789"))   // too short last segment
-	assert.False(t, looksLikePodUID("g1b2c3d4-e5f6-7890-abcd-ef1234567890"))  // 'g' is not hex
-	assert.False(t, looksLikePodUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890x")) // too long
-	assert.False(t, looksLikePodUID("9d6530de59bb553c393de789dcfc6da!"))      // invalid char in 32-char form
-}
-
 func TestIsValidRDTClass(t *testing.T) {
 	assert.True(t, isValidRDTClass("BestEffort"))
 	assert.True(t, isValidRDTClass("Guaranteed"))

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/containers/nri-plugins/pkg/topology v0.0.0
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/fsnotify/fsnotify v1.6.0
+	github.com/google/uuid v1.6.0
 	github.com/intel/goresctrl v0.12.0
 	github.com/intel/memtierd v0.1.1
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.2
@@ -63,7 +64,6 @@ require (
 	github.com/google/gnostic-models v0.6.9 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect


### PR DESCRIPTION
https://github.com/containers/nri-plugins/blob/9b9f6c426d4844e7ff519b8ab75a1b0cd51b1bdc/cmd/plugins/resctrl-mon/resctrl.go#L180
Rework `looksLikePodUID()` to accept/handle both formats of UUID. In other words, with dashes (current expectation) and without dashes. Because, UUID could be in the format of d9ca284e-f063-4bac-8973-791bcb4a8786 or 74038c4519bd838001f4bee0dc95516d with no separation. Otherwise, we end up failing with `mon_group` creation for those pods entirely.

Example log snippet before the fix: 
```
time="2026-06-09T08:22:10Z" level=info msg="synchronizing state: 11 pods, 10 containers"
time="2026-06-09T08:22:10Z" level=info msg="created mon_group /sys/fs/resctrl/mon_groups/2ee80e9a-69b0-4cc2-81ab-10066aefc40c for pod 2ee80e9a-69b0-4cc2-81ab-10066aefc40c"
time="2026-06-09T08:22:10Z" level=debug msg="Synchronize: assigned pid 2536642 for pod 2ee80e9a-69b0-4cc2-81ab-10066aefc40c"
time="2026-06-09T08:22:10Z" level=info msg="created mon_group /sys/fs/resctrl/mon_groups/e466768a-a01c-43c4-8c87-415a494dfb68 for pod e466768a-a01c-43c4-8c87-415a494dfb68"
time="2026-06-09T08:22:10Z" level=debug msg="Synchronize: assigned pid 2491796 for pod e466768a-a01c-43c4-8c87-415a494dfb68"
time="2026-06-09T08:22:10Z" level=info msg="created mon_group /sys/fs/resctrl/mon_groups/2f7c0604-eb05-4c95-a9b4-57476dc78c13 for pod 2f7c0604-eb05-4c95-a9b4-57476dc78c13"
time="2026-06-09T08:22:10Z" level=debug msg="Synchronize: assigned pid 2490959 for pod 2f7c0604-eb05-4c95-a9b4-57476dc78c13"
time="2026-06-09T08:22:10Z" level=info msg="created mon_group /sys/fs/resctrl/mon_groups/d9ca284e-f063-4bac-8973-791bcb4a8786 for pod d9ca284e-f063-4bac-8973-791bcb4a8786"
time="2026-06-09T08:22:10Z" level=debug msg="Synchronize: assigned pid 2489907 for pod d9ca284e-f063-4bac-8973-791bcb4a8786"
time="2026-06-09T08:22:10Z" level=info msg="created mon_group /sys/fs/resctrl/mon_groups/585d05d3-a97e-4894-a6b9-1b3d960687a7 for pod 585d05d3-a97e-4894-a6b9-1b3d960687a7"
time="2026-06-09T08:22:10Z" level=debug msg="Synchronize: assigned pid 2489110 for pod 585d05d3-a97e-4894-a6b9-1b3d960687a7"
time="2026-06-09T08:22:10Z" level=info msg="created mon_group /sys/fs/resctrl/mon_groups/4be23576-26c2-4a05-8cfc-bc57c67b0df8 for pod 4be23576-26c2-4a05-8cfc-bc57c67b0df8"
time="2026-06-09T08:22:10Z" level=debug msg="Synchronize: assigned pid 2485986 for pod 4be23576-26c2-4a05-8cfc-bc57c67b0df8"
time="2026-06-09T08:22:10Z" level=warning msg="Synchronize: failed to create  resctrl monitoring group creation for those pods entirely for pod 9d6530de59bb553c393de789dcfc6da7: invalid pod UID \"9d6530de59bb553c393de789dcfc6da7\""
time="2026-06-09T08:22:10Z" level=warning msg="Synchronize: failed to create mon_group for pod 74038c4519bd838001f4bee0dc95516d: invalid pod UID \"74038c4519bd838001f4bee0dc95516d\""
time="2026-06-09T08:22:10Z" level=warning msg="Synchronize: failed to create mon_group for pod ea0ade74d29d46eaacb5a89c34864be3: invalid pod UID \"ea0ade74d29d46eaacb5a89c34864be3\""
time="2026-06-09T08:22:10Z" level=warning msg="Synchronize: failed to create mon_group for pod 0774f9d04527f4275ff4df1f4d545646: invalid pod UID \"0774f9d04527f4275ff4df1f4d545646\""
time="2026-06-09T08:22:10Z" level=debug msg="background reconciler started (interval=30s)"
time="2026-06-09T08:22:10Z" level=info msg="synchronization complete: tracking 6 pods"
```

and after
```
time="2026-06-09T09:11:39Z" level=info msg="synchronizing state: 10 pods, 10 containers"
time="2026-06-09T09:11:39Z" level=info msg="created mon_group /sys/fs/resctrl/mon_groups/4315ea85-bdb6-48dd-8c98-32a311de896d for pod 4315ea85-bdb6-48dd-8c98-32a311de896d"
time="2026-06-09T09:11:39Z" level=debug msg="Synchronize: assigned pid 2756024 for pod 4315ea85-bdb6-48dd-8c98-32a311de896d"
time="2026-06-09T09:11:39Z" level=info msg="created mon_group /sys/fs/resctrl/mon_groups/e466768a-a01c-43c4-8c87-415a494dfb68 for pod e466768a-a01c-43c4-8c87-415a494dfb68"
time="2026-06-09T09:11:39Z" level=debug msg="Synchronize: assigned pid 2491796 for pod e466768a-a01c-43c4-8c87-415a494dfb68"
time="2026-06-09T09:11:39Z" level=info msg="created mon_group /sys/fs/resctrl/mon_groups/2f7c0604-eb05-4c95-a9b4-57476dc78c13 for pod 2f7c0604-eb05-4c95-a9b4-57476dc78c13"
time="2026-06-09T09:11:39Z" level=debug msg="Synchronize: assigned pid 2490959 for pod 2f7c0604-eb05-4c95-a9b4-57476dc78c13"
time="2026-06-09T09:11:39Z" level=info msg="created mon_group /sys/fs/resctrl/mon_groups/d9ca284e-f063-4bac-8973-791bcb4a8786 for pod d9ca284e-f063-4bac-8973-791bcb4a8786"
time="2026-06-09T09:11:39Z" level=debug msg="Synchronize: assigned pid 2489907 for pod d9ca284e-f063-4bac-8973-791bcb4a8786"
time="2026-06-09T09:11:39Z" level=info msg="created mon_group /sys/fs/resctrl/mon_groups/585d05d3-a97e-4894-a6b9-1b3d960687a7 for pod 585d05d3-a97e-4894-a6b9-1b3d960687a7"
time="2026-06-09T09:11:39Z" level=debug msg="Synchronize: assigned pid 2489110 for pod 585d05d3-a97e-4894-a6b9-1b3d960687a7"
time="2026-06-09T09:11:39Z" level=info msg="created mon_group /sys/fs/resctrl/mon_groups/4be23576-26c2-4a05-8cfc-bc57c67b0df8 for pod 4be23576-26c2-4a05-8cfc-bc57c67b0df8"
time="2026-06-09T09:11:39Z" level=debug msg="Synchronize: assigned pid 2485986 for pod 4be23576-26c2-4a05-8cfc-bc57c67b0df8"
time="2026-06-09T09:11:39Z" level=info msg="created mon_group /sys/fs/resctrl/mon_groups/9d6530de59bb553c393de789dcfc6da7 for pod 9d6530de59bb553c393de789dcfc6da7"
time="2026-06-09T09:11:39Z" level=debug msg="Synchronize: assigned pid 2479507 for pod 9d6530de59bb553c393de789dcfc6da7"
time="2026-06-09T09:11:39Z" level=info msg="created mon_group /sys/fs/resctrl/mon_groups/74038c4519bd838001f4bee0dc95516d for pod 74038c4519bd838001f4bee0dc95516d"
time="2026-06-09T09:11:39Z" level=debug msg="Synchronize: assigned pid 2479485 for pod 74038c4519bd838001f4bee0dc95516d"
time="2026-06-09T09:11:39Z" level=info msg="created mon_group /sys/fs/resctrl/mon_groups/ea0ade74d29d46eaacb5a89c34864be3 for pod ea0ade74d29d46eaacb5a89c34864be3"
time="2026-06-09T09:11:39Z" level=debug msg="Synchronize: assigned pid 2479436 for pod ea0ade74d29d46eaacb5a89c34864be3"
time="2026-06-09T09:11:39Z" level=info msg="created mon_group /sys/fs/resctrl/mon_groups/0774f9d04527f4275ff4df1f4d545646 for pod 0774f9d04527f4275ff4df1f4d545646"
time="2026-06-09T09:11:39Z" level=debug msg="Synchronize: assigned pid 2479431 for pod 0774f9d04527f4275ff4df1f4d545646"
time="2026-06-09T09:11:39Z" level=info msg="removing orphaned mon_group /sys/fs/resctrl/mon_groups/2ee80e9a-69b0-4cc2-81ab-10066aefc40c"
time="2026-06-09T09:11:39Z" level=debug msg="background reconciler started (interval=30s)"
time="2026-06-09T09:11:39Z" level=info msg="synchronization complete: tracking 10 pods"
```