### PR TITLE
config-manager: write NRI timeouts into the containerd plugin table

### DIFF
--- a/cmd/config-manager/main.go
+++ b/cmd/config-manager/main.go
@@ -38,6 +38,9 @@ const (
 	resultDone           = "done"
 	containerdUnit       = "containerd.service"
 	crioUnit             = "crio.service"
+	// containerd reads these only from plugins."io.containerd.nri.v1.nri".
+	pluginRegistrationTimeoutKey = "plugin_registration_timeout"
+	pluginRequestTimeoutKey      = "plugin_request_timeout"
 )
 
 var (
@@ -204,7 +207,16 @@ func updateContainerdConfig(config map[string]interface{}, cfg *nriConfig) map[s
 
 	nri["disable"] = false
 
-	cfg.updateContainerdConfig(config)
+	// Older builds wrote these at the root. containerd ignores them there.
+	// Drop them so a retry does not leave a misleading root copy behind.
+	if cfg.registrationTimeout != "" {
+		nri[pluginRegistrationTimeoutKey] = cfg.registrationTimeout
+		delete(config, pluginRegistrationTimeoutKey)
+	}
+	if cfg.requestTimeout != "" {
+		nri[pluginRequestTimeoutKey] = cfg.requestTimeout
+		delete(config, pluginRequestTimeoutKey)
+	}
 
 	return config
 }
@@ -254,20 +266,6 @@ func (cfg *nriConfig) writeCrioConfig(f *os.File) error {
 		}
 	}
 	return nil
-}
-
-func (cfg *nriConfig) updateContainerdConfig(tomlCfg map[string]interface{}) {
-	const (
-		registrationTimeout = "plugin_registration_timeout"
-		requestTimeout      = "plugin_request_timeout"
-	)
-
-	if cfg.registrationTimeout != "" {
-		tomlCfg[registrationTimeout] = cfg.registrationTimeout
-	}
-	if cfg.requestTimeout != "" {
-		tomlCfg[requestTimeout] = cfg.requestTimeout
-	}
 }
 
 func detectRuntime() (string, *dbus.Conn, error) {

--- a/cmd/config-manager/main_test.go
+++ b/cmd/config-manager/main_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"testing"
+
+	tomlv2 "github.com/pelletier/go-toml/v2"
+)
+
+func TestUpdateContainerdConfigWritesTimeoutsUnderNRIPlugin(t *testing.T) {
+	config := mustUnmarshalTOML(t, `
+version = 2
+root = "/var/lib/containerd"
+
+[plugins."io.containerd.nri.v1.nri"]
+  disable = true
+  plugin_registration_timeout = "5s"
+  plugin_request_timeout = "2s"
+  socket_path = "/var/run/nri/nri.sock"
+`)
+
+	updated := updateContainerdConfig(config, &nriConfig{
+		registrationTimeout: "25s",
+		requestTimeout:      "20s",
+	})
+
+	if _, ok := updated[pluginRegistrationTimeoutKey]; ok {
+		t.Fatalf("registration timeout written at config root")
+	}
+	if _, ok := updated[pluginRequestTimeoutKey]; ok {
+		t.Fatalf("request timeout written at config root")
+	}
+
+	nri := nriPluginSection(t, updated)
+	if got, want := nri["disable"], false; got != want {
+		t.Fatalf("disable: got %v want %v", got, want)
+	}
+	if got, want := nri[pluginRegistrationTimeoutKey], "25s"; got != want {
+		t.Fatalf("registration timeout: got %v want %v", got, want)
+	}
+	if got, want := nri[pluginRequestTimeoutKey], "20s"; got != want {
+		t.Fatalf("request timeout: got %v want %v", got, want)
+	}
+	if got, want := nri["socket_path"], "/var/run/nri/nri.sock"; got != want {
+		t.Fatalf("socket_path: got %v want %v", got, want)
+	}
+}
+
+func TestUpdateContainerdConfigNoTimeoutsLeavesNRIEnabled(t *testing.T) {
+	config := mustUnmarshalTOML(t, `
+version = 2
+plugin_registration_timeout = "25s"
+plugin_request_timeout = "20s"
+
+[plugins."io.containerd.nri.v1.nri"]
+  disable = true
+  plugin_request_timeout = "2s"
+`)
+
+	updated := updateContainerdConfig(config, &nriConfig{})
+
+	if got, want := updated[pluginRegistrationTimeoutKey], "25s"; got != want {
+		t.Fatalf("root registration timeout: got %v want %v", got, want)
+	}
+	if got, want := updated[pluginRequestTimeoutKey], "20s"; got != want {
+		t.Fatalf("root request timeout: got %v want %v", got, want)
+	}
+
+	nri := nriPluginSection(t, updated)
+	if got, want := nri["disable"], false; got != want {
+		t.Fatalf("disable: got %v want %v", got, want)
+	}
+	if got, want := nri[pluginRequestTimeoutKey], "2s"; got != want {
+		t.Fatalf("existing request timeout: got %v want %v", got, want)
+	}
+}
+
+func TestUpdateContainerdConfigCreatesMissingNRISection(t *testing.T) {
+	config := mustUnmarshalTOML(t, `
+version = 2
+`)
+
+	updated := updateContainerdConfig(config, &nriConfig{
+		registrationTimeout: "10s",
+		requestTimeout:      "7s",
+	})
+
+	nri := nriPluginSection(t, updated)
+	if got, want := nri[pluginRegistrationTimeoutKey], "10s"; got != want {
+		t.Fatalf("registration timeout: got %v want %v", got, want)
+	}
+	if got, want := nri[pluginRequestTimeoutKey], "7s"; got != want {
+		t.Fatalf("request timeout: got %v want %v", got, want)
+	}
+}
+
+func mustUnmarshalTOML(t *testing.T, raw string) map[string]interface{} {
+	t.Helper()
+	var config map[string]interface{}
+	if err := tomlv2.Unmarshal([]byte(raw), &config); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if config == nil {
+		t.Fatal("empty toml map")
+	}
+	return config
+}
+
+func nriPluginSection(t *testing.T, config map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	plugins, ok := config["plugins"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("plugins type %T", config["plugins"])
+	}
+	nri, ok := plugins[nriPluginKey].(map[string]interface{})
+	if !ok {
+		t.Fatalf("nri plugin type %T", plugins[nriPluginKey])
+	}
+	return nri
+}


