### PR TITLE
build: drop deprecated golint from the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,6 @@ GO_CMD     := go
 GO_BUILD    = $(GO_CMD) build $(BUILD_FLAGS)
 GO_INSTALL := $(GO_CMD) install
 GO_TEST    := $(GO_CMD) test
-GO_LINT    := golint -set_exit_status
 GO_FMT     := gofmt
 GO_VET     := $(GO_CMD) vet
 GO_DEPS    := $(GO_CMD) list -f '{{ join .Deps "\n" }}'
@@ -439,8 +438,7 @@ fmt format:
 reformat:
 	$(Q)$(GO_FMT) -s -d -w $$(git ls-files '*.go')
 
-lint:
-	$(Q)$(GO_LINT) -set_exit_status ./...
+lint: golangci-lint
 
 vet:
 	$(Q)$(GO_VET) ./...


### PR DESCRIPTION
golint was deprecated by the Go team in 2020. The lint target was the only user of it, and CI does not call it. Point make lint at golangci-lint, which CI already runs, and remove the GO_LINT variable.