### PR TITLE
agent: log watch error reason.

### DIFF
--- a/pkg/agent/watch/object.go
+++ b/pkg/agent/watch/object.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 )
 
@@ -112,6 +113,13 @@ func (w *ObjectWatch) run() error {
 				}
 
 				if e.Type == Error {
+					if status, ok := e.Object.(*metav1.Status); ok {
+						log.Errorf("watch %s failed, %s: %s", w.watchname(),
+							status.Reason, status.Message)
+					} else {
+						log.Errorf("watch %s failed with unexpected event +%v", w.watchname(), e)
+					}
+
 					w.markFailing()
 					w.stop()
 					w.scheduleReopen()


### PR DESCRIPTION
If we receive an error event from a k8s watch, log the watch error message to help figuring out if something is wrong with the watched object itself. Without the error message it can be really difficult to track down the root cause of the failure.