### PR TITLE
build: dispel ghosts from topology-aware images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
 # Ignore any e2e VM directories
 **/n*-containerd/
 **/n*-crio/
+
+# Ignore host build artifacts so they cannot satisfy in-image build targets
+# (e.g. a dynamically linked host binary slipping into a distroless image).
+build/

--- a/cmd/plugins/topology-aware/Dockerfile
+++ b/cmd/plugins/topology-aware/Dockerfile
@@ -38,7 +38,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
          BINARIES="" \
          OTHER_IMAGE_TARGETS="" \
          PLUGINS=nri-resource-policy-topology-aware \
-         install-go-licenses build-plugins-static licenses
+         clean install-go-licenses build-plugins-static licenses
 
 RUN cpgodir() { \
         mkdir -p $2; \


### PR DESCRIPTION
These two commits make sure that dynamically linked binaries should never slip in container images, and that Dockerfiles of all plugins are aligned on how they call make.