### PR TITLE
e2e: add test config forgotten from PR #751.

### DIFF
--- a/test/e2e/policies.test-suite/balloons/n4c16/test25-irq/balloons-denied-irq-claim.cfg
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test25-irq/balloons-denied-irq-claim.cfg
@@ -1,0 +1,19 @@
+config:
+  reservedResources:
+    cpu: 1000m
+  pinCPU: true
+  pinMemory: true
+  controllableInterrupts: [ "*rtc0*" ]
+  balloonTypes:
+    - name: claimer
+      minCPUs: 2
+      maxCPUs: 2
+      irqClaim:
+        - "*ttyS0*"
+        - "*rtc0*"
+  log:
+    debug:
+      - policy
+      - irq
+    klog:
+      skip_headers: true


### PR DESCRIPTION
Add missing IRQ-restricted test balloons config, forgotten from PR #751.