### PR TITLE
mount NRI socket directory as read-only

### DIFF
--- a/deployment/helm/balloons/templates/daemonset.yaml
+++ b/deployment/helm/balloons/templates/daemonset.yaml
@@ -121,6 +121,7 @@ spec:
             mountPath: /var/run/nri-resource-policy
           - name: nrisockets
             mountPath: /var/run/nri
+            readOnly: true
           - name: pod-resources-socket
             mountPath: /var/lib/kubelet/pod-resources
             readOnly: true

--- a/deployment/helm/memory-policy/templates/daemonset.yaml
+++ b/deployment/helm/memory-policy/templates/daemonset.yaml
@@ -69,6 +69,7 @@ spec:
             mountPath: /etc/nri/memory-policy
           - name: nrisockets
             mountPath: /var/run/nri
+            readOnly: true
           - name: mpolset-vol
             mountPath: /mnt/nri-memory-policy-mpolset
       {{- if .Values.podPriorityClassNodeCritical }}

--- a/deployment/helm/memory-qos/templates/daemonset.yaml
+++ b/deployment/helm/memory-qos/templates/daemonset.yaml
@@ -69,6 +69,7 @@ spec:
             mountPath: /etc/nri/memory-qos
           - name: nrisockets
             mountPath: /var/run/nri
+            readOnly: true
       {{- if .Values.podPriorityClassNodeCritical }}
       priorityClassName: system-node-critical
       {{- end }}

--- a/deployment/helm/memtierd/templates/daemonset.yaml
+++ b/deployment/helm/memtierd/templates/daemonset.yaml
@@ -78,6 +78,7 @@ spec:
             mountPath: /etc/nri/memtierd
           - name: nrisockets
             mountPath: /var/run/nri
+            readOnly: true
           - name: host-bitmap
             mountPath: /sys/kernel/mm/page_idle/bitmap
           - name: cgroups-vol

--- a/deployment/helm/resctrl-mon/templates/daemonset.yaml
+++ b/deployment/helm/resctrl-mon/templates/daemonset.yaml
@@ -78,6 +78,7 @@ spec:
             mountPath: /etc/nri/resctrl-mon
           - name: nrisockets
             mountPath: /var/run/nri
+            readOnly: true
           - name: resctrlfs
             mountPath: /sys/fs/resctrl
       {{- if .Values.podPriorityClassNodeCritical }}

--- a/deployment/helm/sgx-epc/templates/daemonset.yaml
+++ b/deployment/helm/sgx-epc/templates/daemonset.yaml
@@ -65,6 +65,7 @@ spec:
           volumeMounts:
           - name: nrisockets
             mountPath: /var/run/nri
+            readOnly: true
       {{- if .Values.podPriorityClassNodeCritical }}
       priorityClassName: system-node-critical
       {{- end }}

--- a/deployment/helm/template/templates/daemonset.yaml
+++ b/deployment/helm/template/templates/daemonset.yaml
@@ -114,6 +114,7 @@ spec:
             mountPath: /var/run/nri-resource-policy
           - name: nrisockets
             mountPath: /var/run/nri
+            readOnly: true
           - name: pod-resources-socket
             mountPath: /var/lib/kubelet/pod-resources
             readOnly: true

--- a/deployment/helm/topology-aware/templates/daemonset.yaml
+++ b/deployment/helm/topology-aware/templates/daemonset.yaml
@@ -121,6 +121,7 @@ spec:
             mountPath: /var/run/nri-resource-policy
           - name: nrisockets
             mountPath: /var/run/nri
+            readOnly: true
           - name: pod-resources-socket
             mountPath: /var/lib/kubelet/pod-resources
             readOnly: true


### PR DESCRIPTION
Plugins don't write to `/var/run/nri` directory but only dial to the socket that exists there.