### PR TITLE
cpufreq: always (debug-)log class enforcement.

### DIFF
--- a/pkg/resmgr/cpuclass/internal/cpufreq/sysfs.go
+++ b/pkg/resmgr/cpuclass/internal/cpufreq/sysfs.go
@@ -87,8 +87,9 @@ func (w *Writer) Enforce(class string, def types.ClassDef, cpus []int) error {
 
 	var firstErr error
 	for _, cpu := range cpus {
-		state := w.lastWritten[cpu]
+		log.Debugf("enforcing cpu frequency from class %q on cpu %d", class, cpu)
 
+		state := w.lastWritten[cpu]
 		if min > 0 && (!state.hasMin || state.min != min) {
 			log.Debugf("enforcing cpu frequency min %d from class %q on cpu %d", min, class, cpu)
 			if err := w.callSetMin(cpu, int(min)); err != nil {


### PR DESCRIPTION
Always debug log cpufreq class enforcement intent. This helps with log-based verification in e2e tests with repeated class assignments. Otherwise some assignment of a cpufreq-only class could be omitted from logs if it does not change cpufreq state for a CPU.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>