### PR TITLE
config-manager: don't panic if containerd/config.toml is empty

### DIFF
--- a/cmd/config-manager/main.go
+++ b/cmd/config-manager/main.go
@@ -180,6 +180,10 @@ func readConfig(file string) (map[string]interface{}, error) {
 	if err := tomlv2.Unmarshal(tomlData, &tomlMap); err != nil {
 		return nil, fmt.Errorf("error unmarshaling TOML: %w", err)
 	}
+
+	if tomlMap == nil {
+		tomlMap = make(map[string]interface{})
+	}
 	return tomlMap, nil
 }
 


### PR DESCRIPTION
Fixes helm install --set nri.runtime.patchConfig=true init container crash loop on systems with no real content in containerd config.toml.