### PR TITLE
Parallelize makefile running

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -102,4 +102,5 @@ jobs:
         with:
           go-version-file: go.mod
       - run: |
-          make install-go-licenses verify-licenses
+          make install-go-licenses
+          make verify-licenses

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,8 @@ E2E_WORKDIR   ?= $(TOP_DIR)/e2e-results
 DOCKER       := docker
 DOCKER_BUILD := $(DOCKER) buildx build
 
+MAKEFLAGS += -j$(shell nproc || printf 1)
+
 # Plugins and other binaries we build.
 #
 # Notes:


### PR DESCRIPTION
This greatly increases especially the speed of license creation. Also benefits the build of the plugins.