### PR TITLE
cpuclass: use more policy agnostic terms in comments.

### DIFF
--- a/config/crd/bases/config.nri_balloonspolicies.yaml
+++ b/config/crd/bases/config.nri_balloonspolicies.yaml
@@ -809,14 +809,13 @@ spec:
                     publishExtendedResource:
                       description: |-
                         PublishExtendedResource opts this CPU class into publishing
-                        a node-level extended resource named
-                        "cpuclass.balloons.nri.io/<class-name>" whose value reflects
-                        the number of logical CPUs that the balloons policy is
-                        currently able to route into this class on the node. The
-                        scheduler can then bin-pack/spread balloons by adding the
-                        same resource to pod requests, avoiding HP-CPU
-                        over-subscription on a single node. Has effect only when
-                        the class also carries PctPriority or SstClosID. Experimental.
+                        a node-level extended resource, using a policy chosen name,
+                        whose value reflects the number of logical CPUs that the policy
+                        is currently able to route into this class on the node. The
+                        scheduler can then bin-pack/spread containers by adding the
+                        same resource to pod requests, avoiding HP-CPU over-subscription
+                        on a single node. Has effect only when the class also carries
+                        PctPriority or SstClosID. Experimental.
                       type: boolean
                     sstClosID:
                       description: |-
@@ -832,8 +831,8 @@ spec:
                     turboPriority:
                       description: |-
                         TurboPriority controls exclusive turbo frequency access.
-                        Among CPU classes with active balloons, only the class with
-                        the highest turboPriority gets the symbolic frequency "turbo"
+                        Among CPU classes with active CPU allocations, only the class
+                        with the highest turboPriority gets the symbolic frequency "turbo"
                         resolved to the actual turbo frequency. All other classes get
                         "turbo" resolved to the base frequency instead.
                         If all classes have turboPriority 0 (default), every class

--- a/config/crd/bases/config.nri_balloonspolicies.yaml
+++ b/config/crd/bases/config.nri_balloonspolicies.yaml
@@ -828,14 +828,13 @@ spec:
                     publishExtendedResource:
                       description: |-
                         PublishExtendedResource opts this CPU class into publishing
-                        a node-level extended resource named
-                        "cpuclass.balloons.nri.io/<class-name>" whose value reflects
-                        the number of logical CPUs that the balloons policy is
-                        currently able to route into this class on the node. The
-                        scheduler can then bin-pack/spread balloons by adding the
-                        same resource to pod requests, avoiding HP-CPU
-                        over-subscription on a single node. Has effect only when
-                        the class also carries PctPriority or SstClosID. Experimental.
+                        a node-level extended resource, using a policy chosen name,
+                        whose value reflects the number of logical CPUs that the policy
+                        is currently able to route into this class on the node. The
+                        scheduler can then bin-pack/spread containers by adding the
+                        same resource to pod requests, avoiding HP-CPU over-subscription
+                        on a single node. Has effect only when the class also carries
+                        PctPriority or SstClosID. Experimental.
                       type: boolean
                     sstClosID:
                       description: |-
@@ -851,8 +850,8 @@ spec:
                     turboPriority:
                       description: |-
                         TurboPriority controls exclusive turbo frequency access.
-                        Among CPU classes with active balloons, only the class with
-                        the highest turboPriority gets the symbolic frequency "turbo"
+                        Among CPU classes with active CPU allocations, only the class
+                        with the highest turboPriority gets the symbolic frequency "turbo"
                         resolved to the actual turbo frequency. All other classes get
                         "turbo" resolved to the base frequency instead.
                         If all classes have turboPriority 0 (default), every class

--- a/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
+++ b/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
@@ -809,14 +809,13 @@ spec:
                     publishExtendedResource:
                       description: |-
                         PublishExtendedResource opts this CPU class into publishing
-                        a node-level extended resource named
-                        "cpuclass.balloons.nri.io/<class-name>" whose value reflects
-                        the number of logical CPUs that the balloons policy is
-                        currently able to route into this class on the node. The
-                        scheduler can then bin-pack/spread balloons by adding the
-                        same resource to pod requests, avoiding HP-CPU
-                        over-subscription on a single node. Has effect only when
-                        the class also carries PctPriority or SstClosID. Experimental.
+                        a node-level extended resource, using a policy chosen name,
+                        whose value reflects the number of logical CPUs that the policy
+                        is currently able to route into this class on the node. The
+                        scheduler can then bin-pack/spread containers by adding the
+                        same resource to pod requests, avoiding HP-CPU over-subscription
+                        on a single node. Has effect only when the class also carries
+                        PctPriority or SstClosID. Experimental.
                       type: boolean
                     sstClosID:
                       description: |-
@@ -832,8 +831,8 @@ spec:
                     turboPriority:
                       description: |-
                         TurboPriority controls exclusive turbo frequency access.
-                        Among CPU classes with active balloons, only the class with
-                        the highest turboPriority gets the symbolic frequency "turbo"
+                        Among CPU classes with active CPU allocations, only the class
+                        with the highest turboPriority gets the symbolic frequency "turbo"
                         resolved to the actual turbo frequency. All other classes get
                         "turbo" resolved to the base frequency instead.
                         If all classes have turboPriority 0 (default), every class

--- a/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
+++ b/deployment/helm/balloons/crds/config.nri_balloonspolicies.yaml
@@ -828,14 +828,13 @@ spec:
                     publishExtendedResource:
                       description: |-
                         PublishExtendedResource opts this CPU class into publishing