### PR DESCRIPTION
The init container wrote `plugin_registration_timeout` and `plugin_request_timeout` at the root of `/etc/containerd/config.toml`. containerd only reads those keys under `plugins.'io.containerd.nri.v1.nri'`, so custom timeout values never took effect. Observed on large nodes where NRI was timing out and we dug in to see how to fix / why fix was not applied. 

Write the keys into the NRI plugin table and drop any stale root copies left by older builds. Added clean up as well since these keys are not valid containerd configurations. 

**Reproduction**
```
❯ kubectl --context <cluster> -n argocd get app nri-resource-policy-topology-aware \
  -o jsonpath='{.spec.source.helm.values}' | yq '.nri.runtime'
patchConfig: true
config:
  pluginRegistrationTimeout: 25s
  pluginRequestTimeout: 20s
```
wait for nri start and patch:
```
❯ kubectl --context <cluster> -n kube-system logs "$POD" \
  -c patch-runtime  | tail -40
time="2026-08-07T15:54:31Z" level=info msg="setting up D-Bus connection..."
time="2026-08-07T15:54:31Z" level=info msg="looking for active runtime units on D-Bus..."
time="2026-08-07T15:54:31Z" level=info msg="found containerd.service..."
time="2026-08-07T15:54:31Z" level=info msg="configuring NRI for containerd..."
time="2026-08-07T15:54:31Z" level=info msg="restarting D-Bus unit containerd.service..."
time="2026-08-07T15:54:33Z" level=info msg="enabled NRI for containerd.service"
```

ssh into the node to inspect patched configs:
```
~ $ cat /etc/containerd/config.toml | grep registration -C 5
disabled_plugins = []
imports = []
oom_score = 0
plugin_dir = ''
plugin_registration_timeout = '25s' <- problem
plugin_request_timeout = '20s'
required_plugins = []
root = '/var/lib/containerd'
state = '/run/containerd'
temp = ''
--
  [plugins.'io.containerd.nri.v1.nri']
    disable = false
    disable_connections = false
    plugin_config_path = '/etc/nri/conf.d'
    plugin_path = '/opt/nri/plugins'
    plugin_registration_timeout = '10s' <- unchanged
    plugin_request_timeout = '7s'
    socket_path = '/var/run/nri/nri.sock'

  [plugins.'io.containerd.runtime.v1.linux']
    no_shim = false
```