### PR TITLE
topology-aware: add support for claiming device-hinted IRQs.

### DIFF
--- a/cmd/plugins/topology-aware/policy/irq-affinity.go
+++ b/cmd/plugins/topology-aware/policy/irq-affinity.go
@@ -16,16 +16,19 @@ package topologyaware
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/containers/nri-plugins/pkg/irq"
+	"github.com/containers/nri-plugins/pkg/topology"
 	"github.com/containers/nri-plugins/pkg/utils/cpuset"
 	"sigs.k8s.io/yaml"
 )
 
 type IrqAffinity struct {
-	Claim []string `json:"claim,omitempty"`
-	Mask  []string `json:"mask,omitempty"`
-	Mode  IrqMode  `json:"mode,omitempty"`
+	Claim   []string `json:"claim,omitempty"`
+	Devices []string `json:"devices,omitempty"`
+	Mask    []string `json:"mask,omitempty"`
+	Mode    IrqMode  `json:"mode,omitempty"`
 }
 
 type IrqMode string
@@ -58,6 +61,49 @@ func parseIrqAffinity(raw []byte) (*IrqAffinity, error) {
 	}
 
 	return parsed, nil
+}
+
+func addIrqAffinityForHints(a *IrqAffinity, hints topology.Hints) error {
+	if len(hints) == 0 || a == nil || len(a.Devices) == 0 {
+		return nil
+	}
+
+	if err := irq.ValidateAllowedPatterns(a.Devices); err != nil {
+		return fmt.Errorf("invalid IRQ affinity devices pattern: %w", err)
+	}
+
+	for source, h := range hints {
+		for _, num := range h.IRQs {
+			irq, err := irq.Interrupt(num)
+			switch {
+			case err != nil:
+				log.Errorf("irq: skipping %s-hinted IRQ %d: %v", source, num, err)
+				continue
+			case !irq.IsAllowed():
+				log.Warnf("irq: skipping denied %s-hinted IRQ %d", source, num)
+				continue
+			}
+
+			matched := false
+			for _, p := range a.Devices {
+				if irq.Match(p) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				log.Debugf("irq: skipping unmatched %s-hinted IRQ %d (%q)",
+					source, num, irq.Description())
+				continue
+			}
+
+			log.Infof("irq: claim matching %s-hinted IRQ %d (%q)",
+				source, num, irq.Description())
+			a.Claim = append(a.Claim, strconv.Itoa(irq.Num()))
+		}
+	}
+
+	return nil
 }
 
 func (p *policy) irqCpus(hwIrq *irq.Irq) (preMask, claim, mask cpuset.CPUSet) {

--- a/cmd/plugins/topology-aware/policy/pod-preferences.go
+++ b/cmd/plugins/topology-aware/policy/pod-preferences.go
@@ -330,6 +330,10 @@ func irqAffinityPreference(ctr cache.Container) (*IrqAffinity, bool, error) {
 
 	switch {
 	case qos == corev1.PodQOSGuaranteed:
+		err := addIrqAffinityForHints(a, ctr.GetTopologyHints())
+		if err != nil {
+			return nil, scope == cache.ContainerScopedAnnotation, err
+		}
 		return a, scope == cache.ContainerScopedAnnotation, nil
 	case scope == cache.ContainerScopedAnnotation:
 		return nil, true, fmt.Errorf("invalid IRQ affinity, QoS class %v is not Guaranteed", qos)

--- a/docs/resource-policy/policy/topology-aware.md
+++ b/docs/resource-policy/policy/topology-aware.md
@@ -739,7 +739,7 @@ Containers eligible for exclusive CPU allocation can be annotated with IRQ
 tuning to claim selected IRQs, mask selected IRQs, or do both, using the
 `irq-affinity.resource-policy.nri.io` annotation key.
 
-The annotation has 3 fields:
+The annotation has 4 fields:
 **`claim`** (list of strings)
 - Lists IRQs handled by the exclusive CPUs allocated to the container.
 - Each item refers to IRQs either by an exact number, or by a pattern
@@ -747,6 +747,9 @@ The annotation has 3 fields:
   instance "*nvme*".
 - The affinity of a claimed IRQ is set to the union of CPUs of all
   containers that claim it.
+**`devices`** (list of strings)
+- The same as `claim`, but listed IRQs match only devices assigned to
+  the container instead of all devices in the system.
 **`mask`** (list of strings)
 - Lists IRQs which should not be handled by the exclusive CPUs allocated
   to the container.

--- a/pkg/irq/irq-cache.go
+++ b/pkg/irq/irq-cache.go
@@ -197,6 +197,25 @@ func (c *irqCache) forEachInterrupt(fn func(*Irq) error, allow []string) error {
 	return nil
 }
 
+// irqByNum returns the interrupt for the given IRQ number.
+func (c *irqCache) irqByNum(num int, allow []string) (*Irq, error) {
+	infos, err := c.interruptInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	info, ok := infos[num]
+	if !ok {
+		return nil, fmt.Errorf("%w: irq %d not found", ErrNoSuchInterrupt, num)
+	}
+
+	return &Irq{
+		num:         info.num,
+		description: info.description,
+		denied:      !isAllowedInterruptBy(info.description, allow),
+	}, nil
+}
+
 // affinityOf returns the CPUs in the affinity of the given interrupt.
 // The affinity is read from procfs only until it is known, and
 // affinities set through the cache are visible before they have been

--- a/pkg/irq/irq-cache_test.go
+++ b/pkg/irq/irq-cache_test.go
@@ -233,7 +233,7 @@ func TestAllowedPatternsCalculatedPerCall(t *testing.T) {
 
 	denied := map[int]bool{}
 	if err := ForEachInterrupt(func(irq *Irq) error {
-		denied[irq.Num()] = !irq.isAllowed()
+		denied[irq.Num()] = !irq.IsAllowed()
 		return nil
 	}); err != nil {
 		t.Fatalf("ForEachInterrupt() failed: %v", err)

--- a/pkg/irq/irq.go
+++ b/pkg/irq/irq.go
@@ -45,6 +45,9 @@ var (
 	// ErrDeniedInterrupt is the error returned for attempts to reference or control
 	// globally disallowed interrupts.
 	ErrDeniedInterrupt = errors.New("denied interrupt")
+	// ErrNoSuchInterrupt is the error returned for attempts to look up a
+	// nonexistent interrupt by number.
+	ErrNoSuchInterrupt = errors.New("no such interrupt")
 )
 
 // SetProcRoot sets the procfs root directory and proc mountpoint. All
@@ -176,6 +179,12 @@ func Interrupts() ([]*Irq, error) {
 	return allowedInterrupts(allowed)
 }
 
+// Interrupt returns the IRQ corresponding to the given interrupt number.
+func Interrupt(num int) (*Irq, error) {
+	irq, err := cache.irqByNum(num, allowed)
+	return irq, err
+}
+
 // allowedInterrupts collects and returns the numbered interrupts
 // listed in /proc/interrupts which can be controlled by this package
 // according to the given allow patterns.
@@ -268,7 +277,10 @@ func (irq *Irq) Match(pattern string) bool {
 	return err == nil && match
 }
 
-func (irq *Irq) isAllowed() bool {
+// IsAllowed returns true if this interrupt may be controlled
+// by the package according to the allow patterns in effect
+// when the Irq was introspected.
+func (irq *Irq) IsAllowed() bool {
 	return !irq.denied
 }
 
@@ -283,7 +295,7 @@ func (irq *Irq) AffinityCpus() (cpuset.CPUSet, error) {
 // While writes are blocked, the affinity is only buffered and write
 // errors are logged instead of being returned.
 func (irq *Irq) SetAffinityCpus(cpus cpuset.CPUSet) error {
-	if !irq.isAllowed() {
+	if !irq.IsAllowed() {
 		return fmt.Errorf("%w: refusing to set affinity of irq %d", ErrDeniedInterrupt, irq.num)
 	}
 	if cpus.IsEmpty() {

--- a/pkg/irq/irq_test.go
+++ b/pkg/irq/irq_test.go
@@ -15,6 +15,7 @@
 package irq
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -77,6 +78,65 @@ func TestInterruptsAndMatch(t *testing.T) {
 		if got := byNum[c.num].Match(c.claim); got != c.want {
 			t.Errorf("irq %d Match(%q) = %v, want %v", c.num, c.claim, got, c.want)
 		}
+	}
+}
+
+func TestInterrupt(t *testing.T) {
+	dir := t.TempDir()
+	SetProcRoot(dir)
+	if err := os.Mkdir(filepath.Join(dir, "proc"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "proc", "interrupts"), []byte(sampleInterrupts), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name        string
+		num         int
+		description string
+		err         error
+	}{
+		{
+			name:        "IRQ 1, i8042",
+			num:         1,
+			description: "IR-IO-APIC 1-edge i8042",
+			err:         nil,
+		},
+		{
+			name:        "IRQ 9, acpi",
+			num:         9,
+			description: "IR-IO-APIC 9-fasteoi acpi",
+			err:         nil,
+		},
+		{
+			name:        "IRQ 16, processor_thermal_device_pci",
+			num:         16,
+			description: "IR-IO-APIC 16-fasteoi i801_smbus, processor_thermal_device_pci",
+			err:         nil,
+		},
+		{
+			name:        "non-existent IRQ 666",
+			num:         666,
+			description: "non-existent IRQ 666",
+			err:         ErrNoSuchInterrupt,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			irq, err := Interrupt(tc.num)
+			switch {
+			case err != nil && tc.err == nil:
+				t.Fatalf("unexpected failure for Interrupt(%d): %v", tc.num, err)
+			case err != nil && !errors.Is(err, tc.err):
+				t.Fatalf("wrong error for Interrupt(%d): %v, expecting %v",
+					tc.num, err, tc.err)
+			case err == nil:
+				if irq.Num() != tc.num || irq.Description() != tc.description {
+					t.Fatalf("Interrupt(%d) = %v, want %d, %q", tc.num,
+						irq, tc.num, tc.description)
+				}
+			}
+		})
 	}
 }
 

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test25-irq/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test25-irq/code.var.sh
@@ -389,3 +389,102 @@ grep -q "denied interrupt: .* denied but matched by user pattern .*" <<< $COMMAN
 
 cleanup
 unset ANN0
+
+#
+# Test IRQ affinity from topology hints.
+#
+
+CONTROLLABLE_INTERRUPTS="[\"*ttyS*\"]"
+
+helm_config=$(COLOCATE_PODS=false \
+              DEBUG_LOGGERS="$DEBUG_LOGGERS,policy" \
+    instantiate helm-config.yaml) helm-launch topology-aware
+
+# Create Guaranteed pod annotated to take IRQ affinity for hinted devices,
+# and with a test topology-hint with IRQ for an allowed ttyS0.
+pod=pod9
+ANN0=$(cat <<EOF
+irq-affinity.resource-policy.nri.io/container.${pod}c0: |
+      devices: [ "*ttyS0*" ]
+EOF
+)
+ANN1=$(cat <<EOF
+test.topologyhints.resource-policy.nri.io/container.${pod}c0: |
+      test:
+        NUMAs: "0"
+        IRQs: [ 4 ]
+EOF
+)
+
+ANN0=$ANN0 ANN1=$ANN1 \
+    CONTCOUNT=1 create guaranteed
+
+verify-irq-cpus ".*ttyS0.*" "$(ctr-cpu-ids $pod ${pod}c0)"
+
+vm-command "kubectl delete pod $pod"
+unset ANN0 ANN1
+
+
+# Create Guaranteed pod annotated to take IRQ affinity for hinted devices,
+# and with a test topology-hint with an IRQ for a denied rtc0. Shouldn't
+# claim IRQ.
+
+pod=pod10
+ANN0=$(cat <<EOF
+irq-affinity.resource-policy.nri.io/container.${pod}c0: |
+      devices: [ "*rtc0*" ]
+EOF
+)
+ANN1=$(cat <<EOF
+test.topologyhints.resource-policy.nri.io/container.${pod}c0: |
+      test:
+        NUMAs: "0"
+        IRQs: [ 8 ]
+EOF
+)
+
+ANN0=$ANN0 ANN1=$ANN1 \
+    CONTCOUNT=1 create guaranteed
+
+verify-irq-cpus ".*rtc0.*" $ALLCPUS
+
+vm-command "kubectl delete pod $pod"
+unset ANN0 ANN1
+
+# Create Guaranteed pod annotated to take IRQ affinity with an invalid
+# match glob. Should fail creating the container.
+
+pod=pod11
+ANN0=$(cat <<EOF
+irq-affinity.resource-policy.nri.io/container.${pod}c0: |
+      devices:
+        - "*ttyS0*"
+        - "[abc"
+EOF
+)
+ANN1=$(cat <<EOF
+test.topologyhints.resource-policy.nri.io/container.${pod}c0: |
+      test:
+        NUMAs: "0"
+        IRQs: [ 4 ]
+EOF
+)
+
+ANN0=$ANN0 ANN1=$ANN1 \
+    wait="" CONTCOUNT=1 create guaranteed
+
+wait-pod-waiting-reason $pod CreateContainerError
+
+ctr=${pod}c0
+vm-command "kubectl get pods $pod -ojson | \
+    jq '.status.containerStatuses | map(select(.name == \"$ctr\")) | .[0].state'"
+
+grep -q "invalid IRQ affinity devices pattern" <<< $COMMAND_OUTPUT ||
+    error "Missing invalid affinity devices pattern error for $ctr"
+
+
+verify-irq-cpus ".*rtc0.*" $ALLCPUS
+
+
+cleanup
+unset ANN0 ANN1

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test25-irq/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test25-irq/code.var.sh
@@ -158,13 +158,13 @@ ALLCPUS=0-15
 # the allocated CPUs.
 
 pod=pod0
-ANN0=$(cat <<'EOF'
-irq-affinity.resource-policy.nri.io/container.pod0c0: |
+ANN0=$(cat <<EOF
+irq-affinity.resource-policy.nri.io/container.${pod}c0: |
       claim: [ "*ttyS0*" ]
 EOF
 )
-ANN1=$(cat <<'EOF'
-irq-affinity.resource-policy.nri.io/container.pod0c1: |
+ANN1=$(cat <<EOF
+irq-affinity.resource-policy.nri.io/container.${pod}c1: |
       claim: [ "*rtc0*" ]
 EOF
 )
@@ -181,18 +181,20 @@ vm-command "kubectl delete pod pod0"
 verify-irq-cpus ".*ttyS0.*" $ALLCPUS
 verify-irq-cpus ".*rtc0.*" $ALLCPUS
 
+unset ANN0 ANN1
+
 # Create pod with 4 containers, 2 eligible for exclusive CPU allocation
 # and 2 others running in shared pools. Annotate the exclusive ones for
 # masked IRQs. Check that allocated CPUs get masked from the IRQs.
 
 pod=pod1
-ANN0=$(cat <<'EOF'
-irq-affinity.resource-policy.nri.io/container.pod1c0: |
+ANN0=$(cat <<EOF
+irq-affinity.resource-policy.nri.io/container.${pod}c0: |
       mask: [ "*ttyS0*" ]
 EOF
 )
-ANN1=$(cat <<'EOF'
-irq-affinity.resource-policy.nri.io/container.pod1c1: |
+ANN1=$(cat <<EOF
+irq-affinity.resource-policy.nri.io/container.${pod}c1: |
       mask: [ "*rtc0*" ]
 EOF
 )
@@ -208,20 +210,22 @@ vm-command "kubectl delete pod pod1"
 verify-irq-cpus ".*ttyS0.*" $ALLCPUS
 verify-irq-cpus ".*rtc0.*" $ALLCPUS
 
+unset ANN0 ANN1
+
 # Create pod with 4 containers, 2 eligible for exclusive CPU allocation
 # and 2 others running in shared pools. Annotate one exclusive ones for
 # and IRQ claim and the other for a masked IRQ. Check that IRQ affinity
 # gets updated accordingly.
 
 pod=pod2
-ANN0=$(cat <<'EOF'
-irq-affinity.resource-policy.nri.io/container.pod2c0: |
+ANN0=$(cat <<EOF
+irq-affinity.resource-policy.nri.io/container.${pod}c0: |
       claim: [ "*ttyS0*" ]
       mask: [ "*" ]
 EOF
 )
-ANN1=$(cat <<'EOF'
-irq-affinity.resource-policy.nri.io/container.pod2c1: |
+ANN1=$(cat <<EOF
+irq-affinity.resource-policy.nri.io/container.${pod}c1: |
       mask: [ "*rtc0*" ]
 EOF
 )
@@ -237,11 +241,13 @@ vm-command "kubectl delete pod pod2"
 verify-irq-cpus ".*ttyS0.*" $ALLCPUS
 verify-irq-cpus ".*rtc0.*" $ALLCPUS
 
+unset ANN0 ANN1
+
 # Create BestEffort pod, try to annotate container for IRQ affinity. Should fail.
 
 pod=pod3
-ANN0=$(cat <<'EOF'
-irq-affinity.resource-policy.nri.io/container.pod3c0: |
+ANN0=$(cat <<EOF
+irq-affinity.resource-policy.nri.io/container.${pod}c0: |
       claim: [ "*ttyS0*" ]
 EOF
 )
@@ -260,8 +266,8 @@ grep -q "invalid IRQ affinity, QoS class .* is not Guaranteed" <<< $COMMAND_OUTP
 # Create Burstable pod, try to annotate container for IRQ affinity. Should fail.
 
 pod=pod4
-ANN0=$(cat <<'EOF'
-irq-affinity.resource-policy.nri.io/container.pod4c0: |
+ANN0=$(cat <<EOF
+irq-affinity.resource-policy.nri.io/container.${pod}c0: |
       claim: [ "*ttyS0*" ]
 EOF
 )
@@ -277,12 +283,14 @@ vm-command "kubectl get pods $pod -ojson | \
 grep -q "invalid IRQ affinity, QoS class .* is not Guaranteed" <<< $COMMAND_OUTPUT ||
     error "Missing QoS-based IRQ affinity denial error for $ctr"
 
+unset ANN0
+
 # Create Guaranteed pod without exclusive CPUs, try to annotate container
 # for IRQ affinity. Should fail.
 
 pod=pod5
-ANN0=$(cat <<'EOF'
-irq-affinity.resource-policy.nri.io/container.pod5c0: |
+ANN0=$(cat <<EOF
+irq-affinity.resource-policy.nri.io/container.${pod}c0: |
       claim: [ "*ttyS0*" ]
 EOF
 )
@@ -298,12 +306,14 @@ vm-command "kubectl get pods $pod -ojson | \
 grep -q "IRQ affinity .* invalid without exclusive CPUs" <<< $COMMAND_OUTPUT ||
     error "Missing shared CPU-based IRQ affinity denial error for $ctr"
 
+unset ANN0
+
 # Create Guaranteed pod with exclusive CPUs but with an unparsable IRQ affinity
 # annotation. Should fail.
 
 pod=pod6
-ANN0=$(cat <<'EOF'
-irq-affinity.resource-policy.nri.io/container.pod6c0: |
+ANN0=$(cat <<EOF
+irq-affinity.resource-policy.nri.io/container.${pod}c0: |
       claim: xyzzy, foobar
 EOF
 )
@@ -319,12 +329,14 @@ vm-command "kubectl get pods $pod -ojson | \
 grep -q "invalid IRQ affinity .*: .*" <<< $COMMAND_OUTPUT ||
     error "Missing unparsable IRQ affinity denial error for $ctr"
 
+unset ANN0
+
 # Create Guaranteed pod with exclusive CPUs but invalid IRQ affinity mode
 # in annotation. Should fail.
 
 pod=pod7
-ANN0=$(cat <<'EOF'
-irq-affinity.resource-policy.nri.io/container.pod7c0: |
+ANN0=$(cat <<EOF
+irq-affinity.resource-policy.nri.io/container.${pod}c0: |
       claim: [ "*ttyS0*" ]
       mask: [ "*rtc0*" ]
       mode: xyzzy
@@ -343,6 +355,7 @@ grep -q "invalid IRQ affinity mode .*xyzzy.* (valid modes: .*)" <<< $COMMAND_OUT
     error "Missing invalid mode based IRQ affinity denial error for $ctr"
 
 cleanup
+unset ANN0
 
 #
 # Restrict interrupts control and verify that it takes effect.
@@ -357,8 +370,8 @@ helm_config=$(COLOCATE_PODS=false \
 
 # Try to exercise control over disallowed ttyS0, too.
 pod=pod8
-ANN0=$(cat <<'EOF'
-irq-affinity.resource-policy.nri.io/container.pod8c0: |
+ANN0=$(cat <<EOF
+irq-affinity.resource-policy.nri.io/container.${pod}c0: |
       claim: [ "*ttyS0*" ]
 EOF
 )
@@ -375,3 +388,4 @@ grep -q "denied interrupt: .* denied but matched by user pattern .*" <<< $COMMAN
     error "Missing IRQ affinity denial error for $ctr"
 
 cleanup
+unset ANN0


### PR DESCRIPTION
Extend annotated `irq-affinity` to allow matching device IRQs to be claimed from topology-hinted devices. If a container is annotated so, resolve matching hinted device IRQs and claim them. Add new e2e test cases for interrupts claimed via device hints.

Note: This PR needs and is manually stacked on top of #761. Marked as a draft until that one gets merged.