### PR TITLE
Fix unescaped dot in regexp

### DIFF
--- a/pkg/resmgr/cache/container.go
+++ b/pkg/resmgr/cache/container.go
@@ -1009,7 +1009,7 @@ var (
 	ignoredTopologyPathRegexps = []*regexp.Regexp{
 		// Kubelet directory can be different, but we can detect it by structure inside of it.
 		// For now, we can safely ignore exposed config maps and secrets for topology hints.
-		regexp.MustCompile(`(kubelet)?/pods/[[:xdigit:]-]+/volumes/kubernetes.io~(configmap|secret)/`),
+		regexp.MustCompile(`(kubelet)?/pods/[[:xdigit:]-]+/volumes/kubernetes\.io~(configmap|secret)/`),
 	}
 )
 


### PR DESCRIPTION
A CodeQL finding. This fixes the unescaped dot that was left in a regexp.