### PR TITLE
e2e: fix otel log test wait error, possible instability

### DIFF
--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test40-otel-logging/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test40-otel-logging/code.var.sh
@@ -18,7 +18,7 @@ helm_config=$(instantiate custom-config.yaml) helm-launch topology-aware
 pod=pod0
 CONTCOUNT=4 create besteffort
 
-vm-command 'kubectl wait --timeout=5s --for=condition=Ready pod $pod'
+vm-command "kubectl wait --timeout=5s --for=condition=Ready pods/$pod"
 
 for ctr in ${pod}c0 ${pod}c1 ${pod}c2 ${pod}c3; do
     echo "verifying logs for default/$pod/$ctr..."


### PR DESCRIPTION
Expanding $pod required using double instead of single quotes.