### PR TITLE
gitignore: ignore __pycache__ directories.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ coverage.txt
 /packages
 
 *.stamp
+__pycache__/
 test/e2e/**/output
 
 test/statistics-analysis/output


### PR DESCRIPTION
Don't commit cached python byte code to the repository.