### PR TITLE
e2e: add missing balloons denied irq claim config

### DIFF
--- a/test/e2e/policies.test-suite/balloons/n4c16/test25-irq/balloons-denied-irq-claim.cfg
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test25-irq/balloons-denied-irq-claim.cfg
@@ -1,0 +1,21 @@
+config:
+  reservedResources:
+    cpu: 1000m
+  pinCPU: true
+  pinMemory: true
+  # Only acpi interrupts are controllable, yet the claimer balloon type
+  # below claims ttyS0. The configuration must be rejected.
+  controllableInterrupts:
+    - "*acpi*"
+  balloonTypes:
+    - name: claimer
+      minCPUs: 2
+      maxCPUs: 2
+      irqClaim:
+        - "*ttyS0*"
+  log:
+    debug:
+      - policy
+      - irq
+    klog:
+      skip_headers: true


### PR DESCRIPTION
test25-irq launches the policy with balloons-denied-irq-claim.cfg to check that claiming an interrupt outside controllableInterrupts is rejected, but the configuration file was never added.