### PR TITLE
e2e: use nop BTRFS/blob corruption handlers for cri-o.

### DIFF
--- a/test/e2e/lib/vm.bash
+++ b/test/e2e/lib/vm.bash
@@ -1119,13 +1119,13 @@ containerd-reimport-image() {
 }
 
 crio-check-unreadable-blobs() {
-    error "TODO: implement unreadable blob check for CRI-O..."
+    echo "TODO: implement unreadable blob check for CRI-O... assuming no errors for now"
 }
 
 crio-fix-unreadable-blobs() {
-    error "TODO: implement unreadable blob fix for CRI-O (if possible)..."
+    echo "TODO: implement unreadable blob fix for CRI-O (if possible)... assuming no-op for now"
 }
 
 crio-reimport-image() {
-    error "TODO: implement image reimport for CRI-O..."
+    echo "TODO: implement image reimport for CRI-O... assuming no-op for now"
 }


### PR DESCRIPTION
It looks like the post-reboot BTRFS/blob corruption bug is not triggered with cri-o as a runtime, only with containerd as surprising as this may sound considering that it is an fs-level corruption (unreadable blob file).

Anyway, switch the cri-o-specfic handlers to mere logging nops for now. We'll revert this and look into it again if we ever see it triggered.