### PR TITLE
balloons: don't discover the system topology twice.

### DIFF
--- a/cmd/plugins/balloons/policy/balloons-policy.go
+++ b/cmd/plugins/balloons/policy/balloons-policy.go
@@ -209,8 +209,6 @@ func New() policy.Backend {
 
 // Setup initializes the balloons policy instance.
 func (p *balloons) Setup(policyOptions *policy.BackendOptions) error {
-	var err error
-
 	bpoptions, ok := policyOptions.Config.(*BalloonsOptions)
 	if !ok {
 		return balloonsError("failed to initialize %s policy: config of wrong type %T",
@@ -223,9 +221,7 @@ func (p *balloons) Setup(policyOptions *policy.BackendOptions) error {
 	p.cpuAllocator = cpuallocator.NewCPUAllocator(policyOptions.System)
 
 	log.Infof("setting up %s policy...", PolicyName)
-	if p.cpuTree, err = NewCpuTreeFromSystem(); err != nil {
-		log.Errorf("creating CPU topology tree failed: %s", err)
-	}
+	p.cpuTree = NewCpuTreeFromSystem(policyOptions.System)
 	log.Debugf("CPU topology: %s", p.cpuTree)
 
 	// Handle policy-specific options

--- a/cmd/plugins/balloons/policy/cputree.go
+++ b/cmd/plugins/balloons/policy/cputree.go
@@ -262,12 +262,8 @@ func (t *cpuTreeNode) CpuLocations(cpus cpuset.CPUSet) [][]string {
 }
 
 // NewCpuTreeFromSystem returns the root node of the topology tree
-// constructed from the underlying system.
-func NewCpuTreeFromSystem() (*cpuTreeNode, error) {
-	sys, err := system.DiscoverSystem(system.DiscoverCPUTopology | system.DiscoverCache)
-	if err != nil {
-		return nil, err
-	}
+// constructed from the given system.
+func NewCpuTreeFromSystem(sys system.System) *cpuTreeNode {
 	// TODO: split deep nested loops into functions
 	sysTree := NewCpuTree("system")
 	sysTree.sys = sys
@@ -321,7 +317,7 @@ func NewCpuTreeFromSystem() (*cpuTreeNode, error) {
 			}
 		}
 	}
-	return sysTree, nil
+	return sysTree
 }
 
 // ToAttributedSlice returns a CPU tree node and recursively all its


### PR DESCRIPTION
NewCpuTreeFromSystem discovered a sysfs.System of its own, presumably to ask for CPU and cache topology explicitly. But DiscoverSystem ignores its flags and discovers everything anyway, so that System held the same data as the one the policy already has in its options. Take it as an argument instead.
