### PR TITLE
cache: avoid a test cache population data race

### DIFF
--- a/pkg/resmgr/cache/pod.go
+++ b/pkg/resmgr/cache/pod.go
@@ -143,12 +143,12 @@ func (p *pod) GetQOSClass() v1.PodQOSClass {
 
 func (p *pod) goFetchPodResources(ch <-chan *podresapi.PodResources) {
 	go func() {
-		p.podResCh = ch
-		p.waitResCh = make(chan struct{})
-		defer close(p.waitResCh)
+		if ch != nil {
+			p.podResCh = ch
+			p.waitResCh = make(chan struct{})
+			defer close(p.waitResCh)
 
-		if p.podResCh != nil {
-			p.PodResources = <-p.podResCh
+			p.PodResources = <-ch
 			log.Debugf("fetched pod resources %+v for %s", p.PodResources, p.GetName())
 		}
 	}()


### PR DESCRIPTION
Omit creating synchronization channel if we don't fetch pod resources, to avoid a data read/write race during test cache population in tests.