### PR TITLE
e2e: install cri-tools/crictl on Fedora 43 and later.

### DIFF
--- a/test/e2e/playbook/provision.yaml
+++ b/test/e2e/playbook/provision.yaml
@@ -196,6 +196,13 @@
             state:
               present
           when: ansible_facts['distribution_major_version'] | int >= 40
+        - name: cri-tools for crictl
+          ansible.builtin.dnf:
+            pkg:
+              - cri-tools
+            state:
+              present
+          when: ansible_facts['distribution_major_version'] | int >= 43
 
     - name: Resize root filesystem to the maximum possible
       when: ansible_facts['distribution'] == "Fedora"


### PR DESCRIPTION
The ansible playbooks on Fedora assume crictl to be available without installing cri-tools. Fix this.