-                        a node-level extended resource named
-                        "cpuclass.balloons.nri.io/<class-name>" whose value reflects
-                        the number of logical CPUs that the balloons policy is
-                        currently able to route into this class on the node. The
-                        scheduler can then bin-pack/spread balloons by adding the
-                        same resource to pod requests, avoiding HP-CPU
-                        over-subscription on a single node. Has effect only when
-                        the class also carries PctPriority or SstClosID. Experimental.
+                        a node-level extended resource, using a policy chosen name,
+                        whose value reflects the number of logical CPUs that the policy
+                        is currently able to route into this class on the node. The
+                        scheduler can then bin-pack/spread containers by adding the
+                        same resource to pod requests, avoiding HP-CPU over-subscription
+                        on a single node. Has effect only when the class also carries
+                        PctPriority or SstClosID. Experimental.
                       type: boolean
                     sstClosID:
                       description: |-
@@ -851,8 +850,8 @@ spec:
                     turboPriority:
                       description: |-
                         TurboPriority controls exclusive turbo frequency access.
-                        Among CPU classes with active balloons, only the class with
-                        the highest turboPriority gets the symbolic frequency "turbo"
+                        Among CPU classes with active CPU allocations, only the class
+                        with the highest turboPriority gets the symbolic frequency "turbo"
                         resolved to the actual turbo frequency. All other classes get
                         "turbo" resolved to the base frequency instead.
                         If all classes have turboPriority 0 (default), every class

--- a/pkg/apis/config/v1alpha1/resmgr/policy/cpuclass.go
+++ b/pkg/apis/config/v1alpha1/resmgr/policy/cpuclass.go
@@ -48,8 +48,8 @@ type CPUClass struct {
 	// Example: ["C4", "C6", "C8", "C10"]
 	DisabledCstates []string `json:"disabledCstates,omitempty"`
 	// TurboPriority controls exclusive turbo frequency access.
-	// Among CPU classes with active balloons, only the class with
-	// the highest turboPriority gets the symbolic frequency "turbo"
+	// Among CPU classes with active CPU allocations, only the class
+	// with the highest turboPriority gets the symbolic frequency "turbo"
 	// resolved to the actual turbo frequency. All other classes get
 	// "turbo" resolved to the base frequency instead.
 	// If all classes have turboPriority 0 (default), every class
@@ -86,13 +86,12 @@ type CPUClass struct {
 	// Same caveat as PctMinFreq.
 	PctMaxFreq Frequency `json:"pctMaxFreq,omitempty"`
 	// PublishExtendedResource opts this CPU class into publishing
-	// a node-level extended resource named
-	// "cpuclass.balloons.nri.io/<class-name>" whose value reflects
-	// the number of logical CPUs that the balloons policy is
-	// currently able to route into this class on the node. The
-	// scheduler can then bin-pack/spread balloons by adding the
-	// same resource to pod requests, avoiding HP-CPU
-	// over-subscription on a single node. Has effect only when
-	// the class also carries PctPriority or SstClosID. Experimental.
+	// a node-level extended resource, using a policy chosen name,
+	// whose value reflects the number of logical CPUs that the policy
+	// is currently able to route into this class on the node. The
+	// scheduler can then bin-pack/spread containers by adding the
+	// same resource to pod requests, avoiding HP-CPU over-subscription
+	// on a single node. Has effect only when the class also carries
+	// PctPriority or SstClosID. Experimental.
 	PublishExtendedResource bool `json:"publishExtendedResource,omitempty"`
 }

--- a/pkg/resmgr/cpuclass/internal/pct/pct.go
+++ b/pkg/resmgr/cpuclass/internal/pct/pct.go
@@ -223,7 +223,7 @@ func (a *Allocator) Configure(classes []*policyapi.CPUClass, allowed cpuset.CPUS
 		// defined). Leaving them on CLOS 0 inflates the SST-TF
 		// active-HP-core count on every punit and prevents bucket-0
 		// turbo selection on punits hosting both an HP and an LP
-		// balloon.
+		// allocations.
 		if lpClos != nil {
 			a.fallbackClos = *lpClos
 			log.Infof("pct: fallback CLOS for non-PCT CPUs set to %d (LP)", a.fallbackClos)
@@ -454,7 +454,7 @@ func (a *Allocator) Active() bool {
 
 // FreeClassCapacity returns the number of logical CPUs that can
 // still be allocated to className, given that 'held' lists CPUs
-// already consumed by some balloon on this node (any class).
+// already consumed by some allocations on this node (any class).
 //
 // Same formula in managed and assoc-only modes:
 //   - HP class: sum over HP-eligible punits of

--- a/pkg/resmgr/cpuclass/internal/pct/pct.go
+++ b/pkg/resmgr/cpuclass/internal/pct/pct.go
@@ -452,7 +452,7 @@ func (a *Allocator) Active() bool {
 	return a != nil && a.mode != pctModeDisabled
 }
 
-// freeClassCapacity returns the number of logical CPUs that can
+// FreeClassCapacity returns the number of logical CPUs that can
 // still be allocated to className, given that 'held' lists CPUs
 // already consumed by some balloon on this node (any class).
 //


### PR DESCRIPTION
Use policy agnostic terms ('policy' instead of 'balloons') in various comments related to cpuclasses and PCT. Fix old/incorrect function name in a docstring comment.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>