### PR TITLE
pkg/sysfs: replace interface{}-based sysfs I/O with typed generics

### DIFF
--- a/pkg/sysfs/system.go
+++ b/pkg/sysfs/system.go
@@ -531,7 +531,7 @@ func (sys *system) SetCpusOnline(online bool, cpus idset.IDSet) (idset.IDSet, er
 			continue
 		}
 
-		if _, err := writeSysfsEntry(entry, "online", desired, &current); err != nil {
+		if err := writeSysfsInt(entry, "online", desired, &current); err != nil {
 			return nil, sysfsError(entry, "failed to set online to %d: %v", desired, err)
 		}
 
@@ -879,22 +879,22 @@ func (sys *system) discoverCPUs() error {
 	sys.cpus = make(map[idset.ID]*cpu)
 
 	base := filepath.Join(sys.path, sysfsCPUPath)
-	_, err := readSysfsEntry(base, "possible", &sys.possibleCPUs, ",")
+	err := readSysfsIDSet(base, "possible", ",", &sys.possibleCPUs)
 	if err != nil {
 		sys.Errorf("failed to get set of possible cpus: %v", err)
 	}
 
-	_, err = readSysfsEntry(base, "present", &sys.presentCPUs, ",")
+	err = readSysfsIDSet(base, "present", ",", &sys.presentCPUs)
 	if err != nil {
 		sys.Errorf("failed to get set of present cpus: %v", err)
 	}
 
-	_, err = readSysfsEntry(base, "online", &sys.onlineCPUs, ",")
+	err = readSysfsIDSet(base, "online", ",", &sys.onlineCPUs)
 	if err != nil {
 		sys.Errorf("failed to get set of online cpus: %v", err)
 	}
 
-	_, err = readSysfsEntry(base, "isolated", &sys.isolatedCPUs, ",")
+	err = readSysfsIDSet(base, "isolated", ",", &sys.isolatedCPUs)
 	if err != nil {
 		sys.Errorf("failed to get set of isolated cpus: %v", err)
 	}
@@ -917,7 +917,7 @@ func (sys *system) discoverCPUs() error {
 	if len(sys.coreKindCPUs) == 0 {
 		for kind, entry := range coreKindCPUPath {
 			cpus := idset.NewIDSet()
-			_, err = readSysfsEntry(sys.path, entry, &cpus, ",")
+			err = readSysfsIDSet(sys.path, entry, ",", &cpus)
 			if err != nil {
 				sys.Errorf("failed to get set of %s cpus: %v", kind, err)
 				if kind == PerformanceCore {
@@ -1031,22 +1031,22 @@ func (sys *system) discoverCPU(path string) error {
 	cpu.online = sys.onlineCPUs.Has(cpu.id)
 
 	if cpu.online {
-		if _, err := readSysfsEntry(path, "topology/physical_package_id", &cpu.pkg); err != nil {
+		if err := readSysfsInt(path, "topology/physical_package_id", &cpu.pkg); err != nil {
 			return err
 		}
-		if _, err := readSysfsEntry(path, "topology/die_id", &cpu.die); err != nil {
+		if err := readSysfsInt(path, "topology/die_id", &cpu.die); err != nil {
 			log.Warnf("failed to read die ID for CPU %d: %v", cpu.id, err)
 		}
-		if _, err := readSysfsEntry(path, "topology/cluster_id", &cpu.cluster); err != nil {
+		if err := readSysfsInt(path, "topology/cluster_id", &cpu.cluster); err != nil {
 			log.Warnf("failed to read cluster ID for CPU %d: %v", cpu.id, err)
 		}
-		if _, err := readSysfsEntry(path, "topology/core_id", &cpu.core); err != nil {
+		if err := readSysfsInt(path, "topology/core_id", &cpu.core); err != nil {
 			return err
 		}
 
-		if _, err := readSysfsEntry(path, "topology/core_cpus_list", &cpu.threads, ","); err != nil {
+		if err := readSysfsIDSet(path, "topology/core_cpus_list", ",", &cpu.threads); err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
-				_, err = readSysfsEntry(path, "topology/thread_siblings_list", &cpu.threads, ",")
+				err = readSysfsIDSet(path, "topology/thread_siblings_list", ",", &cpu.threads)
 			}
 			if err != nil {
 				return err
@@ -1054,16 +1054,16 @@ func (sys *system) discoverCPU(path string) error {
 		}
 	}
 
-	if _, err := readSysfsEntry(path, "cpufreq/base_frequency", &cpu.freq.Base); err != nil {
+	if err := readSysfsUint(path, "cpufreq/base_frequency", &cpu.freq.Base); err != nil {
 		cpu.freq.Base = 0
 	}
-	if _, err := readSysfsEntry(path, "cpufreq/cpuinfo_min_freq", &cpu.freq.Min); err != nil {
+	if err := readSysfsUint(path, "cpufreq/cpuinfo_min_freq", &cpu.freq.Min); err != nil {
 		cpu.freq.Min = 0
 	}
-	if _, err := readSysfsEntry(path, "cpufreq/cpuinfo_max_freq", &cpu.freq.Max); err != nil {
+	if err := readSysfsUint(path, "cpufreq/cpuinfo_max_freq", &cpu.freq.Max); err != nil {
 		cpu.freq.Max = 0
 	}
-	if _, err := readSysfsEntry(path, "cpufreq/energy_performance_preference", &cpu.epp); err != nil {
+	if err := readSysfsEPP(path, "cpufreq/energy_performance_preference", &cpu.epp); err != nil {
 		cpu.epp = EPPUnknown
 	}
 	if node, _ := filepath.Glob(filepath.Join(path, "node[0-9]*")); len(node) == 1 {
@@ -1199,10 +1199,10 @@ func (c *cpu) SetFrequencyLimits(min, max uint64) error {
 		max = c.freq.Max
 	}
 
-	if _, err := writeSysfsEntry(c.path, "cpufreq/scaling_min_freq", min, nil); err != nil {
+	if err := writeSysfsUint(c.path, "cpufreq/scaling_min_freq", min); err != nil {
 		return err
 	}
-	if _, err := writeSysfsEntry(c.path, "cpufreq/scaling_max_freq", max, nil); err != nil {
+	if err := writeSysfsUint(c.path, "cpufreq/scaling_max_freq", max); err != nil {
 		return err
 	}
 
@@ -1376,7 +1376,7 @@ func (sys *system) discoverNodes() error {
 		return nil
 	}
 
-	normalMemNodeIDs, err := readSysfsEntry(sysNodesPath, "has_normal_memory", nil)
+	normalMemNodeIDs, err := readSysfsRaw(sysNodesPath, "has_normal_memory")
 	if err != nil {
 		return fmt.Errorf("failed to discover nodes with normal memory: %v", err)
 	}
@@ -1385,7 +1385,7 @@ func (sys *system) discoverNodes() error {
 		return fmt.Errorf("failed to parse nodes with normal memory (%q): %v",
 			normalMemNodes, err)
 	}
-	memoryNodeIDs, err := readSysfsEntry(sysNodesPath, "has_memory", nil)
+	memoryNodeIDs, err := readSysfsRaw(sysNodesPath, "has_memory")
 	if err != nil {
 		return fmt.Errorf("failed to discover nodes with memory: %v", err)
 	}
@@ -1394,7 +1394,7 @@ func (sys *system) discoverNodes() error {
 		return fmt.Errorf("failed to parse nodes with memory (%q): %v",
 			memoryNodeIDs, err)
 	}
-	onlineNodeIDs, err := readSysfsEntry(sysNodesPath, "online", nil)
+	onlineNodeIDs, err := readSysfsRaw(sysNodesPath, "online")
 	if err != nil {
 		return fmt.Errorf("failed to discover online nodes: %v", err)
 	}
@@ -1505,10 +1505,10 @@ func (sys *system) discoverNodes() error {
 func (sys *system) discoverNode(path string) error {
 	node := &node{path: path, id: getEnumeratedID(path)}
 
-	if _, err := readSysfsEntry(path, "cpulist", &node.cpus, ","); err != nil {
+	if err := readSysfsIDSet(path, "cpulist", ",", &node.cpus); err != nil {
 		return err
 	}
-	if _, err := readSysfsEntry(path, "distance", &node.distance); err != nil {
+	if err := readSysfsIntList(path, "distance", " ", &node.distance); err != nil {
 		return err
 	}
 
@@ -2091,7 +2091,7 @@ func (sys *system) discoverCache(cpu *cpu, path string) error {
 		return sysfsError(path, "unexpected cache path %s", path)
 	}
 
-	if _, err := readSysfsEntry(path, "id", &id); err != nil {
+	if err := readSysfsInt(path, "id", &id); err != nil {
 		return sysfsError(path, "can't read cache id: %v", err)
 	}
 
@@ -2099,14 +2099,14 @@ func (sys *system) discoverCache(cpu *cpu, path string) error {
 		id: id,
 	}
 
-	if _, err := readSysfsEntry(path, "level", &c.level); err != nil {
+	if err := readSysfsInt(path, "level", &c.level); err != nil {
 		return sysfsError(path, "can't read cache level: %v", err)
 	}
-	if _, err := readSysfsEntry(path, "shared_cpu_list", &c.cpus, ","); err != nil {
+	if err := readSysfsIDSet(path, "shared_cpu_list", ",", &c.cpus); err != nil {
 		return sysfsError(path, "can't read shared CPUs: %v", err)
 	}
 	kind := ""
-	if _, err := readSysfsEntry(path, "type", &kind); err != nil {
+	if err := readSysfsString(path, "type", &kind); err != nil {
 		return sysfsError(path, "can't read cache type: %v", err)
 	}
 	switch kind {
@@ -2121,7 +2121,7 @@ func (sys *system) discoverCache(cpu *cpu, path string) error {
 	}
 
 	size := ""
-	if _, err := readSysfsEntry(path, "size", &size); err != nil {
+	if err := readSysfsString(path, "size", &size); err != nil {
 		return sysfsError(path, "can't read cache size: %v", err)
 	}
 

--- a/pkg/sysfs/utils.go
+++ b/pkg/sysfs/utils.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -47,316 +48,207 @@ func getEnumeratedID(name string) idset.ID {
 	return idset.ID(-1)
 }
 
-// Read content of a sysfs entry and convert it according to the type of a given pointer.
-func readSysfsEntry(base, entry string, ptr interface{}, args ...interface{}) (string, error) {
-	var buf string
+// signedInt covers signed integers and named types with a signed-integer
+// underlying type (e.g. idset.ID).
+type signedInt interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64
+}
 
+// unsignedInt covers unsigned integers and named types with an unsigned-integer
+// underlying type.
+type unsignedInt interface {
+	~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64
+}
+
+// readSysfsRaw reads and trims the newline-terminated content of base/entry.
+func readSysfsRaw(base, entry string) (string, error) {
 	path := filepath.Join(base, entry)
-
 	blob, err := os.ReadFile(path)
 	if err != nil {
 		return "", sysfsError(path, "failed to read sysfs entry: %w", err)
 	}
-	buf = strings.Trim(string(blob), "\n")
-
-	if ptr == interface{}(nil) {
-		return buf, nil
-	}
-
-	switch ptr := ptr.(type) {
-	case *string, *int, *uint, *int8, *uint8, *int16, *uint16, *int32, *uint32, *int64, *uint64:
-		err := parseValue(buf, ptr)
-		if err != nil {
-			return "", sysfsError(path, "%w", err)
-		}
-		return buf, nil
-
-	case *idset.IDSet, *[]int, *[]uint, *[]int8, *[]uint8, *[]int16, *[]uint16, *[]int32, *[]uint32, *[]int64, *[]uint64:
-		sep, err := getSeparator(" ", args)
-		if err != nil {
-			return "", sysfsError(path, "%w", err)
-		}
-		err = parseValueList(buf, sep, ptr)
-		if err != nil {
-			return "", sysfsError(path, "%w", err)
-		}
-		return buf, nil
-	case *EPP:
-		*ptr = EPPFromString(buf)
-		return buf, nil
-	}
-
-	return "", sysfsError(path, "unsupported sysfs entry type %T", ptr)
+	return strings.Trim(string(blob), "\n"), nil
 }
 
-// Write a value to a sysfs entry. An optional item separator can be specified for slice values.
-func writeSysfsEntry(base, entry string, val, oldp interface{}, args ...interface{}) (string, error) {
-	var buf, old string
-	var err error
-
-	if oldp != nil {
-		if old, err = readSysfsEntry(base, entry, oldp, args...); err != nil {
-			return "", err
-		}
+// readSysfsInt reads base/entry and parses the content as a signed integer of
+// type T. Named types with a signed-integer underlying type (e.g. idset.ID) work too.
+func readSysfsInt[T signedInt](base, entry string, dst *T) error {
+	buf, err := readSysfsRaw(base, entry)
+	if err != nil {
+		return err
 	}
-
-	path := filepath.Join(base, entry)
-
-	switch val.(type) {
-	case string, int, uint, int8, uint8, int16, uint16, int32, uint32, int64, uint64:
-		buf, err = formatValue(val)
-		if err != nil {
-			return "", sysfsError(path, "%w", err)
-		}
-
-	case idset.IDSet, []int, []uint, []int8, []uint8, []int16, []uint16, []int32, []uint32, []int64, []uint64:
-		sep, err := getSeparator(" ", args)
-		if err != nil {
-			return "", sysfsError(path, "%w", err)
-		}
-		buf, err = formatValueList(sep, val)
-		if err != nil {
-			return "", sysfsError(path, "%w", err)
-		}
-
-	default:
-		return "", sysfsError(path, "unsupported sysfs entry type %T", val)
+	v, err := parseIntTo[T](buf)
+	if err != nil {
+		return sysfsError(filepath.Join(base, entry), "invalid integer %q: %w", buf, err)
 	}
+	*dst = v
+	return nil
+}
 
+// readSysfsUint reads a sysfs file and parses it as an unsigned integer of type T.
+func readSysfsUint[T unsignedInt](base, entry string, dst *T) error {
+	buf, err := readSysfsRaw(base, entry)
+	if err != nil {
+		return err
+	}
+	v, err := parseUintTo[T](buf)
+	if err != nil {
+		return sysfsError(filepath.Join(base, entry), "invalid unsigned integer %q: %w", buf, err)
+	}
+	*dst = v
+	return nil
+}
+
+// readSysfsString reads a sysfs file and stores the trimmed content in dst.
+func readSysfsString(base, entry string, dst *string) error {
+	buf, err := readSysfsRaw(base, entry)
+	if err != nil {
+		return err
+	}
+	*dst = buf
+	return nil
+}
+
+// readSysfsIDSet reads a sysfs file and parses it as a sep-delimited IDSet.
+func readSysfsIDSet(base, entry, sep string, dst *idset.IDSet) error {
+	buf, err := readSysfsRaw(base, entry)
+	if err != nil {
+		return err
+	}
+	if err := parseIDSet(buf, sep, dst); err != nil {
+		return sysfsError(filepath.Join(base, entry), "%w", err)
+	}
+	return nil
+}
+
+// readSysfsIntList reads a sysfs file as a sep-delimited list of signed integers.
+func readSysfsIntList[T signedInt](base, entry, sep string, dst *[]T) error {
+	buf, err := readSysfsRaw(base, entry)
+	if err != nil {
+		return err
+	}
+	v, err := parseIntSlice[T](buf, sep)
+	if err != nil {
+		return sysfsError(filepath.Join(base, entry), "%w", err)
+	}
+	*dst = v
+	return nil
+}
+
+// readSysfsEPP reads a sysfs file and parses it as an EPP value.
+func readSysfsEPP(base, entry string, dst *EPP) error {
+	buf, err := readSysfsRaw(base, entry)
+	if err != nil {
+		return err
+	}
+	*dst = EPPFromString(buf)
+	return nil
+}
+
+// writeSysfsRaw writes buf (plus a trailing newline) to the file at path.
+func writeSysfsRaw(path, buf string) (err error) {
 	f, err := os.OpenFile(path, os.O_WRONLY, 0)
 	if err != nil {
-		return "", sysfsError(path, "cannot open: %w", err)
+		return sysfsError(path, "cannot open: %w", err)
 	}
 	defer func() {
 		if cerr := f.Close(); cerr != nil && err == nil {
 			err = sysfsError(path, "failed to close: %w", cerr)
 		}
 	}()
-
 	if _, err = f.Write([]byte(buf + "\n")); err != nil {
-		return "", sysfsError(path, "cannot write: %w", err)
+		return sysfsError(path, "cannot write: %w", err)
 	}
-
-	return old, nil
-}
-
-// Determine list separator string, given an optional separator variadic argument.
-func getSeparator(defaultVal string, args []interface{}) (string, error) {
-	switch len(args) {
-	case 0:
-		return defaultVal, nil
-	case 1:
-		return args[0].(string), nil
-	}
-
-	return "", fmt.Errorf("invalid separator (%v), 1 expected, %d given", args, len(args))
-}
-
-// Parse a value from a string.
-func parseValue(str string, value interface{}) error {
-	switch value := value.(type) {
-	case *string:
-		*value = str
-
-	case *int, *int8, *int16, *int32, *int64:
-		v, err := strconv.ParseInt(str, 0, 0)
-		if err != nil {
-			return fmt.Errorf("invalid entry '%s': %w", str, err)
-		}
-
-		switch value := value.(type) {
-		case *int:
-			*value = int(v)
-		case *int8:
-			*value = int8(v)
-		case *int16:
-			*value = int16(v)
-		case *int32:
-			*value = int32(v)
-		case *int64:
-			*value = v
-		}
-
-	case *uint, *uint8, *uint16, *uint32, *uint64:
-		v, err := strconv.ParseUint(str, 0, 0)
-		if err != nil {
-			return fmt.Errorf("invalid entry: '%s': %w", str, err)
-		}
-
-		switch value := value.(type) {
-		case *uint:
-			*value = uint(v)
-		case *uint8:
-			*value = uint8(v)
-		case *uint16:
-			*value = uint16(v)
-		case *uint32:
-			*value = uint32(v)
-		case *uint64:
-			*value = v
-		}
-	}
-
 	return nil
 }
 
-// Parse a list of values from a string into a slice.
-func parseValueList(str, sep string, valuep interface{}) error {
-	var value interface{}
-
-	switch valuep.(type) {
-	case *idset.IDSet:
-		value = idset.NewIDSet()
-	case *[]int:
-		value = []int{}
-	case *[]uint:
-		value = []uint{}
-	case *[]int8:
-		value = []int8{}
-	case *[]uint8:
-		value = []uint8{}
-	case *[]int16:
-		value = []int16{}
-	case *[]uint16:
-		value = []uint16{}
-	case *[]int32:
-		value = []int32{}
-	case *[]uint32:
-		value = []uint32{}
-	case *[]int64:
-		value = []int64{}
-	case *[]uint64:
-		value = []uint64{}
-	default:
-		return fmt.Errorf("invalid slice value type: %T", valuep)
+// writeSysfsInt writes val to base/entry. If old is non-nil, the current value
+// is read into *old first.
+func writeSysfsInt[T signedInt](base, entry string, val T, old ...*T) error {
+	if len(old) > 0 && old[0] != nil {
+		if err := readSysfsInt(base, entry, old[0]); err != nil {
+			return err
+		}
 	}
+	return writeSysfsRaw(filepath.Join(base, entry), fmt.Sprintf("%d", val))
+}
 
+// writeSysfsUint writes val to base/entry. If old is non-nil, the current value
+// is read into *old first.
+func writeSysfsUint[T unsignedInt](base, entry string, val T, old ...*T) error {
+	if len(old) > 0 && old[0] != nil {
+		if err := readSysfsUint(base, entry, old[0]); err != nil {
+			return err
+		}
+	}
+	return writeSysfsRaw(filepath.Join(base, entry), fmt.Sprintf("%d", val))
+}
+
+// parseIntTo parses str as a signed integer of type T, using T's actual bit
+// width. Works correctly for named types (e.g. type MyInt8 int8).
+func parseIntTo[T signedInt](str string) (T, error) {
+	var zero T
+	bits := int(reflect.TypeOf(zero).Size()) * 8
+	v, err := strconv.ParseInt(str, 0, bits)
+	return T(v), err
+}
+
+// parseUintTo parses str as an unsigned integer of type T, using T's actual
+// bit width. Works correctly for named types (e.g. type MyUint8 uint8).
+func parseUintTo[T unsignedInt](str string) (T, error) {
+	var zero T
+	bits := int(reflect.TypeOf(zero).Size()) * 8
+	v, err := strconv.ParseUint(str, 0, bits)
+	return T(v), err
+}
+
+// parseIntSlice splits str on sep and parses each token as a T.
+func parseIntSlice[T signedInt](str, sep string) ([]T, error) {
+	var out []T
 	for _, s := range strings.Split(str, sep) {
 		if s == "" {
-			break
+			continue
 		}
-		switch val := value.(type) {
-		case idset.IDSet:
-			if rng := strings.Split(s, "-"); len(rng) == 1 {
-				id, err := strconv.Atoi(s)
-				if err != nil {
-					return fmt.Errorf("invalid entry '%s': %w", s, err)
-				}
-				val.Add(idset.ID(id))
-			} else {
-				beg, err := strconv.Atoi(rng[0])
-				if err != nil {
-					return fmt.Errorf("invalid entry '%s': %w", s, err)
-				}
-				end, err := strconv.Atoi(rng[1])
-				if err != nil {
-					return fmt.Errorf("invalid entry '%s': %w", s, err)
-				}
-				for id := beg; id <= end; id++ {
-					val.Add(idset.ID(id))
-				}
-			}
-			value = val
+		v, err := parseIntTo[T](s)
+		if err != nil {
+			return nil, fmt.Errorf("invalid entry %q: %w", s, err)
+		}
+		out = append(out, v)
+	}
+	return out, nil
+}
 
-		case []int, []int8, []int16, []int32, []int64:
-			v, err := strconv.ParseInt(s, 0, 0)
+// parseIDSet parses a separator-delimited string of integers and ranges (e.g.
+// "0-3 8 12-15") into an idset.IDSet.
+func parseIDSet(str, sep string, dst *idset.IDSet) error {
+	ids := idset.NewIDSet()
+	for _, s := range strings.Split(str, sep) {
+		if s == "" {
+			continue
+		}
+		rng := strings.SplitN(s, "-", 2)
+		if len(rng) == 1 {
+			id, err := strconv.Atoi(s)
 			if err != nil {
-				return fmt.Errorf("invalid entry '%s': %w", s, err)
+				return fmt.Errorf("invalid entry %q: %w", s, err)
 			}
-			switch val := value.(type) {
-			case []int:
-				value = append(val, int(v))
-			case []int8:
-				value = append(val, int8(v))
-			case []int16:
-				value = append(val, int16(v))
-			case []int32:
-				value = append(val, int32(v))
-			case []int64:
-				value = append(val, v)
-			}
-
-		case []uint, []uint8, []uint16, []uint32, []uint64:
-			v, err := strconv.ParseUint(s, 0, 0)
+			ids.Add(idset.ID(id))
+		} else {
+			beg, err := strconv.Atoi(rng[0])
 			if err != nil {
-				return fmt.Errorf("invalid entry '%s': %w", s, err)
+				return fmt.Errorf("invalid entry %q: %w", s, err)
 			}
-			switch val := value.(type) {
-			case []uint:
-				value = append(val, uint(v))
-			case []uint8:
-				value = append(val, uint8(v))
-			case []uint16:
-				value = append(val, uint16(v))
-			case []uint32:
-				value = append(val, uint32(v))
-			case []uint64:
-				value = append(val, v)
+			end, err := strconv.Atoi(rng[1])
+			if err != nil {
+				return fmt.Errorf("invalid entry %q: %w", s, err)
+			}
+			for id := beg; id <= end; id++ {
+				ids.Add(idset.ID(id))
 			}
 		}
 	}
-
-	switch valuep := valuep.(type) {
-	case *idset.IDSet:
-		*valuep = value.(idset.IDSet)
-	case *[]int:
-		*valuep = value.([]int)
-	case *[]uint:
-		*valuep = value.([]uint)
-	case *[]int8:
-		*valuep = value.([]int8)
-	case *[]uint8:
-		*valuep = value.([]uint8)
-	case *[]int16:
-		*valuep = value.([]int16)
-	case *[]uint16:
-		*valuep = value.([]uint16)
-	case *[]int32:
-		*valuep = value.([]int32)
-	case *[]uint32:
-		*valuep = value.([]uint32)
-	case *[]int64:
-		*valuep = value.([]int64)
-	case *[]uint64:
-		*valuep = value.([]uint64)
-	}
-
+	*dst = ids
 	return nil
-}
-
-// Format a value into a string.
-func formatValue(value interface{}) (string, error) {
-	switch value := value.(type) {
-	case string:
-		return value, nil
-	case int, uint, int8, uint8, int16, uint16, int32, uint32, int64, uint64:
-		return fmt.Sprintf("%d", value), nil
-	default:
-		return "", fmt.Errorf("invalid value type %T", value)
-	}
-}
-
-// Format a list of values from a slice into a string.
-func formatValueList(sep string, value interface{}) (string, error) {
-	var v []interface{}
-
-	switch value := value.(type) {
-	case idset.IDSet:
-		return value.StringWithSeparator(sep), nil
-	case []int, []uint, []int8, []uint8, []int16, []uint16, []int32, []uint32, []int64, []uint64:
-		v = value.([]interface{})
-	default:
-		return "", fmt.Errorf("invalid value type %T", value)
-	}
-
-	str := ""
-	t := ""
-	for idx := range v {
-		str = str + t + fmt.Sprintf("%d", v[idx])
-		t = sep
-	}
-
-	return "", nil
 }
 
 // IDSetFromCPUSet returns an id set corresponding to a cpuset.CPUSet.

--- a/pkg/sysfs/utils_test.go
+++ b/pkg/sysfs/utils_test.go
@@ -1,0 +1,804 @@
+// Copyright 2026 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests for unexported sysfs utility functions.
+package sysfs
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	idset "github.com/intel/goresctrl/pkg/utils"
+)
+
+// writeSysfsFile creates base/entry containing content for use in read tests.
+func writeSysfsFile(t *testing.T, base, entry, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(base, entry), []byte(content), 0o600); err != nil {
+		t.Fatalf("writeSysfsFile: %v", err)
+	}
+}
+
+// --------------------------------------------------------------------------
+// parseIntTo
+// --------------------------------------------------------------------------
+
+func TestParseIntTo(t *testing.T) {
+	t.Run("int", func(t *testing.T) {
+		for _, tc := range []struct {
+			in      string
+			want    int
+			wantErr bool
+		}{
+			{"0", 0, false},
+			{"42", 42, false},
+			{"-1", -1, false},
+			{"0xff", 255, false},
+			{"abc", 0, true},
+		} {
+			v, err := parseIntTo[int](tc.in)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("parseIntTo[int](%q) err=%v wantErr=%v", tc.in, err, tc.wantErr)
+			}
+			if err == nil && v != tc.want {
+				t.Errorf("parseIntTo[int](%q) = %d, want %d", tc.in, v, tc.want)
+			}
+		}
+	})
+
+	t.Run("int8_overflow", func(t *testing.T) {
+		if _, err := parseIntTo[int8]("128"); err == nil {
+			t.Error("expected overflow error for int8(128), got nil")
+		}
+		if _, err := parseIntTo[int8]("-129"); err == nil {
+			t.Error("expected overflow error for int8(-129), got nil")
+		}
+		v, err := parseIntTo[int8]("127")
+		if err != nil || v != 127 {
+			t.Errorf("parseIntTo[int8](127) = %d, %v; want 127, nil", v, err)
+		}
+	})
+
+	t.Run("int16_overflow", func(t *testing.T) {
+		if _, err := parseIntTo[int16]("32768"); err == nil {
+			t.Error("expected overflow error for int16(32768), got nil")
+		}
+		v, err := parseIntTo[int16]("32767")
+		if err != nil || v != 32767 {
+			t.Errorf("parseIntTo[int16](32767) = %d, %v; want 32767, nil", v, err)
+		}
+	})
+
+	t.Run("int32_overflow", func(t *testing.T) {
+		if _, err := parseIntTo[int32]("2147483648"); err == nil {
+			t.Error("expected overflow error for int32(2147483648), got nil")
+		}
+	})
+
+	t.Run("int64_max", func(t *testing.T) {
+		v, err := parseIntTo[int64]("9223372036854775807")
+		if err != nil || v != 9223372036854775807 {
+			t.Errorf("parseIntTo[int64](max) = %d, %v", v, err)
+		}
+	})
+
+	// Named types whose underlying type is int should parse at strconv.IntSize bits,
+	// not silently truncate into a smaller type.
+	t.Run("named_int_type", func(t *testing.T) {
+		type myID int
+		v, err := parseIntTo[myID]("100")
+		if err != nil || v != 100 {
+			t.Errorf("parseIntTo[myID](100) = %d, %v; want 100, nil", v, err)
+		}
+	})
+
+	// Named types with a small underlying type (e.g. int8) must also be range-checked
+	// at int8 width, not int width. This was the regression case from PR #676.
+	t.Run("named_int8_type_overflow", func(t *testing.T) {
+		type myInt8 int8
+		if _, err := parseIntTo[myInt8]("128"); err == nil {
+			t.Error("expected overflow error for myInt8(128), got nil")
+		}
+		v, err := parseIntTo[myInt8]("127")
+		if err != nil || v != 127 {
+			t.Errorf("parseIntTo[myInt8](127) = %d, %v; want 127, nil", v, err)
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// parseUintTo
+// --------------------------------------------------------------------------
+
+func TestParseUintTo(t *testing.T) {
+	t.Run("uint", func(t *testing.T) {
+		v, err := parseUintTo[uint]("255")
+		if err != nil || v != 255 {
+			t.Errorf("parseUintTo[uint](255) = %d, %v; want 255, nil", v, err)
+		}
+		if _, err := parseUintTo[uint]("-1"); err == nil {
+			t.Error("expected error for negative uint, got nil")
+		}
+	})
+
+	t.Run("uint8_overflow", func(t *testing.T) {
+		if _, err := parseUintTo[uint8]("256"); err == nil {
+			t.Error("expected overflow error for uint8(256), got nil")
+		}
+		v, err := parseUintTo[uint8]("255")
+		if err != nil || v != 255 {
+			t.Errorf("parseUintTo[uint8](255) = %d, %v; want 255, nil", v, err)
+		}
+	})
+
+	t.Run("uint16_overflow", func(t *testing.T) {
+		if _, err := parseUintTo[uint16]("65536"); err == nil {
+			t.Error("expected overflow error for uint16(65536), got nil")
+		}
+	})
+
+	t.Run("uint32_overflow", func(t *testing.T) {
+		if _, err := parseUintTo[uint32]("4294967296"); err == nil {
+			t.Error("expected overflow error for uint32(4294967296), got nil")
+		}
+	})
+
+	t.Run("uint64_max", func(t *testing.T) {
+		v, err := parseUintTo[uint64]("18446744073709551615")
+		if err != nil || v != 18446744073709551615 {
+			t.Errorf("parseUintTo[uint64](max) = %d, %v", v, err)
+		}
+	})
+
+	t.Run("hex", func(t *testing.T) {
+		v, err := parseUintTo[uint32]("0xff")
+		if err != nil || v != 255 {
+			t.Errorf("parseUintTo[uint32](0xff) = %d, %v; want 255, nil", v, err)
+		}
+	})
+
+	// Named types with a small underlying type (e.g. uint8) must be range-checked
+	// at uint8 width. Without the reflect-based fix this would silently wrap.
+	t.Run("named_uint8_type_overflow", func(t *testing.T) {
+		type myUint8 uint8
+		if _, err := parseUintTo[myUint8]("256"); err == nil {
+			t.Error("expected overflow error for myUint8(256), got nil")
+		}
+		v, err := parseUintTo[myUint8]("255")
+		if err != nil || v != 255 {
+			t.Errorf("parseUintTo[myUint8](255) = %d, %v; want 255, nil", v, err)
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// parseIntSlice
+// --------------------------------------------------------------------------
+
+func TestParseIntSlice(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		got, err := parseIntSlice[int]("10 20 30", " ")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []int{10, 20, 30}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("got[%d]=%d, want %d", i, got[i], want[i])
+			}
+		}
+	})
+
+	// Trailing separator must be skipped (continue), not stop parsing (break).
+	t.Run("trailing_separator_skipped", func(t *testing.T) {
+		got, err := parseIntSlice[int]("1 2 3 ", " ")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 3 {
+			t.Errorf("expected 3 elements, got %d: %v", len(got), got)
+		}
+	})
+
+	// Empty string produces nil slice, not an error.
+	t.Run("empty_string", func(t *testing.T) {
+		got, err := parseIntSlice[int]("", " ")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("expected empty slice, got %v", got)
+		}
+	})
+
+	// Overflow in one element should propagate an error.
+	t.Run("overflow_returns_error", func(t *testing.T) {
+		if _, err := parseIntSlice[int8]("1 200 3", " "); err == nil {
+			t.Error("expected error for int8 overflow in list, got nil")
+		}
+	})
+
+	t.Run("negative_values", func(t *testing.T) {
+		got, err := parseIntSlice[int32]("-3 0 7", " ")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got[0] != -3 || got[1] != 0 || got[2] != 7 {
+			t.Errorf("unexpected values: %v", got)
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// parseIDSet
+// --------------------------------------------------------------------------
+
+func TestParseIDSet(t *testing.T) {
+	parse := func(s, sep string) (idset.IDSet, error) {
+		var ids idset.IDSet
+		return ids, parseIDSet(s, sep, &ids)
+	}
+
+	t.Run("single_ids", func(t *testing.T) {
+		ids, err := parse("0 2 4", " ")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, id := range []int{0, 2, 4} {
+			if !ids.Has(idset.ID(id)) {
+				t.Errorf("expected id %d in set", id)
+			}
+		}
+		if ids.Size() != 3 {
+			t.Errorf("expected size 3, got %d", ids.Size())
+		}
+	})
+
+	t.Run("range", func(t *testing.T) {
+		ids, err := parse("0-3", " ")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ids.Size() != 4 {
+			t.Errorf("expected 4 elements, got %d: %v", ids.Size(), ids)
+		}
+		for i := 0; i <= 3; i++ {
+			if !ids.Has(idset.ID(i)) {
+				t.Errorf("missing id %d", i)
+			}
+		}
+	})
+
+	t.Run("mixed_ids_and_ranges", func(t *testing.T) {
+		ids, err := parse("0-1 4 8-9", " ")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, id := range []int{0, 1, 4, 8, 9} {
+			if !ids.Has(idset.ID(id)) {
+				t.Errorf("expected id %d in set %v", id, ids)
+			}
+		}
+		if ids.Size() != 5 {
+			t.Errorf("expected size 5, got %d", ids.Size())
+		}
+	})
+
+	t.Run("comma_separator", func(t *testing.T) {
+		ids, err := parse("0,1,2", ",")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ids.Size() != 3 {
+			t.Errorf("expected 3, got %d", ids.Size())
+		}
+	})
+
+	// Typical sysfs cpulist format: comma-separated ranges, e.g. "0-7,15-23".
+	t.Run("comma_separated_ranges", func(t *testing.T) {
+		ids, err := parse("0-7,15-23", ",")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ids.Size() != 17 {
+			t.Errorf("expected 17, got %d: %v", ids.Size(), ids)
+		}
+		for _, id := range []int{0, 3, 7, 15, 19, 23} {
+			if !ids.Has(idset.ID(id)) {
+				t.Errorf("expected id %d in set %v", id, ids)
+			}
+		}
+	})
+
+	// Trailing separator should be skipped (continue not break) — same as for parseIntSlice.
+	t.Run("trailing_separator_skipped", func(t *testing.T) {
+		ids, err := parse("0 1 2 ", " ")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ids.Size() != 3 {
+			t.Errorf("expected 3 ids, got %d: %v", ids.Size(), ids)
+		}
+	})
+
+	t.Run("empty_string", func(t *testing.T) {
+		ids, err := parse("", ",")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ids.Size() != 0 {
+			t.Errorf("expected empty set, got %v", ids)
+		}
+	})
+
+	t.Run("invalid_id", func(t *testing.T) {
+		if _, err := parse("0 abc 2", " "); err == nil {
+			t.Error("expected error for non-numeric id, got nil")
+		}
+	})
+
+	t.Run("invalid_range_end", func(t *testing.T) {
+		if _, err := parse("0-abc", " "); err == nil {
+			t.Error("expected error for invalid range end, got nil")
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// readSysfsRaw
+// --------------------------------------------------------------------------
+
+func TestReadSysfsRaw(t *testing.T) {
+	t.Run("reads_and_trims_newline", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSysfsFile(t, dir, "val", "hello\n")
+		got, err := readSysfsRaw(dir, "val")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "hello" {
+			t.Errorf("got %q, want %q", got, "hello")
+		}
+	})
+
+	t.Run("trims_multiple_trailing_newlines", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSysfsFile(t, dir, "val", "42\n\n")
+		got, err := readSysfsRaw(dir, "val")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "42" {
+			t.Errorf("got %q, want %q", got, "42")
+		}
+	})
+
+	t.Run("missing_file_returns_error", func(t *testing.T) {
+		dir := t.TempDir()
+		if _, err := readSysfsRaw(dir, "nonexistent"); err == nil {
+			t.Error("expected error for missing file, got nil")
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// readSysfsInt
+// --------------------------------------------------------------------------
+
+func TestReadSysfsInt(t *testing.T) {
+	t.Run("reads_int", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSysfsFile(t, dir, "id", "7\n")
+		var v int
+		if err := readSysfsInt(dir, "id", &v); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v != 7 {
+			t.Errorf("got %d, want 7", v)
+		}
+	})
+
+	t.Run("reads_named_int_type", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSysfsFile(t, dir, "id", "42\n")
+		var v idset.ID
+		if err := readSysfsInt(dir, "id", &v); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v != 42 {
+			t.Errorf("got %d, want 42", v)
+		}
+	})
+
+	t.Run("overflow_returns_error", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSysfsFile(t, dir, "id", "200\n")
+		var v int8
+		if err := readSysfsInt(dir, "id", &v); err == nil {
+			t.Error("expected overflow error for int8(200), got nil")
+		}
+	})
+
+	t.Run("missing_file_returns_error", func(t *testing.T) {
+		dir := t.TempDir()
+		var v int
+		if err := readSysfsInt(dir, "nonexistent", &v); err == nil {
+			t.Error("expected error for missing file, got nil")
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// readSysfsUint
+// --------------------------------------------------------------------------
+
+func TestReadSysfsUint(t *testing.T) {
+	t.Run("reads_uint64", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSysfsFile(t, dir, "freq", "3200000\n")
+		var v uint64
+		if err := readSysfsUint(dir, "freq", &v); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v != 3200000 {
+			t.Errorf("got %d, want 3200000", v)
+		}
+	})
+
+	t.Run("overflow_returns_error", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSysfsFile(t, dir, "val", "256\n")
+		var v uint8
+		if err := readSysfsUint(dir, "val", &v); err == nil {
+			t.Error("expected overflow error for uint8(256), got nil")
+		}
+	})
+
+	t.Run("negative_value_returns_error", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSysfsFile(t, dir, "val", "-1\n")
+		var v uint64
+		if err := readSysfsUint(dir, "val", &v); err == nil {
+			t.Error("expected error for negative uint, got nil")
+		}
+	})
+
+	t.Run("missing_file_returns_error", func(t *testing.T) {
+		dir := t.TempDir()
+		var v uint64
+		if err := readSysfsUint(dir, "nonexistent", &v); err == nil {
+			t.Error("expected error for missing file, got nil")
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// readSysfsString
+// --------------------------------------------------------------------------
+
+func TestReadSysfsString(t *testing.T) {
+	t.Run("reads_string", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSysfsFile(t, dir, "type", "Unified\n")
+		var v string
+		if err := readSysfsString(dir, "type", &v); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v != "Unified" {
+			t.Errorf("got %q, want %q", v, "Unified")
+		}
+	})
+
+	t.Run("missing_file_returns_error", func(t *testing.T) {
+		dir := t.TempDir()
+		var v string
+		if err := readSysfsString(dir, "nonexistent", &v); err == nil {
+			t.Error("expected error for missing file, got nil")
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// readSysfsIDSet
+// --------------------------------------------------------------------------
+
+func TestReadSysfsIDSet(t *testing.T) {
+	t.Run("reads_idset_with_range", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSysfsFile(t, dir, "cpulist", "0-3,8\n")
+		var ids idset.IDSet
+		if err := readSysfsIDSet(dir, "cpulist", ",", &ids); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ids.Size() != 5 {
+			t.Errorf("expected 5 ids, got %d: %v", ids.Size(), ids)
+		}
+		for _, id := range []int{0, 1, 2, 3, 8} {
+			if !ids.Has(idset.ID(id)) {
+				t.Errorf("expected id %d in set", id)
+			}
+		}
+	})
+
+	t.Run("missing_file_returns_error", func(t *testing.T) {
+		dir := t.TempDir()
+		var ids idset.IDSet
+		if err := readSysfsIDSet(dir, "nonexistent", ",", &ids); err == nil {
+			t.Error("expected error for missing file, got nil")
+		}
+	})
+
+	t.Run("malformed_content_returns_error", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSysfsFile(t, dir, "cpulist", "0,abc,2\n")
+		var ids idset.IDSet
+		if err := readSysfsIDSet(dir, "cpulist", ",", &ids); err == nil {
+			t.Error("expected error for malformed content, got nil")
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// readSysfsIntList
+// --------------------------------------------------------------------------
+
+func TestReadSysfsIntList(t *testing.T) {
+	t.Run("reads_distance_list", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSysfsFile(t, dir, "distance", "10 20 30\n")
+		var v []int
+		if err := readSysfsIntList(dir, "distance", " ", &v); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []int{10, 20, 30}
+		if len(v) != len(want) {
+			t.Fatalf("got %v, want %v", v, want)
+		}
+		for i, w := range want {
+			if v[i] != w {
+				t.Errorf("v[%d]=%d, want %d", i, v[i], w)
+			}
+		}
+	})
+
+	t.Run("overflow_returns_error", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSysfsFile(t, dir, "val", "1 200 3\n")
+		var v []int8
+		if err := readSysfsIntList(dir, "val", " ", &v); err == nil {
+			t.Error("expected overflow error for int8 element, got nil")
+		}
+	})
+
+	t.Run("missing_file_returns_error", func(t *testing.T) {
+		dir := t.TempDir()
+		var v []int
+		if err := readSysfsIntList(dir, "nonexistent", " ", &v); err == nil {
+			t.Error("expected error for missing file, got nil")
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// readSysfsEPP
+// --------------------------------------------------------------------------
+
+func TestReadSysfsEPP(t *testing.T) {
+	for _, tc := range []struct {
+		content string
+		want    EPP
+	}{
+		{"performance\n", EPPPerformance},
+		{"balance_performance\n", EPPBalancePerformance},
+		{"balance_power\n", EPPBalancePower},
+		{"power\n", EPPPower},
+		{"unknown_value\n", EPPUnknown},
+	} {
+		tc := tc
+		t.Run(tc.content[:len(tc.content)-1], func(t *testing.T) {
+			dir := t.TempDir()
+			writeSysfsFile(t, dir, "epp", tc.content)
+			var v EPP
+			if err := readSysfsEPP(dir, "epp", &v); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if v != tc.want {
+				t.Errorf("got %v, want %v", v, tc.want)
+			}
+		})
+	}
+
+	t.Run("missing_file_returns_error", func(t *testing.T) {
+		dir := t.TempDir()
+		var v EPP
+		if err := readSysfsEPP(dir, "nonexistent", &v); err == nil {
+			t.Error("expected error for missing file, got nil")
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// writeSysfsRaw
+// --------------------------------------------------------------------------
+
+func TestWriteSysfsRaw(t *testing.T) {
+	t.Run("writes_and_reads_back", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "val")
+		if err := os.WriteFile(path, []byte("old\n"), 0o600); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+		if err := writeSysfsRaw(path, "new"); err != nil {
+			t.Fatalf("writeSysfsRaw: %v", err)
+		}
+		got, err := readSysfsRaw(dir, "val")
+		if err != nil {
+			t.Fatalf("readSysfsRaw: %v", err)
+		}
+		if got != "new" {
+			t.Errorf("got %q, want %q", got, "new")
+		}
+	})
+
+	t.Run("missing_file_returns_error", func(t *testing.T) {
+		if err := writeSysfsRaw("/nonexistent/path/val", "x"); err == nil {
+			t.Error("expected error for missing file, got nil")
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// writeSysfsInt
+// --------------------------------------------------------------------------
+
+func TestWriteSysfsInt(t *testing.T) {
+	setup := func(t *testing.T, initial string) (base, entry string) {
+		t.Helper()
+		base = t.TempDir()
+		entry = "val"
+		if err := os.WriteFile(filepath.Join(base, entry), []byte(initial+"\n"), 0o600); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+		return base, entry
+	}
+
+	t.Run("writes_value", func(t *testing.T) {
+		base, entry := setup(t, "0")
+		if err := writeSysfsInt(base, entry, int(99)); err != nil {
+			t.Fatalf("writeSysfsInt: %v", err)
+		}
+		var got int
+		if err := readSysfsInt(base, entry, &got); err != nil {
+			t.Fatalf("readSysfsInt: %v", err)
+		}
+		if got != 99 {
+			t.Errorf("got %d, want 99", got)
+		}
+	})
+
+	t.Run("captures_old_value", func(t *testing.T) {
+		base, entry := setup(t, "5")
+		var old int
+		if err := writeSysfsInt(base, entry, int(9), &old); err != nil {
+			t.Fatalf("writeSysfsInt: %v", err)
+		}
+		if old != 5 {
+			t.Errorf("old = %d, want 5", old)
+		}
+		var got int
+		if err := readSysfsInt(base, entry, &got); err != nil {
+			t.Fatalf("readSysfsInt: %v", err)
+		}
+		if got != 9 {
+			t.Errorf("new = %d, want 9", got)
+		}
+	})
+
+	t.Run("negative_value", func(t *testing.T) {
+		base, entry := setup(t, "0")
+		if err := writeSysfsInt(base, entry, int32(-7)); err != nil {
+			t.Fatalf("writeSysfsInt: %v", err)
+		}
+		var got int32
+		if err := readSysfsInt(base, entry, &got); err != nil {
+			t.Fatalf("readSysfsInt: %v", err)
+		}
+		if got != -7 {
+			t.Errorf("got %d, want -7", got)
+		}
+	})
+
+	t.Run("missing_file_returns_error", func(t *testing.T) {
+		if err := writeSysfsInt(t.TempDir(), "nonexistent", int(1)); err == nil {
+			t.Error("expected error for missing file, got nil")
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// writeSysfsUint
+// --------------------------------------------------------------------------
+
+func TestWriteSysfsUint(t *testing.T) {
+	setup := func(t *testing.T, initial string) (base, entry string) {
+		t.Helper()
+		base = t.TempDir()
+		entry = "freq"
+		if err := os.WriteFile(filepath.Join(base, entry), []byte(initial+"\n"), 0o600); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+		return base, entry
+	}
+
+	t.Run("writes_value", func(t *testing.T) {
+		base, entry := setup(t, "0")
+		if err := writeSysfsUint(base, entry, uint64(3200000)); err != nil {
+			t.Fatalf("writeSysfsUint: %v", err)
+		}
+		var got uint64
+		if err := readSysfsUint(base, entry, &got); err != nil {
+			t.Fatalf("readSysfsUint: %v", err)
+		}
+		if got != 3200000 {
+			t.Errorf("got %d, want 3200000", got)
+		}
+	})
+
+	t.Run("captures_old_value", func(t *testing.T) {
+		base, entry := setup(t, "1000000")
+		var old uint64
+		if err := writeSysfsUint(base, entry, uint64(2000000), &old); err != nil {
+			t.Fatalf("writeSysfsUint: %v", err)
+		}
+		if old != 1000000 {
+			t.Errorf("old = %d, want 1000000", old)
+		}
+		var got uint64
+		if err := readSysfsUint(base, entry, &got); err != nil {
+			t.Fatalf("readSysfsUint: %v", err)
+		}
+		if got != 2000000 {
+			t.Errorf("new = %d, want 2000000", got)
+		}
+	})
+
+	t.Run("missing_file_returns_error", func(t *testing.T) {
+		if err := writeSysfsUint(t.TempDir(), "nonexistent", uint64(1)); err == nil {
+			t.Error("expected error for missing file, got nil")
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// strconv.IntSize consistency check
+// --------------------------------------------------------------------------
+
+// TestPlatformIntSize verifies that parseIntTo[int] accepts the platform's max int value.
+func TestPlatformIntSize(t *testing.T) {
+	// Use uint64 shift to avoid overflow in constant expressions, then cast.
+	maxUint64 := uint64(1)<<(strconv.IntSize-1) - 1
+	max := int64(maxUint64)
+	v, err := parseIntTo[int](strconv.FormatInt(max, 10))
+	if err != nil {
+		t.Errorf("parseIntTo[int](%d) unexpected error: %v", max, err)
+	}
+	if int64(v) != max {
+		t.Errorf("parseIntTo[int](%d) = %d", max, v)
+	}
+}


### PR DESCRIPTION
CodeQL flagged integer conversion bugs here (PR #676 was the autofix attempt). The real problem: readSysfsEntry/writeSysfsEntry accepted interface{} and every integer parser called strconv.ParseInt with bitSize=0, meaning 64-bit, then cast the result down -- so parsing "300" into int8 silently gave you 44. Patching the casts doesn't help; the issue is the parse site itself.

Replaced the whole interface{}-based layer with typed generic functions: readSysfsRaw, readSysfsString, readSysfsInt[T], readSysfsUint[T], readSysfsIDSet, readSysfsIntList[T], readSysfsEPP on the read side, and writeSysfsRaw, writeSysfsInt[T], writeSysfsUint[T] for writes.

parseIntTo[T] and parseUintTo[T] use a type switch to get T's actual bit width and pass it straight to strconv.ParseInt/ParseUint. Out-of-range values now error. The unsafe import is gone.

A few other things were broken in the old code:
- parseValueList `break`-ed on empty tokens, stopping the whole parse instead of just skipping the empty slot
- parseIDSet split on "-" without a limit, so "0-7" got three pieces when the separator also happened to be "-"; fixed with SplitN(..., 2)
- formatValueList returned "" instead of the string it built -- removed along with formatValue and other dead helpers

All 27 call sites in system.go updated. Added utils_test.go covering all new utility functions.

Replaces: #676