### PR TITLE
e2e: more robust otel log collection test.

### DIFF
--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test40-otel-logging/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test40-otel-logging/code.var.sh
@@ -20,6 +20,16 @@ CONTCOUNT=4 create besteffort
 
 vm-command "kubectl wait --timeout=5s --for=condition=Ready pods/$pod"
 
+cnt=0
+while [ $cnt -lt 5 ]; do
+   vm-command "crictl ps | grep ${pod}c3 | grep Running"
+   if grep Running <<< $COMMAND_OUTPUT; then
+       break
+   fi
+   sleep 1
+   let cnt=$cnt+1
+done
+
 for ctr in ${pod}c0 ${pod}c1 ${pod}c2 ${pod}c3; do
     echo "verifying logs for default/$pod/$ctr..."
     vm-command-q "cat $OTEL_LOGS" | \

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test40-otel-logging/custom-config.yaml.in
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test40-otel-logging/custom-config.yaml.in
@@ -6,7 +6,7 @@ config:
   instrumentation:
     httpEndpoint: :8891
     logExporter: otlp-grpc
-    logExportPeriod: 10ms
+    logExportPeriod: 1s
   log:
     debug:
       - nri-resource-policy


### PR DESCRIPTION
Don't expect otel logs to be collected by the time the test pod is ready. Check and wait for the last container to be running before trying to verify collected logs.