### PR TITLE
e2e: strict topology hint test fixes

### DIFF
--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test18-strict-alignment/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test18-strict-alignment/code.var.sh
@@ -4,6 +4,21 @@ cleanup() {
     vm-command "kubectl delete namespaces highprio lowprio --now --ignore-not-found"
 }
 
+wait_for_waiting_status_reason() {
+    local pod=$1 ctridx=$2 status=$3
+    local maxtry=5 retry=0
+
+    while [ $retry -lt $maxtry ]; do
+        echo "Waiting for $pod/ctr$ctridx to enter status $status..."
+        vm-command "kubectl get pod $pod -o jsonpath='{.status.containerStatuses[$ctridx].state}' | \
+                        jq '.waiting.reason'"
+        grep -q $status <<< "$COMMAND_OUTPUT" && return 0
+        let retry=$retry+1
+        sleep 1
+    done
+    return 1
+}
+
 cleanup
 helm-terminate
 helm_config=$(instantiate helm-config.yaml) helm-launch topology-aware
@@ -49,6 +64,10 @@ vm-command "kubectl wait --timeout=5s pod pod3 --for=$PodReadyCond" || {
     error "failed to wait for pod3 to start containerd"
 }
 
+wait_for_waiting_status_reason pod3 0 CreateContainerError || {
+    error "failed to wait for pod3/ctr0 to reach CreateContainerError state"
+}
+
 vm-command "kubectl get pod pod3 -o jsonpath='{.status.containerStatuses[0].state}' | \
         grep -q \"fail strict hint\"" || {
     error "pod3c0 unexpectedly passed strict topology hint check"
@@ -65,6 +84,10 @@ wait="" CONTCOUNT=1 CPU=1 MEM=100M create guaranteed
 PodReadyCond='condition=PodReadyToStartContainers'
 vm-command "kubectl wait --timeout=5s pod pod4 --for=$PodReadyCond" || {
     error "failed to wait for pod4 to start containerd"
+}
+
+wait_for_waiting_status_reason pod4 0 CreateContainerError || {
+    error "failed to wait for pod4/ctr0 to reach CreateContainerError state"
 }
 
 vm-command "kubectl get pod pod4 -o jsonpath='{.status.containerStatuses[0].state}' | \
@@ -99,6 +122,10 @@ wait="" CONTCOUNT=1 CPU=1 MEM=100M create guaranteed
 PodReadyCond='condition=PodReadyToStartContainers'
 vm-command "kubectl wait --timeout=5s pod pod6 --for=$PodReadyCond" || {
     error "failed to wait for pod6 to start containerd"
+}
+
+wait_for_waiting_status_reason pod6 0 CreateContainerError || {
+    error "failed to wait for pod6/ctr0 to reach CreateContainerError state"
 }
 
 vm-command "kubectl get pod pod6 -o jsonpath='{.status.containerStatuses[0].state}' | \


### PR DESCRIPTION
In strict topology hint tests, wait for the 'waiting.reason' of a container's status to become 'CreateContainerError' before checking for a particular error message from its status. Otherwise we might not get the status we look for.