### PR TITLE
Dockerfiles: work around parallel make license extraction breakage.

### DIFF
--- a/cmd/config-manager/Dockerfile
+++ b/cmd/config-manager/Dockerfile
@@ -21,6 +21,10 @@ COPY . .
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target="/root/.cache/go-build" \
+    make install-go-licenses
+
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=cache,target="/root/.cache/go-build" \
     make IMAGE_VERSION=${IMAGE_VERSION} \
          BUILD_VERSION=${BUILD_VERSION} \
          BUILD_BUILDID=${BUILD_BUILDID} \
@@ -30,7 +34,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
          OTHER_IMAGE_TARGETS="" \
          BINARIES=config-manager \
          PLUGINS="" \
-         clean install-go-licenses build-binaries-static licenses
+         clean build-binaries-static licenses
 
 FROM gcr.io/distroless/static
 

--- a/cmd/mpolset/Dockerfile
+++ b/cmd/mpolset/Dockerfile
@@ -19,6 +19,9 @@ RUN --mount=type=cache,target=/go/pkg/mod/ go mod download
 # Build mpolset
 COPY . .
 
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=cache,target="/root/.cache/go-build" \
+    make install-go-licenses
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target="/root/.cache/go-build" \
@@ -31,7 +34,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
          OTHER_IMAGE_TARGETS="" \
          BINARIES=mpolset \
          PLUGINS="" \
-         clean install-go-licenses build-binaries-static licenses
+         clean build-binaries-static licenses
 
 FROM gcr.io/distroless/static
 

--- a/cmd/plugins/balloons/Dockerfile
+++ b/cmd/plugins/balloons/Dockerfile
@@ -29,6 +29,10 @@ COPY . .
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target="/root/.cache/go-build" \
+    make install-go-licenses
+
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=cache,target="/root/.cache/go-build" \
     make IMAGE_VERSION=${IMAGE_VERSION} \
          BUILD_VERSION=${BUILD_VERSION} \
          BUILD_BUILDID=${BUILD_BUILDID} \
@@ -39,7 +43,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
          BINARIES="" \
          OTHER_IMAGE_TARGETS="" \
          PLUGINS=nri-resource-policy-balloons \
