### PR TITLE
irq: cache procfs with a write buffer

### DIFF
--- a/cmd/plugins/balloons/policy/balloons-policy.go
+++ b/cmd/plugins/balloons/policy/balloons-policy.go
@@ -256,6 +256,8 @@ func (p *balloons) Start() error {
 
 // Sync synchronizes the active policy state.
 func (p *balloons) Sync(add []cache.Container, del []cache.Container) error {
+	irq.BlockWrites()
+	defer irq.UnblockWrites()
 	p.BlockMeters()
 	defer p.UnblockMeters()
 	defer p.commitCpuClasses()
@@ -281,6 +283,8 @@ func (p *balloons) Sync(add []cache.Container, del []cache.Container) error {
 
 // AllocateResources is a resource allocation request for this policy.
 func (p *balloons) AllocateResources(c cache.Container) error {
+	irq.BlockWrites()
+	defer irq.UnblockWrites()
 	p.BlockMeters()
 	defer p.UnblockMeters()
 	defer p.commitCpuClasses()
@@ -336,6 +340,8 @@ func (p *balloons) AllocateResources(c cache.Container) error {
 
 // ReleaseResources is a resource release request for this policy.
 func (p *balloons) ReleaseResources(c cache.Container) error {
+	irq.BlockWrites()
+	defer irq.UnblockWrites()
 	p.BlockMeters()
 	defer p.UnblockMeters()
 	defer p.commitCpuClasses()
@@ -371,6 +377,8 @@ func (p *balloons) ReleaseResources(c cache.Container) error {
 
 // UpdateResources is a resource allocation update request for this policy.
 func (p *balloons) UpdateResources(c cache.Container) error {
+	irq.BlockWrites()
+	defer irq.UnblockWrites()
 	p.BlockMeters()
 	defer p.UnblockMeters()
 	defer p.commitCpuClasses()
@@ -1622,6 +1630,8 @@ func changesCpuClasses(opts0, opts1 *BalloonsOptions) bool {
 }
 
 func (p *balloons) Reconfigure(newCfg interface{}) error {
+	irq.BlockWrites()
+	defer irq.UnblockWrites()
 	p.BlockMeters()
 	defer p.UnblockMeters()
 	defer p.commitCpuClasses()

--- a/cmd/plugins/topology-aware/policy/topology-aware-policy.go
+++ b/cmd/plugins/topology-aware/policy/topology-aware-policy.go
@@ -93,6 +93,9 @@ func New() policyapi.Backend {
 func (p *policy) Setup(opts *policyapi.BackendOptions) error {
 	var err error
 
+	irq.BlockWrites()
+	defer irq.UnblockWrites()
+
 	cfg, ok := opts.Config.(*cfgapi.Config)
 	if !ok {
 		return policyError("failed initialize %s policy: config of wrong type %T",
@@ -166,6 +169,9 @@ func (p *policy) Start() error {
 
 // Sync synchronizes the state of this policy.
 func (p *policy) Sync(add []cache.Container, del []cache.Container) error {
+	irq.BlockWrites()
+	defer irq.UnblockWrites()
+
 	log.Debugf("synchronizing state...")
 	for _, c := range del {
 		if err := p.ReleaseResources(c); err != nil {
@@ -234,6 +240,9 @@ func (p *policy) checkAllocations(format string, args ...interface{}) {
 
 // AllocateResources is a resource allocation request for this policy.
 func (p *policy) AllocateResources(container cache.Container) error {
+	irq.BlockWrites()
+	defer irq.UnblockWrites()
+
 	log.Debugf("allocating resources for %s (%s)...", container.PrettyName(), container.GetID())
 
 	defer p.commitCpuClasses(container.PrettyName())
@@ -266,6 +275,9 @@ func (p *policy) allocateResources(container cache.Container, poolHint string) e
 
 // ReleaseResources is a resource release request for this policy.
 func (p *policy) ReleaseResources(container cache.Container) error {
+	irq.BlockWrites()
+	defer irq.UnblockWrites()
+
 	log.Debugf("releasing resources for %s (%s)...", container.PrettyName(), container.GetID())
 
 	defer p.commitCpuClasses(container.PrettyName())
@@ -285,6 +297,9 @@ func (p *policy) ReleaseResources(container cache.Container) error {
 
 // UpdateResources is a resource allocation update request for this policy.
 func (p *policy) UpdateResources(container cache.Container) error {
+	irq.BlockWrites()
+	defer irq.UnblockWrites()
+
 	log.Debugf("updating (reallocating) container %s...", container.PrettyName())
 
 	defer p.commitCpuClasses(container.PrettyName())
@@ -516,6 +531,9 @@ func (p *policy) reallocateResources(containers []cache.Container, pools map[str
 }
 
 func (p *policy) Reconfigure(newCfg interface{}) error {
+	irq.BlockWrites()
+	defer irq.UnblockWrites()
+
 	cfg, ok := newCfg.(*cfgapi.Config)
 	if !ok {
 		return policyError("got config of wrong type %T", newCfg)

--- a/docs/resource-policy/policy/balloons.md
+++ b/docs/resource-policy/policy/balloons.md
@@ -1110,6 +1110,13 @@ Affinities are updated by writing
 `/proc/irq/<NUMBER>/smp_affinity_list`, and IRQs are matched against
 `/proc/interrupts`.
 
+The policy assumes that it is the only entity which manages the
+affinities of the IRQs it controls. It caches IRQ data read from procfs,
+so affinities changed by other means while the policy runs are neither
+noticed nor reverted, and IRQs which appear at runtime are not seen.
+Affinities are updated when a policy operation, such as allocating
+resources to a container, completes.
+
 **`irqClaim`** (list of strings)
 - Lists IRQs handled by CPUs of balloons of this type.
 - Each item refers to IRQs either by an exact number, or by a pattern

--- a/docs/resource-policy/policy/topology-aware.md
+++ b/docs/resource-policy/policy/topology-aware.md
@@ -798,6 +798,13 @@ Any container scoped effective IRQ affinity annotation for containers
 without exclusive CPU allocation is considered an error, regardless of
 the container's QoS class, and should prevent the creation of the container.
 
+The policy assumes that it is the only entity which manages the
+affinities of the IRQs it controls. It caches IRQ data read from procfs,
+so affinities changed by other means while the policy runs are neither
+noticed nor reverted, and IRQs which appear at runtime are not seen.
+Affinities are updated when a policy operation, such as allocating
+resources to a container, completes.
+
 #### Restricting IRQ CPU Affinity Tuning
 
 The `controllableInterrupts` configuration setting can be used to restrict

--- a/pkg/irq/irq-cache.go
+++ b/pkg/irq/irq-cache.go
@@ -1,0 +1,334 @@
+// Copyright The NRI Plugins Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package irq
+
+// This file implements the caching layer of the irq package. All procfs
+// reads, writes and parsing of this package happen here.
+//
+// Caching assumes that interrupts are neither added nor removed at
+// runtime, and that no entity outside this package alters interrupt
+// affinities. Therefore the interrupts file is read and parsed only
+// once, and the affinity of an interrupt is read only until its first
+// known value.
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/containers/nri-plugins/pkg/utils/cpuset"
+)
+
+// irqInfo is a numbered interrupt as parsed from the interrupts file,
+// without the allow pattern dependent denied flag.
+type irqInfo struct {
+	num         int
+	description string
+}
+
+// fileOps contains the replaceable file operations of the cache.
+type fileOps struct {
+	readFile  func(string) ([]byte, error)
+	writeFile func(string, []byte, os.FileMode) error
+}
+
+// irqCache caches interrupt data read from procfs and buffers
+// interrupt affinities to be written to procfs.
+type irqCache struct {
+	mu   sync.Mutex
+	proc string  // procfs mountpoint, all paths are built from this
+	ops  fileOps // file operations to use
+
+	info     map[int]irqInfo       // cached numbered interrupts, nil if not read
+	cpus     map[int]cpuset.CPUSet // affinities read from or set through the cache
+	pending  map[int]cpuset.CPUSet // affinities not yet written to procfs, empty if unblocked
+	readOnly map[int]bool          // interrupts whose affinity cannot be written
+
+	writeBlock int // writes to affinities are only buffered while positive
+}
+
+// cache is the interrupt cache of this package.
+var cache = newIrqCache()
+
+// newIrqCache returns a new interrupt cache with real procfs file
+// operations.
+func newIrqCache() *irqCache {
+	return &irqCache{
+		proc: proc,
+		ops: fileOps{
+			readFile:  os.ReadFile,
+			writeFile: os.WriteFile,
+		},
+		cpus:     map[int]cpuset.CPUSet{},
+		pending:  map[int]cpuset.CPUSet{},
+		readOnly: map[int]bool{},
+	}
+}
+
+// interruptsPath returns the path to the interrupts file in procfs.
+func interruptsPath(proc string) string {
+	return filepath.Join(proc, "interrupts")
+}
+
+// smpAffinityListPath returns the path to the smp_affinity_list file
+// of the given interrupt in procfs.
+func smpAffinityListPath(proc string, num int) string {
+	return filepath.Join(proc, "irq", strconv.Itoa(num), "smp_affinity_list")
+}
+
+// isReadOnlyAffinity returns whether the error of a failed affinity
+// write means that the affinity cannot be written at all.
+func isReadOnlyAffinity(err error) bool {
+	// Writing a read-only smp_affinity_list fails with EPERM, writing
+	// an affinity which the kernel manages fails with EIO.
+	return errors.Is(err, os.ErrPermission) ||
+		errors.Is(err, syscall.EIO) ||
+		errors.Is(err, syscall.EROFS)
+}
+
+// parseInterruptsLine returns the interrupt parsed from an interrupts
+// file line and whether the line described a numbered interrupt.
+func parseInterruptsLine(line string) (irqInfo, bool) {
+	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		return irqInfo{}, false
+	}
+	head, rest := fields[0], fields[1:]
+	if !strings.HasSuffix(head, ":") {
+		return irqInfo{}, false
+	}
+	num, err := strconv.Atoi(strings.TrimSuffix(head, ":"))
+	if err != nil {
+		return irqInfo{}, false
+	}
+	// Skip the leading per-CPU interrupt counters and keep the
+	// remaining chip and device description for matching.
+	descStart := len(rest)
+	for i, field := range rest {
+		if _, err := strconv.Atoi(field); err != nil {
+			descStart = i
+			break
+		}
+	}
+	return irqInfo{
+		num:         num,
+		description: strings.Join(rest[descStart:], " "),
+	}, true
+}
+
+// parseInterrupts returns the numbered interrupts parsed from the
+// contents of the interrupts file, keyed by interrupt number.
+func parseInterrupts(data []byte) map[int]irqInfo {
+	infos := map[int]irqInfo{}
+	for line := range strings.SplitSeq(string(data), "\n") {
+		if info, ok := parseInterruptsLine(line); ok {
+			infos[info.num] = info
+		}
+	}
+	return infos
+}
+
+// interruptInfo returns the numbered interrupts of the system, keyed by
+// interrupt number. The interrupts file is read and parsed only once.
+// The returned map is shared and never modified.
+func (c *irqCache) interruptInfo() (map[int]irqInfo, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.info != nil {
+		return c.info, nil
+	}
+
+	data, err := c.ops.readFile(interruptsPath(c.proc))
+	if err != nil {
+		// Failed reads are never cached.
+		return nil, err
+	}
+
+	c.info = parseInterrupts(data)
+	log.Debugf("cached %d numbered interrupts from %s", len(c.info), interruptsPath(c.proc))
+
+	return c.info, nil
+}
+
+// forEachInterrupt calls the given function on every numbered interrupt
+// of the system in interrupt number order, stopping early and returning
+// the error of the first failing call. Whether an interrupt is denied is
+// calculated from the given allow patterns:
+//   - fn: function to call on each interrupt.
+//   - allow: patterns which define the allowed interrupts.
+func (c *irqCache) forEachInterrupt(fn func(*Irq) error, allow []string) error {
+	infos, err := c.interruptInfo()
+	if err != nil {
+		return fmt.Errorf("failed to read interrupts: %w", err)
+	}
+	for _, num := range slices.Sorted(maps.Keys(infos)) {
+		// Mint a fresh Irq on every call: allow patterns, and hence
+		// denied flags, may have changed.
+		info := infos[num]
+		irq := &Irq{
+			num:         info.num,
+			description: info.description,
+			denied:      !isAllowedInterruptBy(info.description, allow),
+		}
+		if err := fn(irq); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// affinityOf returns the CPUs in the affinity of the given interrupt.
+// The affinity is read from procfs only until it is known, and
+// affinities set through the cache are visible before they have been
+// written to procfs.
+func (c *irqCache) affinityOf(num int) (cpuset.CPUSet, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if cpus, ok := c.cpus[num]; ok {
+		return cpus, nil
+	}
+
+	data, err := c.ops.readFile(smpAffinityListPath(c.proc, num))
+	if err != nil {
+		return cpuset.New(), fmt.Errorf("failed to read affinity of irq %d: %w", num, err)
+	}
+	cpus, err := cpuset.Parse(strings.TrimSpace(string(data)))
+	if err != nil {
+		return cpuset.New(), fmt.Errorf("failed to parse affinity of irq %d: %w", num, err)
+	}
+	c.cpus[num] = cpus
+
+	return cpus, nil
+}
+
+// setAffinity sets the CPUs in the affinity of the given interrupt.
+// While writes are blocked, the affinity is only buffered and no error
+// is returned. Otherwise it is written to procfs immediately.
+func (c *irqCache) setAffinity(num int, cpus cpuset.CPUSet) error {
+	c.mu.Lock()
+	if c.readOnly[num] {
+		// Unwritable, do not even try again.
+		c.mu.Unlock()
+		return nil
+	}
+	_, buffered := c.pending[num]
+	if known, ok := c.cpus[num]; ok && !buffered && known.Equals(cpus) {
+		// Already in procfs.
+		c.mu.Unlock()
+		return nil
+	}
+	// An unknown affinity, or buffered but not written yet.
+	c.cpus[num] = cpus
+	c.pending[num] = cpus
+
+	// Write now or later?
+	blocked := c.writeBlock > 0
+	c.mu.Unlock()
+
+	if blocked {
+		return nil
+	}
+	return c.writePending()
+}
+
+// blockWrites starts buffering interrupt affinities instead of writing
+// them to procfs.
+func (c *irqCache) blockWrites() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.writeBlock++
+}
+
+// unblockWrites removes one interrupt affinity write block, writing all
+// buffered affinities to procfs once the last block is removed.
+func (c *irqCache) unblockWrites() {
+	c.mu.Lock()
+	if c.writeBlock == 0 {
+		c.mu.Unlock()
+		log.Errorf("interrupt affinity write block counter went negative, keeping it at 0")
+		return
+	}
+	c.writeBlock--
+	blocked := c.writeBlock > 0
+	c.mu.Unlock()
+
+	if blocked {
+		return
+	}
+	if err := c.writePending(); err != nil {
+		log.Errorf("failed to write buffered interrupt affinities: %v", err)
+	}
+}
+
+// writePending writes all buffered interrupt affinities to procfs in
+// interrupt number order, returning the first error, if any.
+func (c *irqCache) writePending() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var firstErr error
+
+	for _, num := range slices.Sorted(maps.Keys(c.pending)) {
+		cpus := c.pending[num]
+		delete(c.pending, num)
+
+		err := c.ops.writeFile(smpAffinityListPath(c.proc, num), []byte(cpus.String()), 0644)
+		if err == nil {
+			log.Debugf("irq %d (%s) smp_affinity_list written: %s",
+				num, c.info[num].description, cpus)
+			continue
+		}
+
+		// Write failed. Forget the affinity, so that the next
+		// read falls back to procfs and the next update
+		// recalculates and retries.
+		delete(c.cpus, num)
+		if isReadOnlyAffinity(err) {
+			c.readOnly[num] = true
+			log.Warnf("irq %d (%s) affinity is read-only, not setting it again: %v",
+				num, c.info[num].description, err)
+		} else {
+			log.Warnf("failed to set affinity of irq %d (%s) to %q: %v",
+				num, c.info[num].description, cpus, err)
+		}
+		if firstErr == nil {
+			firstErr = fmt.Errorf("failed to set affinity of irq %d to %q: %w", num, cpus, err)
+		}
+	}
+
+	return firstErr
+}
+
+// reset drops all cached interrupt data, buffered affinities included,
+// and points the cache to the given procfs mountpoint. The write block
+// counter is not affected.
+func (c *irqCache) reset(procDir string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.proc = procDir
+	c.info = nil
+	c.cpus = map[int]cpuset.CPUSet{}
+	c.pending = map[int]cpuset.CPUSet{}
+	c.readOnly = map[int]bool{}
+}

--- a/pkg/irq/irq-cache_test.go
+++ b/pkg/irq/irq-cache_test.go
@@ -1,0 +1,738 @@
+// Copyright The NRI Plugins Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package irq
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+
+	"github.com/containers/nri-plugins/pkg/utils/cpuset"
+)
+
+// fakeProc is a fake procfs which counts reads and writes.
+type fakeProc struct {
+	mu       sync.Mutex
+	content  map[string]string
+	reads    map[string]int
+	writes   map[string]int
+	writeErr error
+}
+
+func newFakeProc() *fakeProc {
+	return &fakeProc{
+		content: map[string]string{},
+		reads:   map[string]int{},
+		writes:  map[string]int{},
+	}
+}
+
+func (f *fakeProc) set(path, content string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.content[path] = content
+}
+
+func (f *fakeProc) get(path string) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.content[path]
+}
+
+func (f *fakeProc) failWrites(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.writeErr = err
+}
+
+func (f *fakeProc) readCount(path string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.reads[path]
+}
+
+func (f *fakeProc) writeCount(path string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.writes[path]
+}
+
+func (f *fakeProc) totalReads() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	total := 0
+	for _, n := range f.reads {
+		total += n
+	}
+	return total
+}
+
+func (f *fakeProc) totalWrites() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	total := 0
+	for _, n := range f.writes {
+		total += n
+	}
+	return total
+}
+
+func (f *fakeProc) readFile(path string) ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reads[path]++
+	content, ok := f.content[path]
+	if !ok {
+		return nil, fmt.Errorf("%s: %w", path, os.ErrNotExist)
+	}
+	return []byte(content), nil
+}
+
+func (f *fakeProc) writeFile(path string, data []byte, _ os.FileMode) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.writes[path]++
+	if f.writeErr != nil {
+		return f.writeErr
+	}
+	f.content[path] = string(data)
+	return nil
+}
+
+const testInterrupts = `           CPU0       CPU1       CPU2       CPU3
+  1:          0          0     601604          0  IR-IO-APIC    1-edge      i8042
+  9:     236650          0          0          0  IR-IO-APIC    9-fasteoi   acpi
+ 16:          0          0         32          0  IR-IO-APIC   16-fasteoi   i801_smbus, processor_thermal_device_pci
+NMI:          0          0          0          0  Non-maskable interrupts
+LOC:     123456     123456     123456     123456  Local timer interrupts
+`
+
+// setupCache points the package to a fresh cache backed by a fake
+// procfs mounted at /proc, and undoes this when the test finishes.
+func setupCache(t *testing.T) *fakeProc {
+	t.Helper()
+
+	fake := newFakeProc()
+	fake.set("/proc/interrupts", testInterrupts)
+
+	oldCache, oldAllowed := cache, allowed
+	allowed = nil
+
+	SetProcRoot("")
+	cache = newIrqCache()
+	cache.ops = fileOps{readFile: fake.readFile, writeFile: fake.writeFile}
+
+	t.Cleanup(func() {
+		cache, allowed = oldCache, oldAllowed
+		SetProcRoot("")
+	})
+
+	return fake
+}
+
+// withWritesBlocked calls the given function between BlockWrites and
+// UnblockWrites.
+func withWritesBlocked(fn func()) {
+	BlockWrites()
+	defer UnblockWrites()
+	fn()
+}
+
+// writeBlock returns the write block counter of the cache.
+func writeBlock() int {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	return cache.writeBlock
+}
+
+// affinityPath returns the path of the smp_affinity_list file of the
+// given interrupt in the fake procfs.
+func affinityPath(num int) string {
+	return smpAffinityListPath("/proc", num)
+}
+
+// setAffinity sets the affinity of the given interrupt.
+func setAffinity(t *testing.T, num int, cpus string) {
+	t.Helper()
+	if err := (&Irq{num: num}).SetAffinityCpus(cpuset.MustParse(cpus)); err != nil {
+		t.Fatalf("SetAffinityCpus(%q) on irq %d failed: %v", cpus, num, err)
+	}
+}
+
+// getAffinity returns the affinity of the given interrupt.
+func getAffinity(t *testing.T, num int) string {
+	t.Helper()
+	cpus, err := (&Irq{num: num}).AffinityCpus()
+	if err != nil {
+		t.Fatalf("AffinityCpus() on irq %d failed: %v", num, err)
+	}
+	return cpus.String()
+}
+
+func TestInterruptsReadOnce(t *testing.T) {
+	fake := setupCache(t)
+
+	for i := range 5 {
+		irqs, err := Interrupts()
+		if err != nil {
+			t.Fatalf("round %d: Interrupts() failed: %v", i, err)
+		}
+		if len(irqs) != 3 {
+			t.Fatalf("round %d: expected 3 interrupts, got %d", i, len(irqs))
+		}
+		for n, num := range []int{1, 9, 16} {
+			if irqs[n].Num() != num {
+				t.Fatalf("round %d: interrupt %d is %d, expected %d", i, n, irqs[n].Num(), num)
+			}
+		}
+	}
+
+	if got := fake.readCount("/proc/interrupts"); got != 1 {
+		t.Errorf("expected 1 read of /proc/interrupts, got %d", got)
+	}
+}
+
+func TestAllowedPatternsCalculatedPerCall(t *testing.T) {
+	fake := setupCache(t)
+
+	first, err := Interrupts()
+	if err != nil {
+		t.Fatalf("Interrupts() failed: %v", err)
+	}
+	if len(first) != 3 {
+		t.Fatalf("expected 3 interrupts, got %d", len(first))
+	}
+
+	if _, err := SetAllowedInterrupts([]string{"*i8042*"}); err != nil {
+		t.Fatalf("SetAllowedInterrupts() failed: %v", err)
+	}
+
+	allowedIrqs, err := Interrupts()
+	if err != nil {
+		t.Fatalf("Interrupts() failed: %v", err)
+	}
+	if len(allowedIrqs) != 1 || allowedIrqs[0].Num() != 1 {
+		t.Errorf("expected only irq 1 to be allowed, got %v", allowedIrqs)
+	}
+
+	denied := map[int]bool{}
+	if err := ForEachInterrupt(func(irq *Irq) error {
+		denied[irq.Num()] = !irq.isAllowed()
+		return nil
+	}); err != nil {
+		t.Fatalf("ForEachInterrupt() failed: %v", err)
+	}
+	if denied[1] || !denied[9] || !denied[16] {
+		t.Errorf("unexpected denied flags: %v", denied)
+	}
+
+	if _, err := SetAllowedInterrupts(nil); err != nil {
+		t.Fatalf("SetAllowedInterrupts() failed: %v", err)
+	}
+
+	last, err := Interrupts()
+	if err != nil {
+		t.Fatalf("Interrupts() failed: %v", err)
+	}
+	if len(last) != 3 {
+		t.Errorf("expected 3 interrupts, got %d", len(last))
+	}
+
+	// Interrupts must never be shared between calls: callers would see
+	// each other's denied flags.
+	if first[0] == last[0] {
+		t.Errorf("Interrupts() returned the same *Irq on two calls")
+	}
+
+	if got := fake.readCount("/proc/interrupts"); got != 1 {
+		t.Errorf("expected 1 read of /proc/interrupts, got %d", got)
+	}
+}
+
+func TestAffinityReadOnceAndBlockedWrite(t *testing.T) {
+	fake := setupCache(t)
+	path := affinityPath(42)
+	fake.set(path, "0-3\n")
+
+	if got := getAffinity(t, 42); got != "0-3" {
+		t.Errorf("AffinityCpus() = %q, want 0-3", got)
+	}
+	if got := getAffinity(t, 42); got != "0-3" {
+		t.Errorf("AffinityCpus() = %q, want 0-3", got)
+	}
+	if got := fake.readCount(path); got != 1 {
+		t.Errorf("expected 1 read of %s, got %d", path, got)
+	}
+
+	BlockWrites()
+	setAffinity(t, 42, "1,3")
+
+	// The affinity set is visible immediately, without reading procfs,
+	// even though procfs still has the old value.
+	if got := getAffinity(t, 42); got != "1,3" {
+		t.Errorf("AffinityCpus() after set = %q, want 1,3", got)
+	}
+	if got := fake.readCount(path); got != 1 {
+		t.Errorf("expected 1 read of %s, got %d", path, got)
+	}
+	if got := fake.get(path); got != "0-3\n" {
+		t.Errorf("procfs content = %q, want it unwritten yet", got)
+	}
+
+	UnblockWrites()
+	if got := fake.get(path); got != "1,3" {
+		t.Errorf("procfs content after unblocking = %q, want 1,3", got)
+	}
+	if got := fake.writeCount(path); got != 1 {
+		t.Errorf("expected 1 write of %s, got %d", path, got)
+	}
+}
+
+func TestBlockedWritesCoalesced(t *testing.T) {
+	fake := setupCache(t)
+	path := affinityPath(42)
+	fake.set(path, "0-3")
+
+	BlockWrites()
+	for _, cpus := range []string{"0", "1", "2", "0-1", "3"} {
+		setAffinity(t, 42, cpus)
+	}
+	if got := fake.writeCount(path); got != 0 {
+		t.Errorf("expected no writes while blocked, got %d", got)
+	}
+
+	UnblockWrites()
+	if got := fake.writeCount(path); got != 1 {
+		t.Errorf("expected 1 write of %s, got %d", path, got)
+	}
+	if got := fake.get(path); got != "3" {
+		t.Errorf("procfs content = %q, want the last affinity 3", got)
+	}
+}
+
+func TestNestedWriteBlocksWriteAtLastUnblock(t *testing.T) {
+	fake := setupCache(t)
+	path := affinityPath(42)
+	fake.set(path, "0-3")
+
+	BlockWrites()
+	withWritesBlocked(func() {
+		withWritesBlocked(func() {
+			setAffinity(t, 42, "0")
+		})
+		if got := writeBlock(); got != 2 {
+			t.Errorf("write block counter = %d, want 2", got)
+		}
+		if got := fake.writeCount(path); got != 0 {
+			t.Errorf("expected no writes at write block 2, got %d", got)
+		}
+		setAffinity(t, 42, "1")
+	})
+	if got := fake.writeCount(path); got != 0 {
+		t.Errorf("expected no writes at write block 1, got %d", got)
+	}
+
+	UnblockWrites()
+	if got := writeBlock(); got != 0 {
+		t.Errorf("write block counter = %d, want 0", got)
+	}
+	if got := fake.writeCount(path); got != 1 {
+		t.Errorf("expected 1 write of %s, got %d", path, got)
+	}
+	if got := fake.get(path); got != "1" {
+		t.Errorf("procfs content = %q, want the last affinity 1", got)
+	}
+}
+
+func TestUnblockedWriteIsImmediate(t *testing.T) {
+	fake := setupCache(t)
+	path := affinityPath(42)
+	fake.set(path, "0-3")
+
+	setAffinity(t, 42, "1,3")
+	if got := fake.get(path); got != "1,3" {
+		t.Errorf("procfs content = %q, want 1,3 written immediately", got)
+	}
+
+	// Write errors are returned when writes are not blocked.
+	fake.failWrites(errors.New("test write error"))
+	if err := (&Irq{num: 42}).SetAffinityCpus(cpuset.MustParse("2")); err == nil {
+		t.Errorf("SetAffinityCpus() succeeded despite a failing write")
+	}
+}
+
+func TestUnbalancedUnblockWrites(t *testing.T) {
+	fake := setupCache(t)
+	path := affinityPath(42)
+	fake.set(path, "0-3")
+
+	UnblockWrites()
+	if got := writeBlock(); got != 0 {
+		t.Errorf("write block counter = %d, want 0", got)
+	}
+
+	// Blocking must still work after an unbalanced unblock.
+	withWritesBlocked(func() {
+		setAffinity(t, 42, "1")
+		if got := fake.writeCount(path); got != 0 {
+			t.Errorf("expected no writes while blocked, got %d", got)
+		}
+	})
+	if got := fake.get(path); got != "1" {
+		t.Errorf("procfs content = %q, want 1", got)
+	}
+}
+
+func TestUnchangedAffinityNotWritten(t *testing.T) {
+	fake := setupCache(t)
+	path := affinityPath(42)
+	fake.set(path, "0-3")
+
+	if got := getAffinity(t, 42); got != "0-3" {
+		t.Fatalf("AffinityCpus() = %q, want 0-3", got)
+	}
+
+	withWritesBlocked(func() {
+		setAffinity(t, 42, "0-3")
+	})
+	if got := fake.writeCount(path); got != 0 {
+		t.Errorf("expected no writes of %s, got %d", path, got)
+	}
+}
+
+func TestFailedWriteForgottenAndRetried(t *testing.T) {
+	fake := setupCache(t)
+	path := affinityPath(42)
+	fake.set(path, "0-3")
+	fake.failWrites(errors.New("test write error"))
+
+	if got := getAffinity(t, 42); got != "0-3" {
+		t.Fatalf("AffinityCpus() = %q, want 0-3", got)
+	}
+	if err := (&Irq{num: 42}).SetAffinityCpus(cpuset.MustParse("1,3")); err == nil {
+		t.Errorf("SetAffinityCpus() succeeded despite a failing write")
+	}
+	if got := fake.writeCount(path); got != 1 {
+		t.Errorf("expected 1 write attempt of %s, got %d", path, got)
+	}
+
+	// The failed affinity must be forgotten: reads fall back to procfs
+	// and the next update retries the write.
+	if got := getAffinity(t, 42); got != "0-3" {
+		t.Errorf("AffinityCpus() after a failed write = %q, want 0-3 from procfs", got)
+	}
+	if got := fake.readCount(path); got != 2 {
+		t.Errorf("expected 2 reads of %s, got %d", path, got)
+	}
+
+	fake.failWrites(nil)
+	setAffinity(t, 42, "1,3")
+	if got := fake.get(path); got != "1,3" {
+		t.Errorf("procfs content = %q, want 1,3", got)
+	}
+}
+
+func TestReadOnlyAffinityWrittenOnce(t *testing.T) {
+	fake := setupCache(t)
+	unread, read := affinityPath(42), affinityPath(9)
+	fake.set(unread, "0-3")
+	fake.set(read, "0-1")
+	fake.failWrites(syscall.EPERM)
+
+	// One affinity is already known when its write fails, the other is
+	// not. Both must end up reporting what procfs has.
+	if got := getAffinity(t, 9); got != "0-1" {
+		t.Fatalf("AffinityCpus() = %q, want 0-1", got)
+	}
+	withWritesBlocked(func() {
+		setAffinity(t, 42, "1,3")
+		setAffinity(t, 9, "2")
+	})
+	if got := getAffinity(t, 42); got != "0-3" {
+		t.Errorf("AffinityCpus() = %q, want 0-3 from procfs", got)
+	}
+	if got := getAffinity(t, 9); got != "0-1" {
+		t.Errorf("AffinityCpus() = %q, want 0-1 from procfs", got)
+	}
+
+	// Read-only affinities are not written again.
+	withWritesBlocked(func() {
+		for _, cpus := range []string{"1", "2", "0-3"} {
+			setAffinity(t, 42, cpus)
+			setAffinity(t, 9, cpus)
+		}
+	})
+	for _, path := range []string{unread, read} {
+		if got := fake.writeCount(path); got != 1 {
+			t.Errorf("expected 1 write attempt of %s, got %d", path, got)
+		}
+	}
+}
+
+func TestSetProcRootInvalidates(t *testing.T) {
+	fake := setupCache(t)
+	fake.set(affinityPath(1), "0-3")
+
+	if _, err := Interrupts(); err != nil {
+		t.Fatalf("Interrupts() failed: %v", err)
+	}
+	if got := getAffinity(t, 1); got != "0-3" {
+		t.Fatalf("AffinityCpus() = %q, want 0-3", got)
+	}
+
+	fake.set("/host/proc/interrupts", strings.ReplaceAll(testInterrupts, "acpi", "hostacpi"))
+	fake.set(smpAffinityListPath("/host/proc", 1), "2,3")
+
+	SetProcRoot("/host")
+
+	irqs, err := Interrupts()
+	if err != nil {
+		t.Fatalf("Interrupts() failed: %v", err)
+	}
+	found := false
+	for _, irq := range irqs {
+		if strings.Contains(irq.Description(), "hostacpi") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("interrupts not re-read after SetProcRoot: %v", irqs)
+	}
+	if got := getAffinity(t, 1); got != "2-3" {
+		t.Errorf("AffinityCpus() after SetProcRoot = %q, want 2-3", got)
+	}
+}
+
+func TestSetProcRootDropsBufferedWrites(t *testing.T) {
+	fake := setupCache(t)
+	path := affinityPath(42)
+	fake.set(path, "0-3")
+
+	BlockWrites()
+	setAffinity(t, 42, "1,3")
+	SetProcRoot("/host")
+	UnblockWrites()
+
+	if got := fake.totalWrites(); got != 0 {
+		t.Errorf("expected buffered writes to be dropped, got %d writes", got)
+	}
+	if got := fake.get(path); got != "0-3" {
+		t.Errorf("procfs content = %q, want the untouched 0-3", got)
+	}
+}
+
+func TestDropCache(t *testing.T) {
+	fake := setupCache(t)
+	path := affinityPath(1)
+	fake.set(path, "0-3")
+
+	if _, err := Interrupts(); err != nil {
+		t.Fatalf("Interrupts() failed: %v", err)
+	}
+	if got := getAffinity(t, 1); got != "0-3" {
+		t.Fatalf("AffinityCpus() = %q, want 0-3", got)
+	}
+
+	BlockWrites()
+	setAffinity(t, 1, "1")
+	DropCache()
+	UnblockWrites()
+
+	if got := fake.totalWrites(); got != 0 {
+		t.Errorf("expected buffered writes to be dropped, got %d writes", got)
+	}
+	if _, err := Interrupts(); err != nil {
+		t.Fatalf("Interrupts() failed: %v", err)
+	}
+	if got := getAffinity(t, 1); got != "0-3" {
+		t.Errorf("AffinityCpus() = %q, want 0-3 read again from procfs", got)
+	}
+	if got := fake.readCount("/proc/interrupts"); got != 2 {
+		t.Errorf("expected 2 reads of /proc/interrupts, got %d", got)
+	}
+	if got := fake.readCount(path); got != 2 {
+		t.Errorf("expected 2 reads of %s, got %d", path, got)
+	}
+}
+
+func TestCallbackReentrancy(t *testing.T) {
+	fake := setupCache(t)
+	for _, num := range []int{1, 9, 16} {
+		fake.set(affinityPath(num), "0-3")
+	}
+
+	// A callback which reads and writes affinities must not deadlock.
+	withWritesBlocked(func() {
+		err := ForEachInterrupt(func(irq *Irq) error {
+			cpus, err := irq.AffinityCpus()
+			if err != nil {
+				return err
+			}
+			return irq.SetAffinityCpus(cpus.Union(cpuset.MustParse("4")))
+		})
+		if err != nil {
+			t.Fatalf("ForEachInterrupt() failed: %v", err)
+		}
+	})
+
+	for _, num := range []int{1, 9, 16} {
+		if got := fake.get(affinityPath(num)); got != "0-4" {
+			t.Errorf("irq %d procfs content = %q, want 0-4", num, got)
+		}
+	}
+}
+
+func TestAffinityErrorsNeverWrite(t *testing.T) {
+	fake := setupCache(t)
+	fake.set(affinityPath(42), "0-3")
+
+	if err := (&Irq{num: 42}).SetAffinityCpus(cpuset.New()); err == nil {
+		t.Errorf("SetAffinityCpus(empty) should fail")
+	}
+
+	err := (&Irq{num: 42, denied: true}).SetAffinityCpus(cpuset.MustParse("1"))
+	if !errors.Is(err, ErrDeniedInterrupt) {
+		t.Errorf("SetAffinityCpus() on a denied irq: %v, want %v", err, ErrDeniedInterrupt)
+	}
+
+	if got := fake.totalWrites(); got != 0 {
+		t.Errorf("expected no writes, got %d", got)
+	}
+}
+
+func TestFailedReadNotCached(t *testing.T) {
+	fake := setupCache(t)
+
+	fake.mu.Lock()
+	delete(fake.content, "/proc/interrupts")
+	fake.mu.Unlock()
+
+	if _, err := Interrupts(); err == nil {
+		t.Errorf("Interrupts() succeeded without /proc/interrupts")
+	}
+	if _, err := (&Irq{num: 42}).AffinityCpus(); err == nil {
+		t.Errorf("AffinityCpus() succeeded without smp_affinity_list")
+	}
+
+	fake.set("/proc/interrupts", testInterrupts)
+	fake.set(affinityPath(42), "0-3")
+
+	if irqs, err := Interrupts(); err != nil || len(irqs) != 3 {
+		t.Errorf("Interrupts() = %v, %v, want 3 interrupts", irqs, err)
+	}
+	if got := getAffinity(t, 42); got != "0-3" {
+		t.Errorf("AffinityCpus() = %q, want 0-3", got)
+	}
+}
+
+func TestConcurrentInterruptReaders(t *testing.T) {
+	fake := setupCache(t)
+	path := affinityPath(1)
+	fake.set(path, "0-3")
+
+	// Interrupts are read while validating a configuration, which
+	// happens in the agent goroutine, in parallel with a policy which
+	// sets affinities.
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 50 {
+				if _, err := ValidateAllowedReferencedInterrupts(
+					[]string{"*acpi*"}, []string{"*i8042*"},
+				); err == nil {
+					t.Error("ValidateAllowedReferencedInterrupts() accepted a denied interrupt")
+					return
+				}
+			}
+		}()
+	}
+
+	for pass := range 50 {
+		withWritesBlocked(func() {
+			setAffinity(t, 1, fmt.Sprintf("%d", pass%4))
+		})
+	}
+	wg.Wait()
+
+	if got := fake.readCount("/proc/interrupts"); got != 1 {
+		t.Errorf("expected 1 read of /proc/interrupts, got %d", got)
+	}
+	if got := fake.get(path); got != "1" {
+		t.Errorf("procfs content = %q, want the last affinity 1", got)
+	}
+}
+
+func TestReadWriteAmplification(t *testing.T) {
+	var (
+		irqCount  = 300
+		passCount = 101
+		fake      = setupCache(t)
+		sb        = strings.Builder{}
+	)
+
+	sb.WriteString("           CPU0       CPU1\n")
+	for num := range irqCount {
+		fmt.Fprintf(&sb, "%3d:          0          0  IR-IO-APIC  %d-edge  dev%d\n", num, num, num)
+		fake.set(affinityPath(num), "0-3")
+	}
+	fake.set("/proc/interrupts", sb.String())
+
+	// Mimic a policy synchronization: many nested passes over all
+	// interrupts, reading and writing the affinity of each.
+	BlockWrites()
+	for pass := range passCount {
+		withWritesBlocked(func() {
+			irqs, err := Interrupts()
+			if err != nil {
+				t.Fatalf("pass %d: Interrupts() failed: %v", pass, err)
+			}
+			if len(irqs) != irqCount {
+				t.Fatalf("pass %d: expected %d interrupts, got %d", pass, irqCount, len(irqs))
+			}
+			// Every pass sets a different affinity, just like a policy
+			// which resizes its CPU pools while allocating containers.
+			newCpus := cpuset.MustParse(fmt.Sprintf("%d", pass%4))
+			for _, irq := range irqs {
+				if _, err := irq.AffinityCpus(); err != nil {
+					t.Fatalf("pass %d: AffinityCpus() failed: %v", pass, err)
+				}
+				if err := irq.SetAffinityCpus(newCpus); err != nil {
+					t.Fatalf("pass %d: SetAffinityCpus() failed: %v", pass, err)
+				}
+			}
+		})
+	}
+
+	if got := fake.readCount("/proc/interrupts"); got != 1 {
+		t.Errorf("expected 1 read of /proc/interrupts, got %d", got)
+	}
+	if got, want := fake.totalReads(), 1+irqCount; got != want {
+		t.Errorf("expected %d reads in total, got %d", want, got)
+	}
+	if got := fake.totalWrites(); got != 0 {
+		t.Errorf("expected no writes while blocked, got %d", got)
+	}
+
+	UnblockWrites()
+	if got := fake.totalWrites(); got != irqCount {
+		t.Errorf("expected %d writes, got %d", irqCount, got)
+	}
+}

--- a/pkg/irq/irq.go
+++ b/pkg/irq/irq.go
@@ -15,16 +15,20 @@
 // irq package provides low-level functions to read interrupts from
 // /proc/interrupts and to read and write CPU affinities of interrupts
 // through /proc/irq/NUMBER/smp_affinity_list.
+//
+// Interrupt data read from procfs is cached, which assumes that
+// interrupts are neither added nor removed at runtime and that no
+// entity outside this package alters interrupt affinities. Affinities
+// set between BlockWrites and UnblockWrites are buffered, and only
+// the affinity set last for an interrupt reaches procfs.
 package irq
 
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path"
 	"path/filepath"
 	"strconv"
-	"strings"
 
 	logger "github.com/containers/nri-plugins/pkg/log"
 	"github.com/containers/nri-plugins/pkg/utils/cpuset"
@@ -39,11 +43,13 @@ var (
 	allowed []string
 
 	// ErrDeniedInterrupt is the error returned for attempts to reference or control
-	// globally globally disallowed interrupts.
+	// globally disallowed interrupts.
 	ErrDeniedInterrupt = errors.New("denied interrupt")
 )
 
-// SetProcRoot sets the procfs root directory and proc mountpoint.
+// SetProcRoot sets the procfs root directory and proc mountpoint. All
+// data cached from the previous mountpoint is dropped, including
+// buffered interrupt affinities.
 func SetProcRoot(root string) {
 	if root != "" {
 		procRoot = filepath.Clean(root)
@@ -61,6 +67,28 @@ func SetProcRoot(root string) {
 		procRoot = ""
 	}
 	proc = filepath.Join(procRoot, "/proc")
+	cache.reset(proc)
+}
+
+// DropCache drops all cached interrupt data: the interrupts read from
+// the interrupts file, the affinities read from or written to procfs,
+// and the affinities which are buffered but not written yet.
+func DropCache() {
+	cache.reset(proc)
+}
+
+// BlockWrites starts buffering interrupt affinities instead of writing
+// them to procfs. Every call must be paired with an UnblockWrites call,
+// and the calls may be nested.
+func BlockWrites() {
+	cache.blockWrites()
+}
+
+// UnblockWrites removes one write block set by BlockWrites. Removing
+// the last block writes all buffered interrupt affinities to procfs,
+// logging write errors instead of returning them.
+func UnblockWrites() {
+	cache.unblockWrites()
 }
 
 // ValidateAllowedPatterns validates zero or more globbing patterns
@@ -138,22 +166,7 @@ func ForEachInterrupt(fn func(*Irq) error) error {
 // to determine if an interrupt is allowed to be controlled
 // by this package.
 func forEachInterrupt(fn func(*Irq) error, allow []string) error {
-	data, err := os.ReadFile(filepath.Join(proc, "interrupts"))
-	if err != nil {
-		return fmt.Errorf("failed to read interrupts: %w", err)
-	}
-	for line := range strings.SplitSeq(string(data), "\n") {
-		if irq, ok := parseInterruptsLine(line); ok {
-			if !isAllowedInterruptBy(irq.description, allow) {
-				irq.denied = true
-			}
-			if err := fn(irq); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-
+	return cache.forEachInterrupt(fn, allow)
 }
 
 // Interrupts collects and returns the numbered interrupts listed in
@@ -226,37 +239,6 @@ func ValidateReferencedInterrupts(references []string) ([]*Irq, error) {
 	return denied, err
 }
 
-// parseInterruptsLine returns the interrupt parsed from a
-// /proc/interrupts line and whether the line described a numbered
-// interrupt.
-func parseInterruptsLine(line string) (*Irq, bool) {
-	fields := strings.Fields(line)
-	if len(fields) < 2 {
-		return nil, false
-	}
-	head, rest := fields[0], fields[1:]
-	if !strings.HasSuffix(head, ":") {
-		return nil, false
-	}
-	num, err := strconv.Atoi(strings.TrimSuffix(head, ":"))
-	if err != nil {
-		return nil, false
-	}
-	// Skip the leading per-CPU interrupt counters and keep the
-	// remaining chip and device description for matching.
-	descStart := len(rest)
-	for i, field := range rest {
-		if _, err := strconv.Atoi(field); err != nil {
-			descStart = i
-			break
-		}
-	}
-	return &Irq{
-		num:         num,
-		description: strings.Join(rest[descStart:], " "),
-	}, true
-}
-
 // Num returns the number of the interrupt.
 func (irq *Irq) Num() int {
 	return irq.num
@@ -290,20 +272,16 @@ func (irq *Irq) isAllowed() bool {
 	return !irq.denied
 }
 
-// AffinityCpus returns the CPUs in the affinity of the interrupt.
+// AffinityCpus returns the CPUs in the affinity of the interrupt. The
+// returned CPUs are the ones set last through this package, even if
+// they have not reached procfs yet.
 func (irq *Irq) AffinityCpus() (cpuset.CPUSet, error) {
-	data, err := os.ReadFile(irq.smpAffinityListPath())
-	if err != nil {
-		return cpuset.New(), fmt.Errorf("failed to read affinity of irq %d: %w", irq.num, err)
-	}
-	cpus, err := cpuset.Parse(strings.TrimSpace(string(data)))
-	if err != nil {
-		return cpuset.New(), fmt.Errorf("failed to parse affinity of irq %d: %w", irq.num, err)
-	}
-	return cpus, nil
+	return cache.affinityOf(irq.num)
 }
 
 // SetAffinityCpus sets the CPUs in the affinity of the interrupt.
+// While writes are blocked, the affinity is only buffered and write
+// errors are logged instead of being returned.
 func (irq *Irq) SetAffinityCpus(cpus cpuset.CPUSet) error {
 	if !irq.isAllowed() {
 		return fmt.Errorf("%w: refusing to set affinity of irq %d", ErrDeniedInterrupt, irq.num)
@@ -311,15 +289,5 @@ func (irq *Irq) SetAffinityCpus(cpus cpuset.CPUSet) error {
 	if cpus.IsEmpty() {
 		return fmt.Errorf("refusing to set empty affinity on irq %d", irq.num)
 	}
-	if err := os.WriteFile(irq.smpAffinityListPath(), []byte(cpus.String()), 0644); err != nil {
-		return fmt.Errorf("failed to set affinity of irq %d to %q: %w", irq.num, cpus, err)
-	}
-	log.Debugf("irq %s smp_affinity_list written: %s", irq, cpus)
-	return nil
-}
-
-// smpAffinityListPath returns the path to the smp_affinity_list file
-// of the interrupt.
-func (irq *Irq) smpAffinityListPath() string {
-	return filepath.Join(proc, "irq", strconv.Itoa(irq.num), "smp_affinity_list")
+	return cache.setAffinity(irq.num, cpus)
 }


### PR DESCRIPTION
Add procfs read/write caching to the irq package.
- Always cache reads, data cached in parsed format.
- Write caching (buffering) is controlled with BlockWrites() / UnblockWrites(). Buffered writes are synchronously written when all writes are unblocked.
- If a write fails because IRQ affinity cannot be controlled from userspace, don't try writing that affinity again.
- DropCache() forgets everything: what was read, what was write-buffered, what had failed.