### PR TITLE
Fixes for various CodeQL findings

### DIFF
--- a/pkg/cgroups/cgroupstats.go
+++ b/pkg/cgroups/cgroupstats.go
@@ -468,7 +468,7 @@ func GetGlobalNumaStats() (map[int]GlobalNumaStats, error) {
 
 	for _, dir := range nodeDirs {
 		id := strings.TrimPrefix(dir, prefix)
-		node, err := strconv.ParseInt(id, 10, 64)
+		node, err := strconv.Atoi(id)
 		if err != nil {
 			return map[int]GlobalNumaStats{}, fmt.Errorf("error parsing directory name")
 		}
@@ -498,7 +498,7 @@ func GetGlobalNumaStats() (map[int]GlobalNumaStats, error) {
 			return map[int]GlobalNumaStats{}, fmt.Errorf("error parsing numastat file: %v", err)
 		}
 
-		result[int(node)] = nodeStat
+		result[node] = nodeStat
 	}
 
 	return result, nil

--- a/pkg/resmgr/cache/container.go
+++ b/pkg/resmgr/cache/container.go
@@ -1009,7 +1009,7 @@ var (
 	ignoredTopologyPathRegexps = []*regexp.Regexp{
 		// Kubelet directory can be different, but we can detect it by structure inside of it.
 		// For now, we can safely ignore exposed config maps and secrets for topology hints.
-		regexp.MustCompile(`(kubelet)?/pods/[[:xdigit:]-]+/volumes/kubernetes.io~(configmap|secret)/`),
+		regexp.MustCompile(`(kubelet)?/pods/[[:xdigit:]-]+/volumes/kubernetes\.io~(configmap|secret)/`),
 	}
 )
 

--- a/pkg/sysfs/utils.go
+++ b/pkg/sysfs/utils.go
@@ -158,43 +158,75 @@ func parseValue(str string, value interface{}) error {
 	case *string:
 		*value = str
 
-	case *int, *int8, *int16, *int32, *int64:
+	case *int:
 		v, err := strconv.ParseInt(str, 0, 0)
 		if err != nil {
 			return fmt.Errorf("invalid entry '%s': %w", str, err)
 		}
+		*value = int(v)
 
-		switch value := value.(type) {
-		case *int:
-			*value = int(v)
-		case *int8:
-			*value = int8(v)
-		case *int16:
-			*value = int16(v)
-		case *int32:
-			*value = int32(v)
-		case *int64:
-			*value = v
+	case *int8:
+		v, err := strconv.ParseInt(str, 0, 8)
+		if err != nil {
+			return fmt.Errorf("invalid entry '%s': %w", str, err)
 		}
+		*value = int8(v)
 
-	case *uint, *uint8, *uint16, *uint32, *uint64:
+	case *int16:
+		v, err := strconv.ParseInt(str, 0, 16)
+		if err != nil {
+			return fmt.Errorf("invalid entry '%s': %w", str, err)
+		}
+		*value = int16(v)
+
+	case *int32:
+		v, err := strconv.ParseInt(str, 0, 32)
+		if err != nil {
+			return fmt.Errorf("invalid entry '%s': %w", str, err)
+		}
+		*value = int32(v)
+
+	case *int64:
+		v, err := strconv.ParseInt(str, 0, 64)
+		if err != nil {
+			return fmt.Errorf("invalid entry '%s': %w", str, err)
+		}
+		*value = v
+
+	case *uint:
 		v, err := strconv.ParseUint(str, 0, 0)
 		if err != nil {
 			return fmt.Errorf("invalid entry: '%s': %w", str, err)
 		}
+		*value = uint(v)
 
-		switch value := value.(type) {
-		case *uint:
-			*value = uint(v)
-		case *uint8:
-			*value = uint8(v)
-		case *uint16:
-			*value = uint16(v)
-		case *uint32:
-			*value = uint32(v)
-		case *uint64:
-			*value = v
+	case *uint8:
+		v, err := strconv.ParseUint(str, 0, 8)
+		if err != nil {
+			return fmt.Errorf("invalid entry: '%s': %w", str, err)
 		}
+		*value = uint8(v)
+
+	case *uint16:
+		v, err := strconv.ParseUint(str, 0, 16)
+		if err != nil {
+			return fmt.Errorf("invalid entry: '%s': %w", str, err)
+		}
+		*value = uint16(v)
+
+	case *uint32:
+		v, err := strconv.ParseUint(str, 0, 32)
+		if err != nil {
+			return fmt.Errorf("invalid entry: '%s': %w", str, err)
+		}
+		*value = uint32(v)
+
+	case *uint64:
+		v, err := strconv.ParseUint(str, 0, 64)
+		if err != nil {
+			return fmt.Errorf("invalid entry: '%s': %w", str, err)
+		}
+		*value = v
 	}
 
 	return nil
@@ -259,38 +291,70 @@ func parseValueList(str, sep string, valuep interface{}) error {
 			value = val
 
 		case []int, []int8, []int16, []int32, []int64:
-			v, err := strconv.ParseInt(s, 0, 0)
-			if err != nil {
-				return fmt.Errorf("invalid entry '%s': %w", s, err)
-			}
 			switch val := value.(type) {
 			case []int:
+				v, err := strconv.ParseInt(s, 0, strconv.IntSize)
+				if err != nil {
+					return fmt.Errorf("invalid entry '%s': %w", s, err)
+				}
 				value = append(val, int(v))
 			case []int8:
+				v, err := strconv.ParseInt(s, 0, 8)
+				if err != nil {
+					return fmt.Errorf("invalid entry '%s': %w", s, err)
+				}
 				value = append(val, int8(v))
 			case []int16:
+				v, err := strconv.ParseInt(s, 0, 16)
+				if err != nil {
+					return fmt.Errorf("invalid entry '%s': %w", s, err)
+				}
 				value = append(val, int16(v))
 			case []int32:
+				v, err := strconv.ParseInt(s, 0, 32)
+				if err != nil {
+					return fmt.Errorf("invalid entry '%s': %w", s, err)
+				}
 				value = append(val, int32(v))
 			case []int64:
+				v, err := strconv.ParseInt(s, 0, 64)
+				if err != nil {
+					return fmt.Errorf("invalid entry '%s': %w", s, err)
+				}
 				value = append(val, v)
 			}
 
 		case []uint, []uint8, []uint16, []uint32, []uint64:
-			v, err := strconv.ParseUint(s, 0, 0)
-			if err != nil {
-				return fmt.Errorf("invalid entry '%s': %w", s, err)
-			}
 			switch val := value.(type) {
 			case []uint:
+				v, err := strconv.ParseUint(s, 0, strconv.IntSize)
+				if err != nil {
+					return fmt.Errorf("invalid entry '%s': %w", s, err)
+				}
 				value = append(val, uint(v))
 			case []uint8:
+				v, err := strconv.ParseUint(s, 0, 8)
+				if err != nil {
+					return fmt.Errorf("invalid entry '%s': %w", s, err)
+				}
 				value = append(val, uint8(v))
 			case []uint16:
+				v, err := strconv.ParseUint(s, 0, 16)
+				if err != nil {
+					return fmt.Errorf("invalid entry '%s': %w", s, err)
+				}
 				value = append(val, uint16(v))
 			case []uint32:
+				v, err := strconv.ParseUint(s, 0, 32)
+				if err != nil {
+					return fmt.Errorf("invalid entry '%s': %w", s, err)
+				}
 				value = append(val, uint32(v))
 			case []uint64:
+				v, err := strconv.ParseUint(s, 0, 64)
+				if err != nil {
+					return fmt.Errorf("invalid entry '%s': %w", s, err)
+				}
 				value = append(val, v)
 			}
 		}


### PR DESCRIPTION
CodeQL findings. Mostly fixes for incorrect conversion between integer types, but includes a regexp cleanup. From copilot autofix.