### PR TITLE
balloons/agent: fix/rewrite/simplify extended resource handling

### DIFF
--- a/cmd/plugins/balloons/policy/balloons-policy.go
+++ b/cmd/plugins/balloons/policy/balloons-policy.go
@@ -579,13 +579,15 @@ func (p *balloons) GetTopologyZones() []*policy.TopologyZone {
 }
 
 // GetExtendedResources returns the node-level extended resources
-// the balloons policy publishes for the local Node.
-func (p *balloons) GetExtendedResources() map[string]resource.Quantity {
-	out := map[string]resource.Quantity{}
-	if p.cpuClasses == nil || !p.cpuClasses.PctActive() {
-		return out
+// the balloons policy manages on the local Node.
+func (p *balloons) GetExtendedResources() map[string]*resource.Quantity {
+	// Own the entire domain unconditionally: any key under it
+	// that we do not explicitly publish below must be removed.
+	out := map[string]*resource.Quantity{
+		"cpuclass.balloons.nri.io/*": nil,
 	}
-	if p.bpoptions == nil {
+	// Experimental cpuClass.PublishExtendedResource publishes only PCT capacity.
+	if p.cpuClasses == nil || !p.cpuClasses.PctActive() || p.bpoptions == nil {
 		return out
 	}
 	for _, cc := range p.bpoptions.CPUClasses {
@@ -607,7 +609,7 @@ func (p *balloons) GetExtendedResources() map[string]resource.Quantity {
 		if free < 0 {
 			free = 0
 		}
-		out["cpuclass.balloons.nri.io/"+cc.Name] = *resource.NewQuantity(int64(free), resource.DecimalSI)
+		out["cpuclass.balloons.nri.io/"+cc.Name] = resource.NewQuantity(int64(free), resource.DecimalSI)
 	}
 	return out
 }

--- a/cmd/plugins/template/policy/template-policy.go
+++ b/cmd/plugins/template/policy/template-policy.go
@@ -122,7 +122,7 @@ func (p *policy) GetTopologyZones() []*policyapi.TopologyZone {
 
 // GetExtendedResources returns the node-level extended resources
 // to publish for this policy. The template policy publishes none.
-func (p *policy) GetExtendedResources() map[string]resource.Quantity {
+func (p *policy) GetExtendedResources() map[string]*resource.Quantity {
 	return nil
 }
 

--- a/cmd/plugins/topology-aware/policy/topology-aware-policy.go
+++ b/cmd/plugins/topology-aware/policy/topology-aware-policy.go
@@ -397,7 +397,7 @@ func (p *policy) GetTopologyZones() []*policyapi.TopologyZone {
 
 // GetExtendedResources returns the node-level extended resources
 // to publish for this policy. The topology-aware policy publishes none.
-func (p *policy) GetExtendedResources() map[string]resource.Quantity {
+func (p *policy) GetExtendedResources() map[string]*resource.Quantity {
 	return nil
 }
 

--- a/docs/resource-policy/policy/balloons.md
+++ b/docs/resource-policy/policy/balloons.md
@@ -910,9 +910,11 @@ CPU class definitions. Each class is an object with:
   available CPU capacity as
   `cpuclass.balloons.nri.io/<CPU-CLASS-NAME>` extended
   resource. Enables Kubernetes to schedule pods on nodes with enough
-  CPUs of wanted priority. Note: container's `cpu` and
-  extended resource requests **must be equal** to avoid
-  over and under subscription.
+  CPUs of wanted priority. Notes: container's `cpu` and extended
+  resource requests **must be equal** to avoid over and under
+  subscription. Extended resources are not cleaned up from node status
+  when balloons is stopped or uninstalled. Balloons reconciliation
+  removes extended resources when configured not to publish them.
 
 **`turboDomain`** (string, policy-level configuration):
 

--- a/docs/resource-policy/policy/howto/balloons-pct-example-auto.md
+++ b/docs/resource-policy/policy/howto/balloons-pct-example-auto.md
@@ -796,10 +796,24 @@ kubectl delete -f pod-hp-1.yaml -f pod-hp-2.yaml -f pod-hp-3.yaml \
 kubectl delete -f balloons-pct-managed.yaml --ignore-not-found
 ```
 
-Deleting the `BalloonsPolicy` CR is the policy's defined "reset"
-trigger: the plugin reacts to losing its effective configuration
-by removing every `cpuclass.balloons.nri.io/*` extended resource
-it had published. Verify before uninstalling the chart:
+Deleting the `BalloonsPolicy` CR, or uninstalling the chart, does
+not remove published `cpuclass.balloons.nri.io/*` extended
+resources by itself: they live in the node's status capacity, not
+in CR-managed objects, and the plugin does not clear them on
+shutdown. A running plugin reconciles them instead: whenever the
+balloons policy is (re)configured so that it no longer publishes a
+resource, the agent removes the stale resource; likewise, starting
+the plugin with a non-publishing configuration reconciles away any
+resource left over from a previous run, regardless of how it got
+there.
+
+It is therefore good practice to apply a "reset" `BalloonsPolicy`
+(one that publishes nothing) and let the plugin reconcile before
+uninstalling: this also clears any published
+`cpuclass.balloons.nri.io/*` extended resources while the plugin is
+still running.
+
+To verify no `cpuclass.balloons.nri.io/*` resources remain:
 
 ```bash
 kubectl get node -o jsonpath='{.items[0].status.capacity}' \

--- a/docs/resource-policy/policy/howto/balloons-pct-example-manual.md
+++ b/docs/resource-policy/policy/howto/balloons-pct-example-manual.md
@@ -804,10 +804,24 @@ kubectl delete -f pod-hp-1.yaml -f pod-hp-2.yaml -f pod-hp-3.yaml \
 kubectl delete -f balloons-pct-assoconly.yaml --ignore-not-found
 ```
 
-Deleting the `BalloonsPolicy` CR is the policy's defined "reset"
-trigger: the plugin reacts to losing its effective configuration
-by removing every `cpuclass.balloons.nri.io/*` extended resource
-it had published. Verify before uninstalling the chart:
+Deleting the `BalloonsPolicy` CR, or uninstalling the chart, does
+not remove published `cpuclass.balloons.nri.io/*` extended
+resources by itself: they live in the node's status capacity, not
+in CR-managed objects, and the plugin does not clear them on
+shutdown. A running plugin reconciles them instead: whenever the
+balloons policy is (re)configured so that it no longer publishes a
+resource, the agent removes the stale resource; likewise, starting
+the plugin with a non-publishing configuration reconciles away any
+resource left over from a previous run, regardless of how it got
+there.
+
+It is therefore good practice to apply a "reset" `BalloonsPolicy`
+(one that publishes nothing) and let the plugin reconcile before
+uninstalling: this also clears any published
+`cpuclass.balloons.nri.io/*` extended resources while the plugin is
+still running.
+
+To verify no `cpuclass.balloons.nri.io/*` resources remain:
 
 ```bash
 kubectl get node -o jsonpath='{.items[0].status.capacity}' \

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -143,6 +144,10 @@ type Agent struct {
 	groupCfg      metav1.Object   // group-specific/default config resource
 	currentCfg    metav1.Object
 
+	extResWant map[string]*resource.Quantity // extended resources desired state
+	extResLock sync.Mutex                    // lock accessing the desired state
+	extResWake chan struct{}                 // reconciliation trigger
+
 	stopLock sync.Mutex
 	stopC    chan struct{}
 	doneC    chan struct{}
@@ -161,6 +166,7 @@ func New(cfgIf ConfigInterface, options ...Option) (*Agent, error) {
 		namespace:  defaultNamespace,
 		groupLabel: defaultGroupLabel,
 		cfgIf:      cfgIf,
+		extResWake: make(chan struct{}, 1),
 		stopC:      make(chan struct{}),
 	}
 
@@ -200,6 +206,8 @@ func (a *Agent) Start(notifyFn NotifyFn) error {
 		}
 		return w.ResultChan()
 	}
+
+	go a.reconcileExtendedResourcesLoop()
 
 	for {
 		select {
@@ -258,10 +266,6 @@ func (a *Agent) Stop() {
 	defer a.stopLock.Unlock()
 
 	if a.stopC != nil {
-		// Remove any extended resources we own on this node so
-		// a graceful shutdown does not leave orphan capacity
-		// entries behind.
-		a.ClearNodeExtendedResources()
 		close(a.stopC)
 		<-a.doneC
 		a.stopC = nil
@@ -601,10 +605,6 @@ func (a *Agent) updateGroupConfig(obj runtime.Object) {
 func (a *Agent) updateConfig(cfg metav1.Object) {
 	if cfg == nil {
 		log.Warnf("node (%s) has no effective configuration", a.nodeName)
-		// With no effective configuration there is nothing left to
-		// publish, so drop any extended resources we currently own
-		// on the node.
-		a.ClearNodeExtendedResources()
 		return
 	}
 

--- a/pkg/agent/node-extended-resources.go
+++ b/pkg/agent/node-extended-resources.go
@@ -19,9 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"path"
 	"slices"
 	"strings"
-	"sync"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -29,270 +29,271 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// extendedResourcesLock serializes concurrent node.status PATCHes
-// emitted by the policy on container events. Last writer wins.
-var extendedResourcesLock sync.Mutex
+// extResResyncInterval bounds how often the reconciler re-checks
+// the Node against the desired state without an explicit request.
+// It retries transient API failures and heals external drift.
+const extResResyncInterval = 30 * time.Second
 
-// lastPublishedExtendedResources tracks the resources we currently
-// own on this node, so that we can issue 'remove' patches for
-// resources that the policy stops reporting.
-var lastPublishedExtendedResources = map[string]resource.Quantity{}
+// extResRetrySyncInterval is time between reconciliation rounds
+// when previous round failed. Avoids flooding the API server.
+const extResRetrySyncInterval = 5 * time.Second
 
-// extendedResourcesSynced is set after the first successful
-// node-status scan. Until then, every publish will first try to
-// seed lastPublishedExtendedResources from the node so that
-// resources left over by a prior plugin process (helm reinstall,
-// pod crash, switch to a different policy, etc.) get pruned by
-// the regular diff logic on the next publish.
-var extendedResourcesSynced bool
+// nriExtendedResourceGlob restricts which extended resources this
+// agent is ever allowed to publish or remove. Regardless of what a
+// policy claims to own or wants to publish, only resources whose
+// name matches this pattern can be changed.
+const nriExtendedResourceGlob = "*.nri.io/*"
 
-// extendedResourceDomain is the per-domain prefix the agent owns.
-// Only resources whose name starts with this prefix are touched
-// by the agent (other extended resources advertised by other
-// controllers are left alone).
-const extendedResourceDomain = "cpuclass.balloons.nri.io/"
+// isNRIExtendedResource reports whether 'name' is an extended
+// resource this agent is allowed to manage.
+func isNRIExtendedResource(name string) bool {
+	return globMatch(nriExtendedResourceGlob, name)
+}
 
-// UpdateNodeExtendedResources publishes the given resource map
-// to Node.status.capacity using a JSON patch. Resources previously
-// owned by the agent but absent from 'resources' are removed.
-// Runs asynchronously to avoid stalling NRI request paths.
-func (a *Agent) UpdateNodeExtendedResources(resources map[string]resource.Quantity) error {
+// UpdateNodeExtendedResources records 'resources' as the desired
+// state of the local Node's status.capacity and wakes the
+// reconciler to take care of status change.
+//
+// 'resources' must describe the *complete* desired state:
+//
+//   - A non-nil value publishes (adds/replaces) the named resource
+//     with the given capacity.
+//   - A nil value whose key contains no '*' removes that exact
+//     resource if it is currently present on the Node.
+//   - A nil value whose key contains '*' is an ownership pattern:
+//     every resource currently on the Node that matches the
+//     pattern but is not being published is removed.
+//
+// If the resources map is empty or nil, nothing is to be published or
+// removed, and therefore querying and modifying Node status/capacity
+// is omitted.
+//
+// Because every request carries the full desired state, a newer
+// request fully supersedes older ones; the reconciler therefore
+// coalesces bursts and only ever drives the Node towards the most
+// recent request.
+func (a *Agent) UpdateNodeExtendedResources(resources map[string]*resource.Quantity) error {
 	if a.hasLocalConfig() {
 		return nil
 	}
 	if a.k8sCli == nil || a.nodeName == "" {
 		return nil
 	}
-	// Snapshot inputs and run in the background; node-status
-	// PATCHes can be slow under apiserver load and we never
-	// want NRI hooks to block on them.
-	snapshot := make(map[string]resource.Quantity, len(resources))
+
+	snapshot := make(map[string]*resource.Quantity, len(resources))
 	for k, v := range resources {
-		snapshot[k] = v
-	}
-	go func() {
-		if err := a.updateNodeExtendedResources(snapshot); err != nil {
-			log.Errorf("failed to publish extended resources: %v", err)
-		}
-	}()
-	return nil
-}
-
-func (a *Agent) updateNodeExtendedResources(resources map[string]resource.Quantity) error {
-	extendedResourcesLock.Lock()
-	defer extendedResourcesLock.Unlock()
-
-	// First call after process start: scan the node for keys we
-	// already own (from a prior plugin process), so the diff
-	// below can prune any that the current policy no longer
-	// publishes. Failure is non-fatal -- we just fall back to
-	// "trust our in-memory state".
-	if !extendedResourcesSynced {
-		if err := a.syncExtendedResourcesFromNode(); err != nil {
-			log.Warnf("extended-resource startup sync failed (orphans from a prior plugin process may persist): %v", err)
-		}
-		extendedResourcesSynced = true
-	}
-
-	// Compute the patch: add/replace keys present in 'resources',
-	// remove keys we owned before but are now gone.
-	type jsonPatchOp struct {
-		Op    string      `json:"op"`
-		Path  string      `json:"path"`
-		Value interface{} `json:"value,omitempty"`
-	}
-
-	ops := []jsonPatchOp{}
-	for name, qty := range resources {
-		if !strings.HasPrefix(name, extendedResourceDomain) {
-			log.Warnf("refusing to publish resource %q: not in domain %q",
-				name, extendedResourceDomain)
+		if v == nil {
+			snapshot[k] = nil
 			continue
 		}
-		ops = append(ops, jsonPatchOp{
-			Op:    "add",
-			Path:  "/status/capacity/" + escapeJSONPointer(name),
-			Value: qty.String(),
-		})
-	}
-	for name := range lastPublishedExtendedResources {
-		if _, kept := resources[name]; kept {
-			continue
-		}
-		ops = append(ops, jsonPatchOp{
-			Op:   "remove",
-			Path: "/status/capacity/" + escapeJSONPointer(name),
-		})
+		q := v.DeepCopy()
+		snapshot[k] = &q
 	}
 
-	if len(ops) == 0 {
-		return nil
-	}
+	a.extResLock.Lock()
+	a.extResWant = snapshot
+	a.extResLock.Unlock()
 
-	body, err := json.Marshal(ops)
-	if err != nil {
-		return fmt.Errorf("marshal patch: %w", err)
-	}
-
-	ctx := context.Background()
-	_, err = a.k8sCli.CoreV1().Nodes().Patch(
-		ctx, a.nodeName, types.JSONPatchType, body,
-		metav1.PatchOptions{}, "status")
-	if err != nil {
-		// JSON patch "add" on a missing path fails when the
-		// node has no prior resource of that name -- 'add'
-		// requires the parent to exist, but for a map value
-		// it should create the key. In practice apiservers
-		// behave correctly here. If we ever hit issues, fall
-		// back to a strategic merge patch.
-		return fmt.Errorf("patch node %s status: %w", a.nodeName, err)
-	}
-
-	// Record current set for next diff.
-	lastPublishedExtendedResources = make(map[string]resource.Quantity, len(resources))
-	for k, v := range resources {
-		lastPublishedExtendedResources[k] = v
-	}
-
-	publishedSummary := summarizeExtendedResources(resources)
-	if publishedSummary != "" {
-		log.Infof("published node extended resources: %s", publishedSummary)
+	// Coalescing wakeup: if a signal is already pending, the
+	// reconciler will pick up the latest desired state anyway.
+	select {
+	case a.extResWake <- struct{}{}:
+	default:
 	}
 	return nil
 }
 
-// escapeJSONPointer escapes '~' and '/' per RFC 6901 so that a
-// resource name containing slashes survives as a single JSON
-// Pointer segment.
-func escapeJSONPointer(s string) string {
-	s = strings.ReplaceAll(s, "~", "~0")
-	s = strings.ReplaceAll(s, "/", "~1")
-	return s
+// reconcileExtendedResourcesLoop is the single long-lived worker
+// that drives the Node's status.capacity towards the most recently
+// requested desired state. Running as a single goroutine, it
+// guarantees in-order, non-overlapping reconciles (no last-writer
+// race) and at most one in-flight GET+PATCH. It reconciles on every
+// wakeup and periodically, so transient API failures and external
+// drift are corrected even without new requests.
+func (a *Agent) reconcileExtendedResourcesLoop() {
+	timer := time.NewTimer(extResResyncInterval)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-a.stopC:
+			return
+		case <-a.extResWake:
+		case <-timer.C:
+		}
+
+		// We are about to reconcile, so cancel any pending timer
+		// fire and recompute the next deadline from now below. This
+		// drains the channel if the timer already fired but we were
+		// woken by something else, keeping the single-fire invariant.
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+
+		nextInterval := extResResyncInterval
+
+		a.extResLock.Lock()
+		resources := a.extResWant
+		a.extResLock.Unlock()
+		if len(resources) > 0 {
+			// Only touch the API server when there is a desired
+			// state to reconcile towards.
+			if err := a.reconcileNodeExtendedResources(); err != nil {
+				log.Errorf("failed to reconcile extended resources: %v", err)
+				nextInterval = extResRetrySyncInterval
+			}
+		}
+
+		timer.Reset(nextInterval)
+	}
 }
 
-// summarizeExtendedResources formats the map deterministically
-// for logs: "name1=N1, name2=N2, ...".
-func summarizeExtendedResources(m map[string]resource.Quantity) string {
-	if len(m) == 0 {
-		return ""
-	}
-	sortedKeys := slices.Sorted(maps.Keys(m))
-	parts := make([]string, 0, len(sortedKeys))
-	for _, k := range sortedKeys {
-		v := m[k]
-		parts = append(parts, fmt.Sprintf("%s=%s", k, &v))
-	}
-	return strings.Join(parts, ", ")
-}
-
-// syncExtendedResourcesFromNode reads Node.status.capacity and
-// seeds lastPublishedExtendedResources with every entry whose
-// key carries extendedResourceDomain. Caller must hold
-// extendedResourcesLock.
-func (a *Agent) syncExtendedResourcesFromNode() error {
+// reconcileNodeExtendedResources computes and applies the JSON
+// patch that brings Node.status.capacity in line with the most
+// recently requested desired state.
+func (a *Agent) reconcileNodeExtendedResources() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	node, err := a.k8sCli.CoreV1().Nodes().Get(ctx, a.nodeName, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("get node %s: %w", a.nodeName, err)
+		return fmt.Errorf("failed to get extended resources: get node %s: %w", a.nodeName, err)
 	}
-	owned := map[string]resource.Quantity{}
-	for name, q := range node.Status.Capacity {
-		key := string(name)
-		if !strings.HasPrefix(key, extendedResourceDomain) {
+
+	// Snapshot the latest desired state now that we hold fresh
+	// node status.
+	a.extResLock.Lock()
+	resources := a.extResWant
+	a.extResLock.Unlock()
+	if len(resources) == 0 {
+		return nil
+	}
+
+	// Split the input into the things we want published, the
+	// exact keys we want gone, and the ownership patterns that
+	// tell us which additional (possibly unknown) keys on the
+	// Node we are responsible for pruning. Names outside our
+	// ownership domain are refused here and never acted upon.
+	publish := map[string]string{}
+	exactRemove := map[string]bool{}
+	ownGlobs := []string{}
+	for name, qty := range resources {
+		if qty != nil {
+			if strings.Contains(name, "*") {
+				log.Errorf("ignoring extended resource %q: wildcards are only allowed on owned (nil-valued) keys", name)
+				continue
+			}
+			if !isNRIExtendedResource(name) {
+				log.Errorf("refusing to publish extended resource %q: name does not match %q", name, nriExtendedResourceGlob)
+				continue
+			}
+			publish[name] = qty.String()
 			continue
 		}
-		owned[key] = q
-		if _, ours := lastPublishedExtendedResources[key]; !ours {
-			lastPublishedExtendedResources[key] = q
+		if strings.Contains(name, "*") {
+			ownGlobs = append(ownGlobs, name)
+			continue
+		}
+		if !isNRIExtendedResource(name) {
+			log.Errorf("refusing to remove extended resource %q: name does not match %q", name, nriExtendedResourceGlob)
+			continue
+		}
+		exactRemove[name] = true
+	}
+
+	current := map[string]string{}
+	for name, q := range node.Status.Capacity {
+		current[string(name)] = q.String()
+	}
+
+	// Determine which currently-present keys must be removed:
+	// exact removals plus every key matched by an ownership glob
+	// that we are not publishing. Regardless of what the policy
+	// asked for, never touch a key outside our ownership domain.
+	removeSet := map[string]bool{}
+	for name := range current {
+		if !isNRIExtendedResource(name) {
+			continue
+		}
+		if _, keep := publish[name]; keep {
+			continue
+		}
+		if exactRemove[name] {
+			removeSet[name] = true
+			continue
+		}
+		for _, glob := range ownGlobs {
+			if globMatch(glob, name) {
+				removeSet[name] = true
+				break
+			}
 		}
 	}
-	if len(owned) > 0 {
-		log.Infof("extended-resource startup sync: found %d existing key(s) on node %s: %s",
-			len(owned), a.nodeName, summarizeExtendedResources(owned))
+
+	// Now we have the current state, the desired state, and the
+	// set of keys to remove. Build a single JSON merge patch that
+	// will bring the Node into compliance.
+	updatedCapacity := map[string]any{}
+	for name, newValue := range publish {
+		if curValue, ok := current[name]; ok && curValue == newValue {
+			continue
+		}
+		updatedCapacity[name] = newValue
+	}
+	for name := range removeSet {
+		updatedCapacity[name] = nil
+	}
+	if len(updatedCapacity) == 0 {
+		return nil
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"status": map[string]any{
+			"capacity": updatedCapacity,
+		},
+	})
+	if err != nil {
+		log.Warnf("failed to marshal update-resources patch: %v", err)
+		return err
+	}
+
+	mergeCtx, mergeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer mergeCancel()
+	_, err = a.k8sCli.CoreV1().Nodes().Patch(
+		mergeCtx, a.nodeName, types.MergePatchType, body,
+		metav1.PatchOptions{}, "status")
+	if err != nil {
+		return fmt.Errorf("patch node %s status: %w", a.nodeName, err)
+	}
+
+	if s := summarizeResources(publish); s != "" {
+		log.Infof("published node extended resources: %s", s)
+	}
+	if len(removeSet) > 0 {
+		log.Infof("removed node extended resources: %s", strings.Join(slices.Sorted(maps.Keys(removeSet)), ", "))
 	}
 	return nil
 }
 
-// ClearNodeExtendedResources removes every node-status key the
-// agent currently owns (every key in lastPublishedExtendedResources
-// plus, for safety, every key currently present on the node that
-// carries our domain prefix). Best-effort and synchronous, with a
-// short timeout; intended for Agent.Stop() so a graceful shutdown
-// does not leave orphan capacity entries behind.
-func (a *Agent) ClearNodeExtendedResources() {
-	if a.hasLocalConfig() {
-		return
-	}
-	if a.k8sCli == nil || a.nodeName == "" {
-		return
-	}
-
-	extendedResourcesLock.Lock()
-	defer extendedResourcesLock.Unlock()
-
-	toRemove := map[string]struct{}{}
-	for k := range lastPublishedExtendedResources {
-		toRemove[k] = struct{}{}
-	}
-
-	// Also fold in anything currently on the node under our
-	// domain that we may not be tracking (e.g., startup sync
-	// never ran because no publish happened before Stop). Best
-	// effort: ignore the read error and fall back to the
-	// in-memory set.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	if node, err := a.k8sCli.CoreV1().Nodes().Get(ctx, a.nodeName, metav1.GetOptions{}); err == nil {
-		for name := range node.Status.Capacity {
-			key := string(name)
-			if strings.HasPrefix(key, extendedResourceDomain) {
-				toRemove[key] = struct{}{}
-			}
-		}
-	}
-	cancel()
-
-	if len(toRemove) == 0 {
-		return
-	}
-
-	type jsonPatchOp struct {
-		Op   string `json:"op"`
-		Path string `json:"path"`
-	}
-	ops := make([]jsonPatchOp, 0, len(toRemove))
-	keys := make([]string, 0, len(toRemove))
-	for k := range toRemove {
-		ops = append(ops, jsonPatchOp{
-			Op:   "remove",
-			Path: "/status/capacity/" + escapeJSONPointer(k),
-		})
-		keys = append(keys, k)
-	}
-
-	body, err := json.Marshal(ops)
+func globMatch(pattern, name string) bool {
+	matched, err := path.Match(pattern, name)
 	if err != nil {
-		log.Warnf("ClearNodeExtendedResources: marshal patch: %v", err)
-		return
+		log.Errorf("invalid extended resources glob pattern %q: %v", pattern, err)
 	}
+	return matched
+}
 
-	pctx, pcancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer pcancel()
-	_, err = a.k8sCli.CoreV1().Nodes().Patch(
-		pctx, a.nodeName, types.JSONPatchType, body,
-		metav1.PatchOptions{}, "status")
-	if err != nil {
-		log.Warnf("ClearNodeExtendedResources: patch node %s: %v", a.nodeName, err)
-		return
+// summarizeResources formats a name->value map deterministically
+// for logs: "name1=v1, name2=v2, ...".
+func summarizeResources(m map[string]string) string {
+	if len(m) == 0 {
+		return ""
 	}
-
-	// Stable order in the log
-	for i := 1; i < len(keys); i++ {
-		for j := i; j > 0 && keys[j-1] > keys[j]; j-- {
-			keys[j-1], keys[j] = keys[j], keys[j-1]
-		}
+	parts := make([]string, 0, len(m))
+	for _, k := range slices.Sorted(maps.Keys(m)) {
+		parts = append(parts, fmt.Sprintf("%s=%s", k, m[k]))
 	}
-	log.Infof("cleared node extended resources on shutdown: %s", strings.Join(keys, ", "))
-
-	lastPublishedExtendedResources = map[string]resource.Quantity{}
+	return strings.Join(parts, ", ")
 }

--- a/pkg/resmgr/policy/policy.go
+++ b/pkg/resmgr/policy/policy.go
@@ -117,14 +117,21 @@ type Backend interface {
 	ExportResourceData(cache.Container) map[string]string
 	// GetTopologyZones returns the policy/pool data for 'topology zone' CRDs.
 	GetTopologyZones() []*TopologyZone
-	// GetExtendedResources returns node-level extended resources
-	// this policy wishes to publish on the local Node, mapping
-	// fully-qualified resource name (e.g.
-	// "cpuclass.balloons.nri.io/hp-pct") to its current capacity
-	// (logical CPU count). Returning nil or an empty map means
-	// "publish nothing"; previously-published resources are then
-	// cleared by the agent.
-	GetExtendedResources() map[string]resource.Quantity
+	// GetExtendedResources returns the node-level extended
+	// resources this policy manages on the local Node. The map
+	// communicates both what to publish and what the policy owns,
+	// so that the agent can reconcile node state without any
+	// policy-specific knowledge:
+	//   - A non-nil value publishes (or replaces) the named
+	//     resource with the given capacity.
+	//   - A nil value marks the key as "owned but not published":
+	//     if the key is a plain resource name it is removed when
+	//     present; if the key contains '*' it is an ownership
+	//     pattern and every matching resource currently on the
+	//     Node that the policy is not publishing is removed.
+	// Returning nil or an empty map means the policy owns and
+	// publishes nothing.
+	GetExtendedResources() map[string]*resource.Quantity
 }
 
 // Policy is the exposed interface for container resource allocations decision making.
@@ -151,9 +158,9 @@ type Policy interface {
 	ExportResourceData(cache.Container)
 	// GetTopologyZones returns the policy/pool data for 'topology zone' CRDs.
 	GetTopologyZones() []*TopologyZone
-	// GetExtendedResources returns node-level extended resources
-	// the active policy wishes to publish on the local Node.
-	GetExtendedResources() map[string]resource.Quantity
+	// GetExtendedResources returns the node-level extended
+	// resources the active policy manages on the local Node.
+	GetExtendedResources() map[string]*resource.Quantity
 }
 
 // Metrics is the interface we expect policy-specific metrics to implement.
@@ -348,8 +355,8 @@ func (p *policy) GetTopologyZones() []*TopologyZone {
 	return p.active.GetTopologyZones()
 }
 
-// GetExtendedResources returns node-level extended resources the
-// active policy wishes to publish on the local Node.
-func (p *policy) GetExtendedResources() map[string]resource.Quantity {
+// GetExtendedResources returns the node-level extended resources
+// the active policy manages on the local Node.
+func (p *policy) GetExtendedResources() map[string]*resource.Quantity {
 	return p.active.GetExtendedResources()
 }

--- a/pkg/resmgr/resource-manager.go
+++ b/pkg/resmgr/resource-manager.go
@@ -298,8 +298,8 @@ func (m *resmgr) updateTopologyZones() {
 	}
 }
 
-// updateNodeExtendedResources publishes (or clears) the
-// node-level extended resources the active policy advertises.
+// updateNodeExtendedResources reconciles the node-level extended
+// resources the active policy manages.
 func (m *resmgr) updateNodeExtendedResources() {
 	resources := m.policy.GetExtendedResources()
 	if err := m.agent.UpdateNodeExtendedResources(resources); err != nil {

--- a/test/e2e/policies.test-suite/balloons/n4c16/test19-pct/balloons-pct-nopublish.cfg
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test19-pct/balloons-pct-nopublish.cfg
@@ -1,0 +1,56 @@
+config:
+  agent:
+    nodeResourceTopology: true
+  allocatorTopologyBalancing: false
+  availableResources:
+    cpu: cpuset:2-7,10-13
+  reservedResources:
+    cpu: 750m
+
+  pinCPU: true
+
+  idleCPUClass: default-class
+
+  balloonTypes:
+  - name: reserved
+    cpuClass: default-class
+  - name: pct-hp-bln
+    cpuClass: pct-hp
+    minCPUs: 1
+    maxCPUs: 1
+  - name: pct-hp2-bln
+    cpuClass: pct-hp
+    minCPUs: 1
+    maxCPUs: 2
+  - name: pct-lp-bln
+    cpuClass: pct-lp
+    minCPUs: 1
+    maxCPUs: 2
+  - name: pct-lp2-bln
+    cpuClass: pct-lp
+    minCPUs: 1
+    maxCPUs: 1
+
+  cpuClasses:
+  - name: default-class
+    minFreq: "base"
+    maxFreq: "base"
+  - name: pct-hp
+    minFreq: "turbo"
+    maxFreq: "turbo"
+    pctPriority: high
+  - name: pct-lp
+    minFreq: "min"
+    maxFreq: "base"
+    pctPriority: low
+
+  log:
+    debug:
+      - policy
+      - nri-plugin
+      - cpu
+      - cpuclass
+extraEnv:
+  OVERRIDE_SYS_CPUFREQ: '''[{"cpus": "0-15", "base": 2900000, "min": 800000, "max": 3800000}]'''
+  OVERRIDE_SST: '''{"supported": true, "clos_count": 4, "packages": [{"id": 0, "cpus": "0-7", "tf_supported": true, "cp_supported": true, "max_hp_cpus": 2}, {"id": 1, "cpus": "8-15", "tf_supported": true, "cp_supported": true, "max_hp_cpus": 2}]}'''
+  OVERRIDE_SST_STATE_DIR: "/tmp/nri-pct-mock"

--- a/test/e2e/policies.test-suite/balloons/n4c16/test19-pct/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test19-pct/code.var.sh
@@ -18,6 +18,13 @@
 #     set is rejected.
 #  8. Assoc-only mode: configuration with sstClosID only does NOT
 #     call PrepareManagedMode (no log line) and only associates CPUs.
+#  9. Extended-resource reconciliation (Phase 1.5): in-process
+#     reconfiguration that stops/starts publishing removes/re-adds
+#     the resource; and a resource injected directly on the node
+#     (simulating an orphan left behind e.g. by a non-graceful
+#     kill, a crash, an upgrade or manual intervention) is
+#     reconciled away by a freshly launched, non-publishing policy
+#     via its cpuclass.balloons.nri.io/* domain ownership.
 
 helm-terminate
 
@@ -90,6 +97,54 @@ wait-pod-gone() {
     return 0
 }
 
+# get-ext <resource-name> stores the given extended resource
+# capacity (or the string "missing") in COMMAND_OUTPUT.
+get-ext() {
+    local name=$1
+    vm-command "kubectl get nodes -o json | jq -r '.items[] | (.status.capacity[\"$name\"] // \"missing\")'"
+}
+
+# get-ext-hp stores the pct-hp extended resource capacity (or the
+# string "missing") in COMMAND_OUTPUT.
+get-ext-hp() {
+    get-ext "cpuclass.balloons.nri.io/pct-hp"
+}
+
+# wait-ext-hp <want> <message> [timeout=30] [interval=2]
+# Polls until the pct-hp extended resource equals <want> (a number
+# or the string "missing"), or fails with <message> on timeout.
+wait-ext-hp() {
+    local want=$1 msg=$2 timeout=${3:-30} interval=${4:-2} elapsed=0
+    while [ "$elapsed" -lt "$timeout" ]; do
+        get-ext-hp
+        [ "$COMMAND_OUTPUT" == "$want" ] && return 0
+        sleep "$interval"
+        elapsed=$((elapsed + interval))
+    done
+    get-ext-hp
+    command-error "$msg (expected '$want', got '$COMMAND_OUTPUT')"
+}
+
+# helm-upgrade <config> performs an in-process reconfiguration by
+# upgrading the running helm release with a new plugin config. Only
+# the policy custom resource changes, so the plugin pod is not
+# restarted and the agent reconfigures in place.
+helm-upgrade() {
+    local cfg=$1
+    host-command "$SCP \"$cfg\" $VM_HOSTNAME:" ||
+        command-error "copying \"$cfg\" to VM failed"
+    vm-command "helm upgrade -n kube-system test ./helm/balloons \
+             --values=$(basename "$cfg") \
+             --set image.name=localhost/balloons \
+             --set image.tag=testing \
+             --set image.pullPolicy=Never \
+             --set resources.cpu=50m \
+             --set resources.memory=256Mi \
+             --set plugin-test.enableAPIs=true" ||
+        command-error "helm upgrade with $cfg failed"
+}
+
+
 ###############################################################################
 # Phase 1: Managed mode -- HP + LP cpuClasses
 ###############################################################################
@@ -105,10 +160,7 @@ wait-assert-log-contains 'ConfigureClos.*ClosID:0 MinFreq:3800000 MaxFreq:380000
 wait-assert-log-contains 'ConfigureClos.*ClosID:3 MinFreq:800000 MaxFreq:2900000' "LP CLOS 3 not programmed with MinFreq=min (800000) MaxFreq=base (2900000)"
 wait-assert-log-contains 'EnableCP done' "EnableCP missing"
 
-vm-command "kubectl get nodes -o json | jq -r '
-  .items[] | (.status.capacity[\"cpuclass.balloons.nri.io/pct-hp\"] // \"extended resource missing\")'"
-[ "$COMMAND_OUTPUT" == "4" ] || \
-    command-error "expected 4 PCT HP CPUs published as extended resources"
+wait-ext-hp 4 "expected 4 PCT HP CPUs published as extended resources"
 
 # Phase 1.2: schedule a pod in the HP balloon.
 CPUREQ=1 CPULIM=1 MEMREQ=10M MEMLIM=10M \
@@ -212,10 +264,80 @@ wait-assert-log-grew 'to CLOS 3' "$prev_to_clos3" "after deleting remaining pods
 
 helm-terminate
 
-vm-command "kubectl get nodes -o json | jq -r '
-  .items[] | (.status.capacity[\"cpuclass.balloons.nri.io/pct-hp\"] // \"extended resource missing\")'"
-[ "$COMMAND_OUTPUT" == "extended resource missing" ] || \
-    command-error "expected published extended resources to be cleaned up and missing after uninstall"
+###############################################################################
+# Phase 1.5: extended-resource reconciliation
+###############################################################################
+
+helm_config=$TEST_DIR/balloons-pct-managed.cfg helm-launch balloons
+wait-ext-hp 4 "HP extended resource not published after (re)launch"
+
+# In-process reconfiguration: switch to a config that keeps the
+# pct-hp cpuClass but stops publishing it. The running plugin must
+# reconcile the node and REMOVE the now-unowned resource without a
+# restart.
+helm-upgrade "$TEST_DIR/balloons-pct-nopublish.cfg"
+wait-ext-hp missing "in-process reconfig to a non-publishing config did not remove the HP extended resource"
+
+# In-process reconfiguration back to publishing: the resource must
+# reappear.
+helm-upgrade "$TEST_DIR/balloons-pct-managed.cfg"
+wait-ext-hp 4 "in-process reconfig back to a publishing config did not re-publish the HP extended resource"
+
+# Tear down the release so the next helm-launch starts from a clean
+# slate. Note: the plugin no longer removes published extended
+# resources on shutdown; leftovers are reconciled away on the next
+# launch (verified below).
+helm-terminate
+
+# Reconciliation must remove extended resources it does not own
+# regardless of how they got there (e.g. left behind by a
+# non-graceful kill, a crash, or manual intervention) as long as the
+# policy claims ownership of their domain. Simulate such leftover
+# state directly, without depending on any particular failure mode
+# of a previous plugin instance, by patching the node's status
+# ourselves.
+node_name=$(vm-command-q "kubectl get nodes -o jsonpath='{.items[0].metadata.name}'")
+vm-command "kubectl patch node $node_name --subresource=status --type merge \
+    -p '{\"status\":{\"capacity\":{\"cpuclass.balloons.nri.io/pct-hp\":\"4\"}}}'" ||
+    command-error "failed to inject orphan HP extended resource for the reconciliation test"
+get-ext-hp
+[ "$COMMAND_OUTPUT" == "4" ] || \
+    command-error "expected injected orphan HP extended resource (4) to be visible, got '$COMMAND_OUTPUT'"
+
+# Also inject an unrelated extended resource that lives OUTSIDE the
+# *.nri.io/* domain. Even though the balloons policy claims to own
+# (and could accidentally request the removal of) resources, the
+# agent must never touch resources outside the *.nri.io/* domain.
+# This resource must survive reconciliation untouched.
+vm-command "kubectl patch node $node_name --subresource=status --type merge \
+    -p '{\"status\":{\"capacity\":{\"example.com/not-owned\":\"7\"}}}'" ||
+    command-error "failed to inject unrelated non-nri.io extended resource"
+get-ext "example.com/not-owned"
+[ "$COMMAND_OUTPUT" == "7" ] || \
+    command-error "expected injected non-nri.io extended resource (7) to be visible, got '$COMMAND_OUTPUT'"
+
+# Launch a config that publishes nothing. On startup the fresh
+# plugin process has no memory of the resource injected above, yet
+# the balloons policy claims ownership of the whole
+# cpuclass.balloons.nri.io/* domain, so the agent must reconcile the
+# node and remove the orphan.
+helm_config=$TEST_DIR/balloons-pct-nopublish.cfg helm-launch balloons
+wait-ext-hp missing "reconciliation on launch did not remove the orphan HP extended resource"
+
+# The unrelated non-nri.io resource must NOT have been removed: the
+# agent refuses to touch anything outside the *.nri.io/* domain.
+get-ext "example.com/not-owned"
+[ "$COMMAND_OUTPUT" == "7" ] || \
+    command-error "reconciliation removed or altered a non-nri.io extended resource (expected '7', got '$COMMAND_OUTPUT')"
+
+# Clean up the unrelated resource we injected so we leave the node
+# as we found it.
+vm-command "kubectl patch node $node_name --subresource=status --type merge \
+    -p '{\"status\":{\"capacity\":{\"example.com/not-owned\":null}}}'" ||
+    command-error "failed to clean up the injected non-nri.io extended resource"
+
+helm-terminate
+
 
 ###############################################################################
 # Phase 2: Assoc-only mode (sstClosID without pctPriority)


### PR DESCRIPTION
This change abandons earlier idea of always removing published extended resources on container exit and reconfiguration. Exit on "helm uninstall" is especially challenging because helm may remove serviceaccount and permissions before the policy can patch the node. On the other hand, successfully clean-up on exit is not critical, and clean-up on reconfiguration is completely unnecessary when adopting reconciliation approach implemented here: update resources if necessary.

This change extends GetExtendedResources() in policy interface to communicate extended resource domains/patterns owned by the policy. This enables the agent to remove extended resources owned by a policy, even if exact resource names depended on previous (already lost) policy configurations.

Adding/updating/removing extended resources is switched to MergePatchType to make it more robust against failures that could be caused by delayed earlier resource removals, for instance.