### PR TITLE
resmgr: force a cache save after CreateContainer.

### DIFF
--- a/pkg/resmgr/nri.go
+++ b/pkg/resmgr/nri.go
@@ -453,6 +453,13 @@ func (p *nriPlugin) CreateContainer(ctx context.Context, pod *api.PodSandbox, co
 	m.Lock()
 	defer m.Unlock()
 
+	m.cache.BlockSave()
+	defer func() {
+		if err := m.cache.UnblockSave(); err != nil {
+			nri.Errorf("failed to unblock cache save: %v", err)
+		}
+	}()
+
 	c, err := m.cache.InsertContainer(container, cache.WithContainerState(cache.ContainerStateCreating))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to cache container: %w", err)


### PR DESCRIPTION
Force a cache save after CreateContainer, ensuring its state gets updated to Created on disk, too. Failing to do so could leave the last created container in the synthetic Creating state which is ignored during startup. This in turn could cause the last container to not get properly reallocated if the policy gets restarted or crashes.
