### PR TITLE
e2e: always nuke OTEL collector after tests.

### DIFF
--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test40-otel-logging/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test40-otel-logging/code.var.sh
@@ -1,12 +1,23 @@
 OTEL_LOGS=/tmp/otel/data/otel-export.out
 
 cleanup() {
-    vm-command "kubectl delete -f otel-collector.yaml" || :
+    always-cleanup
     vm-command "kubectl delete pods --all" || :
     helm-terminate || :
     vm-command "mkdir -p /tmp/otel/data && chmod a+rw /tmp/otel/data"
     vm-command "rm -f $OTEL_LOGS && touch -f $OTEL_LOGS && chmod a+rw $OTEL_LOGS"
 }
+
+# We better always clean up the otel collector. It takes an extra 750m CPU
+# request allocation from the reserved/kube-system CPUs which is normally
+# enough alone to exhaust our CPU reservation. Otherwise any subsequent
+# tests, or typically subsequent test runs against the same VM, might have
+# false positives due to the extra lingering CPU allocation.
+always-cleanup() {
+    vm-command "kubectl delete -f otel-collector.yaml" || :
+}
+
+trap always-cleanup EXIT
 
 cleanup
 


### PR DESCRIPTION
We run the OTEL collector pod in the `kube-system` namespace, IOW on the reserved CPU set/pool. Normally this would be alone enough to exhaust reserved CPUs. So always clean up the OTEL collector pod, also on test failures, to avoid false positives in subsequent test runs against the same VM failing due to the OTEL collectors unexpected CPU request.