### PR TITLE
e2e: wait for OTEL image pull/collector to start in tests.

### DIFF
--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test40-otel-logging/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test40-otel-logging/code.var.sh
@@ -23,6 +23,7 @@ cleanup
 
 vm-put-file $(instantiate otel-collector.yaml) otel-collector.yaml
 vm-command "kubectl apply -f otel-collector.yaml"
+vm-command "kubectl -n kube-system wait deployments/otel-collector --for=condition=Available --timeout=300s"
 
 helm_config=$(instantiate custom-config.yaml) helm-launch topology-aware
 


### PR DESCRIPTION
Wait for OTEL collector to start before proceeding with the rest of the tests. On a pristine node this typically takes tens of seconds, since the OTEL collector image needs to be pulled first.