### PR TITLE
topology-aware: don't try to restore cache on startup.

### DIFF
--- a/cmd/plugins/topology-aware/policy/topology-aware-policy.go
+++ b/cmd/plugins/topology-aware/policy/topology-aware-policy.go
@@ -141,10 +141,6 @@ func (p *policy) Description() string {
 
 // Start prepares this policy for accepting allocation/release requests.
 func (p *policy) Start() error {
-	if err := p.restoreCache(); err != nil {
-		return policyError("failed to start: %v", err)
-	}
-
 	// Turn coldstart forcibly off if we have movable non-DRAM memory.
 	// Note that although this can change dynamically we only check it
 	// during startup and trust users to either not fiddle with memory
@@ -726,19 +722,6 @@ func (p *policy) findExistingTopologyLevel(level cfgapi.CPUTopologyLevel) cfgapi
 	}
 
 	return cfgapi.CPUTopologyLevelPackage
-}
-
-func (p *policy) restoreCache() error {
-	allocations := p.newAllocations()
-	if p.cache.GetPolicyEntry(keyAllocations, &allocations) {
-		if err := p.restoreAllocations(&allocations); err != nil {
-			return policyError("failed to restore allocations from cache: %v", err)
-		}
-		p.allocations.Dump(log.Infof, "restored ")
-	}
-	p.saveAllocations()
-
-	return nil
 }
 
 func (p *policy) checkColdstartOff() {


### PR DESCRIPTION
Don't try to restore allocations from the cache on startup. All policy specific data is cleared from the cache by resmgr before it is handed over to the policy, so allocations will be empty. Will re-establish them during runtime synchronization.