### PR TITLE
Makefile: make sure test cleanup is not run in parallel with tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -382,7 +382,7 @@ ginkgo-test-setup:
 	        fi); \
 	done
 
-ginkgo-test-cleanup:
+ginkgo-test-cleanup: ginkgo-tests ginkgo-subpkgs-tests
 	$(Q)for i in $$(find $(TEST_PKGS) -name $(TEST_CLEANUP)); do \
 	    echo "- Running test cleanup $$i..."; \
 	    (cd $${i%/*}; \


### PR DESCRIPTION
Make sure any package/test-specific cleanup scripts are only run after the tests themselves have completed.