### PR TITLE
Add trivy and codeql workflows

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,13 @@
+name: Manually Run CodeQL Analysis
+
+on:
+  workflow_dispatch:
+
+jobs:
+  codeql:
+    permissions:
+      contents: read
+      security-events: write
+    uses: "./.github/workflows/common-codeql.yaml"
+    with:
+      export-report: true

--- a/.github/workflows/common-codeql.yaml
+++ b/.github/workflows/common-codeql.yaml
@@ -1,0 +1,43 @@
+name: CodeQL
+on:
+  workflow_call:
+    inputs:
+      export-report:
+        default: false
+        required: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  codeql-scan:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@3d8036cf7fe7433e4a725cf513a6ea56c7fd0f14 # codeql-bundle-v2.25.0
+      with:
+        languages: go
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@3d8036cf7fe7433e4a725cf513a6ea56c7fd0f14 # codeql-bundle-v2.25.0
+
+    - name: Generate CodeQL Security Report
+      if: ${{ inputs.export-report }}
+      uses: rsdmike/github-security-report-action@a149b24539044c92786ec39af8ba38c93496495d # v3.0.4
+      with:
+        template: report
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Upload PDF report as an artifact
+      if: ${{ inputs.export-report }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: codeql-report
+        path: report.pdf

--- a/.github/workflows/common-trivy.yaml
+++ b/.github/workflows/common-trivy.yaml
@@ -1,0 +1,97 @@
+name: Trivy
+on:
+  workflow_call:
+    inputs:
+      upload-to-github-security-tab:
+        default: false
+        required: false
+        type: boolean
+      export-csv:
+        default: false
+        required: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  trivy-scan-licenses:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+    - name: Run Trivy in fs mode
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      with:
+        scan-type: fs
+        scan-ref: .
+        exit-code: 1
+        scanners: license
+        severity: "UNKNOWN,MEDIUM,HIGH,CRITICAL"
+
+  trivy-scan-vulns:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+    - name: Run Trivy in fs mode
+      # This can later be turned into a blocking step if deemed necessary, but now we just want the update to the security tab and the artifact for review.
+      continue-on-error: true
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      with:
+        scan-type: fs
+        scan-ref: .
+        exit-code: 0
+        list-all-pkgs: true
+        format: json
+        output: trivy-report.json
+
+    - name: Show report in human-readable format
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      with:
+        scan-type: convert
+        vuln-type: ''
+        severity: ''
+        image-ref: trivy-report.json
+        format: table
+
+    - name: Convert report to sarif format
+      if: ${{ inputs.upload-to-github-security-tab }}
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      with:
+        scan-type: convert
+        vuln-type: ''
+        severity: ''
+        image-ref: trivy-report.json
+        format: sarif
+        output: trivy-report.sarif
+
+    - name: Upload sarif report to GitHub Security tab
+      if: ${{ inputs.upload-to-github-security-tab }}
+      uses: github/codeql-action/upload-sarif@3d8036cf7fe7433e4a725cf513a6ea56c7fd0f14 # codeql-bundle-v2.25.0
+      with:
+       sarif_file: trivy-report.sarif
+
+    - name: Convert report to csv
+      if: ${{ inputs.export-csv }}
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      with:
+        scan-type: convert
+        vuln-type: ''
+        severity: ''
+        image-ref: trivy-report.json
+        format: template
+        template: "@.github/workflows/trivy-csv.tpl"
+        output: trivy-report.csv
+
+    - name: Upload CSV report as an artifact
+      if: ${{ inputs.export-csv }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: trivy-report
+        path: trivy-report.csv

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    tags: [ 'v*' ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  trivy:
+    permissions:
+      contents: read
+      security-events: write
+    uses: "./.github/workflows/common-trivy.yaml"
+    with:
+      export-csv: true
+
+  codeql:
+    permissions:
+      contents: read
+      security-events: write
+    uses: "./.github/workflows/common-codeql.yaml"
+    with:
+      export-report: true

--- a/.github/workflows/scan-periodic.yaml
+++ b/.github/workflows/scan-periodic.yaml
@@ -1,0 +1,16 @@
+name: Scan periodic
+on:
+  schedule:
+    - cron: '15 3 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  trivy:
+    permissions:
+      contents: read
+      security-events: write
+    uses: "./.github/workflows/common-trivy.yaml"
+    with:
+      upload-to-github-security-tab: true

--- a/.github/workflows/trivy-csv.tpl
+++ b/.github/workflows/trivy-csv.tpl
@@ -1,0 +1,29 @@
+{{ range . }}
+Trivy Vulnerability Scan Results ({{- .Target -}})
+VulnerabilityID,Severity,CVSS Score,Title,Library,Vulnerable Version,Fixed Version,Information URL,Triage Information
+{{ range .Vulnerabilities }}
+    {{- .VulnerabilityID }},
+    {{- .Severity }},
+    {{- range $key, $value := .CVSS }}
+        {{- if (eq $key "nvd") }}
+            {{- .V3Score -}}
+        {{- end }}
+    {{- end }},
+    {{- quote .Title }},
+    {{- quote .PkgName }},
+    {{- quote .InstalledVersion }},
+    {{- quote .FixedVersion }},
+    {{- .PrimaryURL }}
+{{ else -}}
+    No vulnerabilities found at this time.
+{{ end }}
+Trivy Dependency Scan Results ({{ .Target }})
+ID,Name,Version,Notes
+{{ range .Packages -}}
+    {{- quote .ID }},
+    {{- quote .Name }},
+    {{- quote .Version }}
+{{ else -}}
+    No dependencies found at this time.
+{{ end }}
+{{ end }}

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -104,3 +104,17 @@ jobs:
       - run: |
           make install-go-licenses
           make verify-licenses
+
+  trivy:
+    permissions:
+      contents: read
+      security-events: write
+    uses: "./.github/workflows/common-trivy.yaml"
+    with:
+      upload-to-github-security-tab: true
+
+  codeql:
+    permissions:
+      contents: read
+      security-events: write
+    uses: "./.github/workflows/common-codeql.yaml"


### PR DESCRIPTION
These workflow changes are originally for the most part from the goresctrl project, hence the co-authorship with marquiz.

Technically speaking, it is not absolutely necessary to have the possibility of running trivy and codeql inside the nri-plugins project itself. These tools can be also run in a fork, as I have been doing.

But for the longer term, it would perhaps be better for the project to keep an eye for security issues found by also these two tools. The issues are conveniently shown in the "Security and quality" tab for those with enough permissions in the project. A pdf-report will also be available.