-         clean install-go-licenses build-plugins-static licenses
+         clean build-plugins-static licenses
 
 RUN cpgodir() { \
         mkdir -p $2; \

--- a/cmd/plugins/memory-policy/Dockerfile
+++ b/cmd/plugins/memory-policy/Dockerfile
@@ -21,6 +21,10 @@ COPY . .
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target="/root/.cache/go-build" \
+    make install-go-licenses
+
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=cache,target="/root/.cache/go-build" \
     make IMAGE_VERSION=${IMAGE_VERSION} \
          BUILD_VERSION=${BUILD_VERSION} \
          BUILD_BUILDID=${BUILD_BUILDID} \
@@ -30,7 +34,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
          OTHER_IMAGE_TARGETS="" \
          BINARIES=mpolset \
          PLUGINS=nri-memory-policy \
-         clean install-go-licenses build-plugins-static build-binaries-static licenses
+         clean build-plugins-static build-binaries-static licenses
 
 FROM gcr.io/distroless/static
 

--- a/cmd/plugins/memory-qos/Dockerfile
+++ b/cmd/plugins/memory-qos/Dockerfile
@@ -21,6 +21,10 @@ COPY . .
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target="/root/.cache/go-build" \
+    make install-go-licenses
+
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=cache,target="/root/.cache/go-build" \
     make IMAGE_VERSION=${IMAGE_VERSION} \
          BUILD_VERSION=${BUILD_VERSION} \
          BUILD_BUILDID=${BUILD_BUILDID} \
@@ -29,7 +33,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
          OTHER_IMAGE_TARGETS="" \
          BINARIES="" \
          PLUGINS=nri-memory-qos \
-         clean install-go-licenses build-plugins-static licenses
+         clean build-plugins-static licenses
 
 FROM gcr.io/distroless/static
 

--- a/cmd/plugins/memtierd/Dockerfile
+++ b/cmd/plugins/memtierd/Dockerfile
@@ -28,6 +28,10 @@ COPY . .
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target="/root/.cache/go-build" \
+    make install-go-licenses
+
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=cache,target="/root/.cache/go-build" \
     make IMAGE_VERSION=${IMAGE_VERSION} \
          BUILD_VERSION=${BUILD_VERSION} \
          BUILD_BUILDID=${BUILD_BUILDID} \
@@ -36,7 +40,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
          OTHER_IMAGE_TARGETS="" \
          BINARIES="" \
          PLUGINS=nri-memtierd \
-         clean install-go-licenses build-plugins-static licenses
+         clean build-plugins-static licenses
 
 FROM gcr.io/distroless/static
 ENV PATH=/bin

--- a/cmd/plugins/resctrl-mon/Dockerfile
+++ b/cmd/plugins/resctrl-mon/Dockerfile
@@ -21,6 +21,10 @@ COPY . .
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target="/root/.cache/go-build" \
+    make install-go-licenses
+
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=cache,target="/root/.cache/go-build" \
     make IMAGE_VERSION=${IMAGE_VERSION} \
          BUILD_VERSION=${BUILD_VERSION} \
          BUILD_BUILDID=${BUILD_BUILDID} \
@@ -29,7 +33,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
          OTHER_IMAGE_TARGETS="" \
          BINARIES="" \
          PLUGINS=nri-resctrl-mon \
-         clean install-go-licenses build-plugins-static licenses
+         clean build-plugins-static licenses
 
 FROM gcr.io/distroless/static
 

--- a/cmd/plugins/sgx-epc/Dockerfile
+++ b/cmd/plugins/sgx-epc/Dockerfile
@@ -19,6 +19,9 @@ RUN --mount=type=cache,target=/go/pkg/mod/ go mod download
 # Build the nri-sgx-epc plugin.
 COPY . .
 
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=cache,target="/root/.cache/go-build" \
+    make install-go-licenses
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target="/root/.cache/go-build" \
@@ -31,7 +34,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
          OTHER_IMAGE_TARGETS="" \
          BINARIES="" \
          PLUGINS=nri-sgx-epc \
-         clean install-go-licenses build-plugins-static licenses
+         clean build-plugins-static licenses
 
 FROM gcr.io/distroless/static
 

--- a/cmd/plugins/template/Dockerfile
+++ b/cmd/plugins/template/Dockerfile
@@ -29,6 +29,10 @@ COPY . .
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target="/root/.cache/go-build" \
+    make install-go-licenses
+
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=cache,target="/root/.cache/go-build" \
     make IMAGE_VERSION=${IMAGE_VERSION} \
          BUILD_VERSION=${BUILD_VERSION} \
          BUILD_BUILDID=${BUILD_BUILDID} \
@@ -38,7 +42,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
          BINARIES="" \
          OTHER_IMAGE_TARGETS="" \
          PLUGINS=nri-resource-policy-template \
-         clean install-go-licenses build-plugins-static licenses
+         clean build-plugins-static licenses
 
 RUN cpgodir() { \
         mkdir -p $2; \

--- a/cmd/plugins/topology-aware/Dockerfile
+++ b/cmd/plugins/topology-aware/Dockerfile
@@ -29,6 +29,10 @@ COPY . .
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target="/root/.cache/go-build" \
+    make install-go-licenses
+
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=cache,target="/root/.cache/go-build" \
     make IMAGE_VERSION=${IMAGE_VERSION} \
          BUILD_VERSION=${BUILD_VERSION} \
          BUILD_BUILDID=${BUILD_BUILDID} \
@@ -38,7 +42,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
          BINARIES="" \
          OTHER_IMAGE_TARGETS="" \
          PLUGINS=nri-resource-policy-topology-aware \
-         clean install-go-licenses build-plugins-static licenses
+         clean build-plugins-static licenses
 
 RUN cpgodir() { \
         mkdir -p $2; \

--- a/cmd/resource-annotator/Dockerfile
+++ b/cmd/resource-annotator/Dockerfile
@@ -21,6 +21,10 @@ COPY . .
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target="/root/.cache/go-build" \
+    make install-go-licenses
+
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=cache,target="/root/.cache/go-build" \
     make IMAGE_VERSION=${IMAGE_VERSION} \
          BUILD_VERSION=${BUILD_VERSION} \
          BUILD_BUILDID=${BUILD_BUILDID} \
@@ -30,7 +34,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
          OTHER_IMAGE_TARGETS="" \
          BINARIES=resource-annotator \
          PLUGINS="" \
-         clean install-go-licenses build-binaries-static licenses
+         clean build-binaries-static licenses
 
 FROM gcr.io/distroless/static
 


### PR DESCRIPTION
Work around parallel make (commit b3b8d54ae6) breaking license extraction during dockerized image building, but do it without adding a target dependency on `install-go-licenses` to `licenses`.