### PR TITLE
Move tar.go to testutils

### DIFF
--- a/cmd/plugins/topology-aware/policy/libmem_test.go
+++ b/cmd/plugins/topology-aware/policy/libmem_test.go
@@ -23,7 +23,7 @@ import (
 	cfgapi "github.com/containers/nri-plugins/pkg/apis/config/v1alpha1/resmgr/policy/topologyaware"
 	policyapi "github.com/containers/nri-plugins/pkg/resmgr/policy"
 	system "github.com/containers/nri-plugins/pkg/sysfs"
-	"github.com/containers/nri-plugins/pkg/utils"
+	"github.com/containers/nri-plugins/pkg/testutils"
 )
 
 // setupTestPolicy creates a policy from the server sysfs testdata.
@@ -33,7 +33,7 @@ func setupTestPolicy(t *testing.T) (*policy, string) {
 	if err != nil {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}
-	if err := utils.UncompressTbz2(path.Join("testdata", "sysfs.tar.bz2"), dir); err != nil {
+	if err := testutils.UncompressTbz2(path.Join("testdata", "sysfs.tar.bz2"), dir); err != nil {
 		if rerr := os.RemoveAll(dir); rerr != nil {
 			t.Logf("failed to remove temp dir %q: %v", dir, rerr)
 		}

--- a/cmd/plugins/topology-aware/policy/pools_test.go
+++ b/cmd/plugins/topology-aware/policy/pools_test.go
@@ -24,7 +24,7 @@ import (
 	policyapi "github.com/containers/nri-plugins/pkg/resmgr/policy"
 
 	system "github.com/containers/nri-plugins/pkg/sysfs"
-	"github.com/containers/nri-plugins/pkg/utils"
+	"github.com/containers/nri-plugins/pkg/testutils"
 )
 
 func findNodeWithName(name string, nodes []Node) Node {
@@ -53,7 +53,7 @@ func TestPoolCreation(t *testing.T) {
 	defer removeAll(t, dir)
 
 	// Uncompress the test data to the directory.
-	err = utils.UncompressTbz2(path.Join("testdata", "sysfs.tar.bz2"), dir)
+	err = testutils.UncompressTbz2(path.Join("testdata", "sysfs.tar.bz2"), dir)
 	if err != nil {
 		panic(err)
 	}
@@ -208,7 +208,7 @@ func TestWorkloadPlacement(t *testing.T) {
 	defer removeAll(t, dir)
 
 	// Uncompress the test data to the directory.
-	err = utils.UncompressTbz2(path.Join("testdata", "sysfs.tar.bz2"), dir)
+	err = testutils.UncompressTbz2(path.Join("testdata", "sysfs.tar.bz2"), dir)
 	if err != nil {
 		panic(err)
 	}
@@ -314,7 +314,7 @@ func TestAffinities(t *testing.T) {
 	defer removeAll(t, dir)
 
 	// Uncompress the test data to the directory.
-	err = utils.UncompressTbz2(path.Join("testdata", "sysfs.tar.bz2"), dir)
+	err = testutils.UncompressTbz2(path.Join("testdata", "sysfs.tar.bz2"), dir)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/cpuallocator/cpuallocator_test.go
+++ b/pkg/cpuallocator/cpuallocator_test.go
@@ -19,10 +19,10 @@ import (
 	"path"
 	"testing"
 
+	"github.com/containers/nri-plugins/pkg/testutils"
 	"github.com/containers/nri-plugins/pkg/utils/cpuset"
 
 	"github.com/containers/nri-plugins/pkg/sysfs"
-	"github.com/containers/nri-plugins/pkg/utils"
 
 	logger "github.com/containers/nri-plugins/pkg/log"
 )
@@ -35,7 +35,7 @@ func TestAllocatorHelper(t *testing.T) {
 	}
 	defer removeAll(t, tmpdir)
 
-	if err := utils.UncompressTbz2(path.Join("testdata", "sysfs.tar.bz2"), tmpdir); err != nil {
+	if err := testutils.UncompressTbz2(path.Join("testdata", "sysfs.tar.bz2"), tmpdir); err != nil {
 		t.Fatalf("failed to decompress testdata: %v", err)
 	}
 
@@ -113,7 +113,7 @@ func TestClusteredAllocation(t *testing.T) {
 	}
 	defer removeAll(t, tmpdir)
 
-	if err := utils.UncompressTbz2(path.Join("testdata", "sysfs.tar.bz2"), tmpdir); err != nil {
+	if err := testutils.UncompressTbz2(path.Join("testdata", "sysfs.tar.bz2"), tmpdir); err != nil {
 		t.Fatalf("failed to decompress testdata: %v", err)
 	}
 
@@ -329,7 +329,7 @@ func TestClusteredCoreKindAllocation(t *testing.T) {
 	}
 	defer removeAll(t, tmpdir)
 
-	if err := utils.UncompressTbz2(path.Join("testdata", "sysfs.tar.bz2"), tmpdir); err != nil {
+	if err := testutils.UncompressTbz2(path.Join("testdata", "sysfs.tar.bz2"), tmpdir); err != nil {
 		t.Fatalf("failed to decompress testdata: %v", err)
 	}
 

--- a/pkg/testutils/tar.go
+++ b/pkg/testutils/tar.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package utils
+package testutils
 
 import (
 	"archive/tar"
@@ -22,6 +22,8 @@ import (
 	"path"
 )
 
+// UncompressTbz2 extracts a bzip2-compressed tar archive.
+// This is a test-only utility and must not be used in production code.
 func UncompressTbz2(archive string, dir string) error {
 	file, err := os.Open(archive)
 	if err != nil {


### PR DESCRIPTION
There are various CodeQL findings from inside tar.go related to extracting potentially malicious tar files. However tar.go was only ever used inside test code. Hardening test code is futile as any malicious user can modify the code base of their fork in any way they want and thus attack the CI system.

Moving tar.go to testutils and putting in a comment stating that the code must not be used in production makes it clear that this code is only to be used for testing. The CodeQL findings can then be marked as "wontfix".